### PR TITLE
Fix version of linters that CI uses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ version: 2.1
         - run:
             name: "Linting"
             command:
-                make bootstrap build lint
+                TOOLS_DIR=$(mktemp -d) make bootstrap build lint
         - run:
             name: "Checks if code is generated correctly"
             command:

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ generate: clean
 	$(GO) generate -v ./...
 
 bootstrap:
-	GO111MODULE=off go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(TOOLS_DIR) v1.18.0
 
 clean:
 	rm -rf $(GOPATH_BUILD)


### PR DESCRIPTION
    * In order to have a stable build we should fix a version
      of linters that we use.
    * Reverse b1cbc4ca1a5ac879b7b25e8e0c12bf20c12e5580
    * Update golangci to 1.18.0 to get support for go 1.13
