### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/cloudflare/circl


### PR DESCRIPTION
Adding ``go.mod`` will solve many issues.
* we can now have ``internal`` directory where code that's common, but necessarily worth exporting can be stored
* lots of stuff can be removed from Makefile 
* easier integration with travis

https://github.com/golang/go/wiki/Modules