### PR TITLE
Makes 'vet' happy again:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ GO           ?= go
 # -run="^_" as we want to avoid running tests by 'bench' and there never be a test starting with _
 BENCH_OPTS   ?= -v -bench=. -run="^_"
 V            ?= 0
-GOCACHE      ?= off
 GOARCH       ?=
 
 ifeq ($(NOASM),1)
@@ -40,11 +39,11 @@ prep-%:
 
 test: clean $(addprefix prep-,$(TARGETS))
 	cd $(GOPATH_LOCAL); GOPATH=$(GOPATH_LOCAL) $(GO) vet ./...
-	cd $(GOPATH_LOCAL); GOARCH=$(GOARCH) GOCACHE=$(GOCACHE) GOPATH=$(GOPATH_LOCAL) \
+	cd $(GOPATH_LOCAL); GOARCH=$(GOARCH) GOPATH=$(GOPATH_LOCAL) \
 		$(GO) test $(OPTS) ./...
 
 bench: clean $(addprefix prep-,$(TARGETS))
-	cd $(GOPATH_LOCAL); GOCACHE=$(GOCACHE) GOPATH=$(GOPATH_LOCAL) $(GO) test \
+	cd $(GOPATH_LOCAL); GOPATH=$(GOPATH_LOCAL) $(GO) test \
 		$(BENCH_OPTS) ./...
 
 cover: clean $(addprefix prep-,$(TARGETS))

--- a/dh/sidh/internal/p503/arith_amd64.s
+++ b/dh/sidh/internal/p503/arith_amd64.s
@@ -692,8 +692,8 @@ TEXT ·fp503SubReduced(SB), NOSPLIT, $0-24
 	RET
 
 TEXT ·fp503Mul(SB), NOSPLIT, $104-24
-	MOVQ    z+ 0(FP), CX
-	MOVQ    x+ 8(FP), REG_P1
+	MOVQ    z+0(FP), CX
+	MOVQ    x+8(FP), REG_P1
 	MOVQ    y+16(FP), REG_P2
 
 	// Check wether to use optimized implementation

--- a/hash/sha3/keccakf_amd64.s
+++ b/hash/sha3/keccakf_amd64.s
@@ -319,9 +319,9 @@
 	MOVQ rDi, _si(oState); \
 	MOVQ rDo, _so(oState)  \
 
-// func keccakF1600(state *[25]uint64)
+// func keccakF1600(a *[25]uint64)
 TEXT ·keccakF1600(SB), 0, $200-8
-	MOVQ state+0(FP), rpState
+	MOVQ a+0(FP), rpState
 
 	// Convert the user state into an internal state
 	NOTQ _be(rpState)

--- a/utils/cpuid_amd64.s
+++ b/utils/cpuid_amd64.s
@@ -2,7 +2,7 @@
 
 #include "textflag.h"
 
-TEXT ·cpuid(SB), NOSPLIT, $0-4
+TEXT ·cpuid(SB), NOSPLIT, $0-24
     MOVL eaxArg+0(FP), AX
     MOVL ecxArg+4(FP), CX
     CPUID


### PR DESCRIPTION
* Removes GOCACHE=off. Since go 1.12 this environment var is removed
  and spec says caching is actually required.
* 'go vet' was complaining about some nits.
* Frame pointer of 'cpuid' function was too small
* Name of the variable in SHA-3 was wrong. This will be ported to x/crypto