### PR TITLE
Building golangci-lint during CI using go1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ version: 2.1
         - run:
             name: "Linting"
             command:
-                TOOLS_DIR=$(mktemp -d) make bootstrap build lint
+                make bootstrap build lint
         - run:
             name: "Checks if code is generated correctly"
             command:

--- a/.etc/golangci.yml
+++ b/.etc/golangci.yml
@@ -10,6 +10,7 @@ linters:
   - gochecknoglobals
   - gochecknoinits
   - dupl
+  - funlen
 
 issues:
   exclude-rules:

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ generate: clean
 	$(GO) generate -v ./...
 
 bootstrap:
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(TOOLS_DIR) v1.16.0
+	GO111MODULE=off go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
 clean:
 	rm -rf $(GOPATH_BUILD)


### PR DESCRIPTION
Changes:
 - Fetching golangci-lint from goreleaser.com brings a version compiled
   with go1.12, which once it is run with go1.13 fails.
 - Once goreleaser.com build golangci-lint with go1.13, then it can be
   restored to the previous fetching method.
 - Removing funlen linter, which was added in the latest version.
