### PR TITLE
[ci] Let's drop support for Go 1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,10 +45,10 @@ jobs:
             GOVER: latest
 
     # Test against older version of golang
-    golang_1_11:
+    golang_1_12:
         <<: *nativejob
         environment:
-            GOVER: 1.11
+            GOVER: 1.12
 
     # Test for ARM64
     arm64:
@@ -67,4 +67,4 @@ workflows:
             - amd64
             - arm64
             - cover
-            - golang_1_11
+            - golang_1_12


### PR DESCRIPTION
Those Add/Mul/Sub functions from math/bits are not available in 1.11.
I would rather propose dropping support for 1.11 and claiming we support 1.12 and newer

ARM64 build currently uses 1.11, but I already have an update. Nevertheless, after updating I've found out
we need to do some fixes because new ``go vet`` is not happy. That's comming

Thoughts?