### PR TITLE
Enable unconvert linter

### DIFF
--- a/.etc/golangci.yml
+++ b/.etc/golangci.yml
@@ -1,7 +1,6 @@
 linters:
   enable-all: true
   disable:
-  - unconvert
   - nakedret
   - deadcode
   - gosimple

--- a/dh/sidh/internal/common/utils.go
+++ b/dh/sidh/internal/common/utils.go
@@ -15,7 +15,7 @@ func Cpick(pick int, out, in1, in2 []byte) {
 //
 // It is an error to call this function if the input byte slice is less than 2*bytelen(p) bytes long.
 func BytesToFp2(fp2 *Fp2, input []byte, bytelen int) {
-	if len(input) < int(2*bytelen) {
+	if len(input) < 2*bytelen {
 		panic("input byte slice too short")
 	}
 
@@ -31,7 +31,7 @@ func BytesToFp2(fp2 *Fp2, input []byte, bytelen int) {
 //
 // The output byte slice must be at least 2*bytelen(p) bytes long.
 func Fp2ToBytes(output []byte, fp2 *Fp2, bytelen int) {
-	if len(output) < int(2*bytelen) {
+	if len(output) < 2*bytelen {
 		panic("output byte slice too short")
 	}
 

--- a/dh/sidh/sidh.go
+++ b/dh/sidh/sidh.go
@@ -147,7 +147,7 @@ func (prv *PrivateKey) Export(out []byte) {
 func (prv *PrivateKey) Size() int {
 	tmp := len(prv.Scalar)
 	if prv.Variant() == KeyVariant_SIKE {
-		tmp += int(prv.params.MsgLen)
+		tmp += prv.params.MsgLen
 	}
 	return tmp
 }

--- a/dh/sidh/sidh_test.go
+++ b/dh/sidh/sidh_test.go
@@ -284,7 +284,7 @@ func testPrivateKeyBelowMax(t testing.TB, id uint8) {
 
 				// Convert to big-endian, as that's what expected by (*Int)SetBytes()
 				prv.Export(secretBytes)
-				for i := 0; i < int(blen/2); i++ {
+				for i := 0; i < blen/2; i++ {
 					tmp := secretBytes[i] ^ secretBytes[blen-i-1]
 					secretBytes[i] = tmp ^ secretBytes[i]
 					secretBytes[blen-i-1] = tmp ^ secretBytes[blen-i-1]


### PR DESCRIPTION
`unconvert` removes unnecessary type conversions. This diff enables the linter and fixes a few occurrences.

Updates #26