### PR TITLE
Fix staticcheck problems

### DIFF
--- a/dh/sidh/sidh_test.go
+++ b/dh/sidh/sidh_test.go
@@ -257,7 +257,7 @@ func testImportExport(t *testing.T, v sidhVec) {
 	bBytes2 := make([]byte, b.Size())
 	a.Export(aBytes2)
 	b.Export(bBytes2)
-	if !bytes.Equal(aBytes, aBytes2) || !bytes.Equal(aBytes, aBytes2) {
+	if !bytes.Equal(aBytes, aBytes2) || !bytes.Equal(bBytes, bBytes2) {
 		t.Fatalf("Second export doesn't match first export")
 	}
 }


### PR DESCRIPTION
Fixes two problems reported by staticcheck:

```
dh/sidh/sidh.go:190:6: SA4006: this value of `err` is never used (staticcheck)
		_, err = io.ReadFull(rand, prv.S)
		   ^
dh/sidh/sidh_test.go:260:5: SA4000: identical expressions on the left and right side of the '||' operator (staticcheck)
	if !bytes.Equal(aBytes, aBytes2) || !bytes.Equal(aBytes, aBytes2) {
	   ^
```

Updates #26