### PR TITLE
Enable gosimple linter

### DIFF
--- a/.etc/golangci.yml
+++ b/.etc/golangci.yml
@@ -2,7 +2,6 @@ linters:
   enable-all: true
   disable:
   - deadcode
-  - gosimple
   - unused
   - varcheck
   - gofmt

--- a/dh/sidh/internal/common/utils.go
+++ b/dh/sidh/internal/common/utils.go
@@ -6,7 +6,7 @@ package common
 // else out is undefined
 func Cpick(pick int, out, in1, in2 []byte) {
 	var which = byte((int8(pick << 7)) >> 7)
-	for i, _ := range out {
+	for i := range out {
 		out[i] = (in1[i] & which) | (in2[i] & ^which)
 	}
 }

--- a/dh/sidh/sike.go
+++ b/dh/sidh/sike.go
@@ -179,11 +179,11 @@ func (c *KEM) Decapsulate(secret []byte, prv *PrivateKey, pub *PublicKey, cipher
 // after Allocate and between subsequent calls to Encapsulate
 // and/or Decapsulate.
 func (c *KEM) Reset() {
-	for i, _ := range c.msg {
+	for i := range c.msg {
 		c.msg[i] = 0
 	}
 
-	for i, _ := range c.secretBytes {
+	for i := range c.secretBytes {
 		c.secretBytes[i] = 0
 	}
 }
@@ -207,7 +207,7 @@ func (c *KEM) generateCiphertext(ctext []byte, skA *PrivateKey, pkA, pkB *Public
 	c.cshakeF.Reset()
 	c.cshakeF.Write(j[:skA.params.SharedSecretSize])
 	c.cshakeF.Read(n[:ptextLen])
-	for i, _ := range ptext {
+	for i := range ptext {
 		n[i] ^= ptext[i]
 	}
 
@@ -256,7 +256,7 @@ func (c *KEM) decrypt(n []byte, prv *PrivateKey, ctext []byte) int {
 	c.cshakeF.Reset()
 	c.cshakeF.Write(j[:prv.params.SharedSecretSize])
 	c.cshakeF.Read(n[:c1_len])
-	for i, _ := range n[:c1_len] {
+	for i := range n[:c1_len] {
 		n[i] ^= ctext[pk_len+i]
 	}
 	return c1_len

--- a/dh/sidh/sike_test.go
+++ b/dh/sidh/sike_test.go
@@ -44,7 +44,7 @@ func testPKERoundTrip(t *testing.T, v sikeVec) {
 	var params = common.Params(v.id)
 	var ct = make([]byte, v.kem.CiphertextSize())
 	var msg = make([]byte, params.MsgLen)
-	for i, _ := range msg {
+	for i := range msg {
 		msg[i] = byte(i)
 	}
 
@@ -80,7 +80,7 @@ func testPKEKeyGeneration(t *testing.T, v sikeVec) {
 	var pk = NewPublicKey(v.id, KeyVariant_SIKE)
 	var sk = NewPrivateKey(v.id, KeyVariant_SIKE)
 
-	for i, _ := range msg {
+	for i := range msg {
 		msg[i] = byte(i)
 	}
 

--- a/hash/sha3/sha3_test.go
+++ b/hash/sha3/sha3_test.go
@@ -251,8 +251,8 @@ func TestClone(t *testing.T) {
 func TestCloneAndReset(t *testing.T) {
 	// Shake 256, uses SHA-3 with rate = 136
 	d1 := NewShake256()
-	buf1 := make([]byte, 28, 28)
-	buf2 := make([]byte, 28, 28)
+	buf1 := make([]byte, 28)
+	buf2 := make([]byte, 28)
 	d1.Write([]byte{0xcc})
 	// Reading x bytes where x<168-136. This makes capability
 	// of the state buffer shorter.


### PR DESCRIPTION
The gosimple linter suggests code simplifications. All the suggested changes seemed reasonable to me.

This diff enables the linters and fixes the issues it flagged.

Updates #26