### PR TITLE
Generic implementation of FourQ operations

### DIFF
--- a/dh/curve4q/curve4Q.go
+++ b/dh/curve4q/curve4Q.go
@@ -1,5 +1,3 @@
-// +build amd64,go1.12
-
 package curve4q
 
 import "github.com/cloudflare/circl/ecc/fourq"

--- a/dh/curve4q/curve4Q_test.go
+++ b/dh/curve4q/curve4Q_test.go
@@ -1,5 +1,3 @@
-// +build amd64,go1.12
-
 package curve4q
 
 import (

--- a/ecc/fourq/curve.go
+++ b/ecc/fourq/curve.go
@@ -1,5 +1,3 @@
-// +build amd64,go1.12
-
 package fourq
 
 import (

--- a/ecc/fourq/curve_test.go
+++ b/ecc/fourq/curve_test.go
@@ -1,5 +1,3 @@
-// +build amd64,go1.12
-
 package fourq
 
 import (

--- a/ecc/fourq/fp.go
+++ b/ecc/fourq/fp.go
@@ -1,5 +1,3 @@
-// +build amd64,go1.12
-
 package fourq
 
 import (
@@ -19,6 +17,7 @@ const SizeFp = 16
 // Fp is an element (in littleEndian order) of prime field GF(2^127-1).
 type Fp [SizeFp]byte
 
+func (f *Fp) String() string       { return conv.BytesLe2Hex(f[:]) }
 func (f *Fp) isZero() bool         { fpMod(f); return *f == Fp{} }
 func (f *Fp) toBigInt() *big.Int   { fpMod(f); return conv.BytesLe2BigInt(f[:]) }
 func (f *Fp) setBigInt(b *big.Int) { conv.BigInt2BytesLe((*f)[:], b); fpMod(f) }

--- a/ecc/fourq/fp_amd64.go
+++ b/ecc/fourq/fp_amd64.go
@@ -1,4 +1,4 @@
-// +build amd64,go1.12
+// +build amd64,!purego
 
 package fourq
 

--- a/ecc/fourq/fp_amd64.h
+++ b/ecc/fourq/fp_amd64.h
@@ -1,3 +1,14 @@
+// CHECK_BMI2 triggers bmi2 if supported,
+// otherwise it fallbacks to legacy code.
+#define CHECK_BMI2(label, legacy, bmi2) \
+    CMPB ·hasBMI2(SB), $0 \
+    JE label              \
+    bmi2                  \
+    RET                   \
+    label:                \
+    legacy                \
+    RET
+
 #define _fpReduce(c0, c1) \
     BTRQ $63, c1          \
     ADCQ  $0, c0          \

--- a/ecc/fourq/fp_amd64.h
+++ b/ecc/fourq/fp_amd64.h
@@ -55,3 +55,31 @@
     SBBQ  $0, DX      \
     MOVQ AX, 0+c      \
     MOVQ DX, 8+c
+
+#define _fpMulLeg(C2, C1, C0, a, b) \
+    MOVQ   $0, C2 \
+    MOVQ  0+b, CX \
+    MOVQ  0+a, AX \
+    MULQ CX       \
+    MOVQ AX, C0   \
+    MOVQ DX, C1   \
+    MOVQ  8+a, AX \
+    MULQ CX       \
+    SHLQ $1,DX    \
+    ADDQ DX,C0    \
+    ADCQ AX, C1   \
+    ADCQ $0, C2   \
+    MOVQ  8+b, CX \
+    MOVQ  0+a, AX \
+    MULQ CX       \
+    SHLQ $1,DX    \
+    ADDQ DX,C0    \
+    ADCQ AX, C1   \
+    ADCQ $0, C2   \
+    MOVQ  8+a, AX \
+    MULQ CX       \
+    SHLQ $1,AX,DX \
+    SHLQ $1,AX    \
+    ADDQ AX,C0    \
+    ADCQ DX, C1   \
+    ADCQ $0, C2

--- a/ecc/fourq/fp_amd64.s
+++ b/ecc/fourq/fp_amd64.s
@@ -1,3 +1,5 @@
+// +build amd64,!purego
+
 #include "textflag.h"
 #include "fp_amd64.h"
 

--- a/ecc/fourq/fp_amd64.s
+++ b/ecc/fourq/fp_amd64.s
@@ -47,40 +47,11 @@ TEXT ·fpHlf(SB),0,$0-16
 TEXT ·fpMul(SB),0,$0-24
     MOVQ a+8(FP), DI
     MOVQ b+16(FP), SI
-    MOVQ $0, CX
-
-    MOVQ 0(DI), AX
-    MULQ 0(SI)
-    MOVQ AX, R8
-    MOVQ DX, R9
-
-    MOVQ 0(DI), AX
-    MULQ 8(SI)
-    SHLQ $1, DX
-    ADDQ DX, R8
-    ADCQ AX, R9
-    ADCQ $0, CX
-
-    MOVQ 8(DI), AX
-    MULQ 0(SI)
-    SHLQ $1, DX
-    ADDQ DX, R8
-    ADCQ AX, R9
-    ADCQ $0, CX
-
-    MOVQ 8(DI), AX
-    MULQ 8(SI)
-    SHLQ $1, DX
-    SHLQ $1, AX
-    ADCQ $0, DX
-    ADDQ AX, R8
-    ADCQ DX, R9
-    ADCQ $0, CX
-
-    SHLQ $1, CX
+    _fpMulLeg(R10, R9, R8, 0(DI), 0(SI))
+    SHLQ $1, R10
     BTRQ $63, R9
-    ADCQ CX, R8
-    ADCQ $0, R9
+    ADCQ R10, R8
+    ADCQ  $0, R9
     _fpReduce(R8, R9)
 
     MOVQ c+0(FP), DI

--- a/ecc/fourq/fp_generic.go
+++ b/ecc/fourq/fp_generic.go
@@ -7,11 +7,12 @@ import (
 	"unsafe"
 )
 
-type elt64 [2]uint64
+type elt64 = [2]uint64
 
 const mask = uint64(1) << 63
 
 func fpModGeneric(c *Fp) { fpSubGeneric(c, c, &modulusP) }
+
 func fpAddGeneric(c, a, b *Fp) {
 	aa, bb, cc := (*elt64)(unsafe.Pointer(a)), (*elt64)(unsafe.Pointer(b)), (*elt64)(unsafe.Pointer(c))
 	c0, x := bits.Add64(aa[0], bb[0], 0)
@@ -21,6 +22,7 @@ func fpAddGeneric(c, a, b *Fp) {
 	cc[0], x = bits.Add64(c0, 0, bit)
 	cc[1], _ = bits.Add64(c1, 0, x)
 }
+
 func fpSubGeneric(c, a, b *Fp) {
 	aa, bb, cc := (*elt64)(unsafe.Pointer(a)), (*elt64)(unsafe.Pointer(b)), (*elt64)(unsafe.Pointer(c))
 	c0, x := bits.Sub64(aa[0], bb[0], 0)
@@ -30,6 +32,7 @@ func fpSubGeneric(c, a, b *Fp) {
 	cc[0], x = bits.Sub64(c0, 0, x)
 	cc[1], _ = bits.Sub64(c1, 0, x)
 }
+
 func fpMulGeneric(c, a, b *Fp) {
 	aa, bb, cc := (*elt64)(unsafe.Pointer(a)), (*elt64)(unsafe.Pointer(b)), (*elt64)(unsafe.Pointer(c))
 	c1, c0 := bits.Mul64(aa[0], bb[0])

--- a/ecc/fourq/fp_generic.go
+++ b/ecc/fourq/fp_generic.go
@@ -9,8 +9,6 @@ import (
 
 type elt64 = [2]uint64
 
-const mask = uint64(1) << 63
-
 func fpModGeneric(c *Fp) { fpSubGeneric(c, c, &modulusP) }
 
 func fpAddGeneric(c, a, b *Fp) {

--- a/ecc/fourq/fp_generic.go
+++ b/ecc/fourq/fp_generic.go
@@ -1,0 +1,69 @@
+// +build go1.12
+
+package fourq
+
+import (
+	"math/bits"
+	"unsafe"
+)
+
+type elt64 [2]uint64
+
+const mask = uint64(1) << 63
+
+func fpModGeneric(c *Fp) { fpSubGeneric(c, c, &modulusP) }
+func fpAddGeneric(c, a, b *Fp) {
+	aa, bb, cc := (*elt64)(unsafe.Pointer(a)), (*elt64)(unsafe.Pointer(b)), (*elt64)(unsafe.Pointer(c))
+	c0, x := bits.Add64(aa[0], bb[0], 0)
+	c1, _ := bits.Add64(aa[1], bb[1], x)
+	bit := (c1 >> 63) & 1
+	c1 = c1 &^ mask
+	cc[0], x = bits.Add64(c0, 0, bit)
+	cc[1], _ = bits.Add64(c1, 0, x)
+}
+func fpSubGeneric(c, a, b *Fp) {
+	aa, bb, cc := (*elt64)(unsafe.Pointer(a)), (*elt64)(unsafe.Pointer(b)), (*elt64)(unsafe.Pointer(c))
+	c0, x := bits.Sub64(aa[0], bb[0], 0)
+	c1, _ := bits.Sub64(aa[1], bb[1], x)
+	x = (c1 & mask) >> 63
+	c1 = c1 &^ mask
+	cc[0], x = bits.Sub64(c0, 0, x)
+	cc[1], _ = bits.Sub64(c1, 0, x)
+}
+func fpMulGeneric(c, a, b *Fp) {
+	aa, bb, cc := (*elt64)(unsafe.Pointer(a)), (*elt64)(unsafe.Pointer(b)), (*elt64)(unsafe.Pointer(c))
+	c1, c0 := bits.Mul64(aa[0], bb[0])
+	hi, lo := bits.Mul64(aa[0], bb[1])
+	c0, x := bits.Add64(c0, hi<<1, 0)
+	c1, c2 := bits.Add64(c1, lo, x)
+
+	hi, lo = bits.Mul64(aa[1], bb[0])
+	c0, x = bits.Add64(c0, hi<<1, 0)
+	c1, x = bits.Add64(c1, lo, x)
+	c2, _ = bits.Add64(c2, 0, x)
+
+	hi, lo = bits.Mul64(aa[1], bb[1])
+	hi = (hi << 1) | (lo >> 63)
+	lo = lo << 1
+	c0, x = bits.Add64(c0, lo, 0)
+	c1, x = bits.Add64(c1, hi, x)
+	c2, _ = bits.Add64(c2, 0, x)
+
+	c2 = c2 << 1
+	x = (c1 & mask) >> 63
+	c1 = c1 &^ mask
+	c0, x = bits.Add64(c0, c2, x)
+	c1, _ = bits.Add64(c1, 0, x)
+
+	x = (c1 & mask) >> 63
+	c1 = c1 &^ mask
+	cc[0], x = bits.Add64(c0, 0, x)
+	cc[1], _ = bits.Add64(c1, 0, x)
+}
+
+func fpHlfGeneric(c, a *Fp) {
+	aa, cc := (*elt64)(unsafe.Pointer(a)), (*elt64)(unsafe.Pointer(c))
+	hlf := aa[0] & 0x1
+	cc[0] = (aa[1] << 63) | (aa[0] >> 1)
+	cc[1] = (hlf << 62) | (aa[1] >> 1)
+}

--- a/ecc/fourq/fp_generic.go
+++ b/ecc/fourq/fp_generic.go
@@ -17,20 +17,18 @@ func fpAddGeneric(c, a, b *Fp) {
 	aa, bb, cc := (*elt64)(unsafe.Pointer(a)), (*elt64)(unsafe.Pointer(b)), (*elt64)(unsafe.Pointer(c))
 	c0, x := bits.Add64(aa[0], bb[0], 0)
 	c1, _ := bits.Add64(aa[1], bb[1], x)
-	bit := (c1 >> 63) & 1
-	c1 = c1 &^ mask
-	cc[0], x = bits.Add64(c0, 0, bit)
-	cc[1], _ = bits.Add64(c1, 0, x)
+	c1, x = bits.Add64(c1, c1, 0)
+	cc[0], x = bits.Add64(c0, 0, x)
+	cc[1], _ = bits.Add64(c1>>1, 0, x)
 }
 
 func fpSubGeneric(c, a, b *Fp) {
 	aa, bb, cc := (*elt64)(unsafe.Pointer(a)), (*elt64)(unsafe.Pointer(b)), (*elt64)(unsafe.Pointer(c))
 	c0, x := bits.Sub64(aa[0], bb[0], 0)
 	c1, _ := bits.Sub64(aa[1], bb[1], x)
-	x = (c1 & mask) >> 63
-	c1 = c1 &^ mask
+	c1, x = bits.Add64(c1, c1, 0)
 	cc[0], x = bits.Sub64(c0, 0, x)
-	cc[1], _ = bits.Sub64(c1, 0, x)
+	cc[1], _ = bits.Sub64(c1>>1, 0, x)
 }
 
 func fpMulGeneric(c, a, b *Fp) {
@@ -38,7 +36,8 @@ func fpMulGeneric(c, a, b *Fp) {
 	c1, c0 := bits.Mul64(aa[0], bb[0])
 	hi, lo := bits.Mul64(aa[0], bb[1])
 	c0, x := bits.Add64(c0, hi<<1, 0)
-	c1, c2 := bits.Add64(c1, lo, x)
+	c1, x = bits.Add64(c1, lo, x)
+	c2, _ := bits.Add64(0, 0, x)
 
 	hi, lo = bits.Mul64(aa[1], bb[0])
 	c0, x = bits.Add64(c0, hi<<1, 0)
@@ -46,22 +45,20 @@ func fpMulGeneric(c, a, b *Fp) {
 	c2, _ = bits.Add64(c2, 0, x)
 
 	hi, lo = bits.Mul64(aa[1], bb[1])
-	hi = (hi << 1) | (lo >> 63)
-	lo = lo << 1
+	lo, x = bits.Add64(lo, lo, 0)
+	hi, _ = bits.Add64(hi, hi, x)
+
 	c0, x = bits.Add64(c0, lo, 0)
 	c1, x = bits.Add64(c1, hi, x)
 	c2, _ = bits.Add64(c2, 0, x)
 
-	c2 = c2 << 1
-	x = (c1 & mask) >> 63
-	c1 = c1 &^ mask
-	c0, x = bits.Add64(c0, c2, x)
-	c1, _ = bits.Add64(c1, 0, x)
+	c1, x = bits.Add64(c1, c1, 0)
+	c0, x = bits.Add64(c0, c2<<1, x)
+	c1, _ = bits.Add64(c1>>1, 0, x)
 
-	x = (c1 & mask) >> 63
-	c1 = c1 &^ mask
+	c1, x = bits.Add64(c1, c1, 0)
 	cc[0], x = bits.Add64(c0, 0, x)
-	cc[1], _ = bits.Add64(c1, 0, x)
+	cc[1], _ = bits.Add64(c1>>1, 0, x)
 }
 
 func fpSqrGeneric(c, a *Fp) { fpMulGeneric(c, a, a) }

--- a/ecc/fourq/fp_generic.go
+++ b/ecc/fourq/fp_generic.go
@@ -64,6 +64,8 @@ func fpMulGeneric(c, a, b *Fp) {
 	cc[1], _ = bits.Add64(c1, 0, x)
 }
 
+func fpSqrGeneric(c, a *Fp) { fpMulGeneric(c, a, a) }
+
 func fpHlfGeneric(c, a *Fp) {
 	aa, cc := (*elt64)(unsafe.Pointer(a)), (*elt64)(unsafe.Pointer(c))
 	hlf := aa[0] & 0x1

--- a/ecc/fourq/fp_noasm.go
+++ b/ecc/fourq/fp_noasm.go
@@ -6,5 +6,5 @@ func fpMod(c *Fp)       { fpModGeneric(c) }
 func fpAdd(c, a, b *Fp) { fpAddGeneric(c, a, b) }
 func fpSub(c, a, b *Fp) { fpSubGeneric(c, a, b) }
 func fpMul(c, a, b *Fp) { fpMulGeneric(c, a, b) }
-func fpSqr(c, a *Fp)    { fpMulGeneric(c, a, a) }
+func fpSqr(c, a *Fp)    { fpSqrGeneric(c, a) }
 func fpHlf(c, a *Fp)    { fpHlfGeneric(c, a) }

--- a/ecc/fourq/fp_noasm.go
+++ b/ecc/fourq/fp_noasm.go
@@ -1,0 +1,10 @@
+// +build !amd64 purego
+
+package fourq
+
+func fpMod(c *Fp)       { fpModGeneric(c) }
+func fpAdd(c, a, b *Fp) { fpAddGeneric(c, a, b) }
+func fpSub(c, a, b *Fp) { fpSubGeneric(c, a, b) }
+func fpMul(c, a, b *Fp) { fpMulGeneric(c, a, b) }
+func fpSqr(c, a *Fp)    { fpMulGeneric(c, a, a) }
+func fpHlf(c, a *Fp)    { fpHlfGeneric(c, a) }

--- a/ecc/fourq/fp_test.go
+++ b/ecc/fourq/fp_test.go
@@ -1,5 +1,3 @@
-// +build amd64,go1.12
-
 package fourq
 
 import (

--- a/ecc/fourq/fp_test.go
+++ b/ecc/fourq/fp_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/cloudflare/circl/internal/test"
 )
 
+type tFpAdd = func(z, x, y *Fp)
+type tFpSub = func(z, x, y *Fp)
+type tFpMul = func(z, x, y *Fp)
+type tFpSqr = func(z, x *Fp)
+type tFpHlf = func(z, x *Fp)
+type tFpModp = func(z *Fp)
+
 func getModulus() *big.Int {
 	p := big.NewInt(1)
 	return p.Lsh(p, 127).Sub(p, big.NewInt(1))
@@ -95,7 +102,7 @@ func TestFpIsZero(t *testing.T) {
 	}
 }
 
-func TestFpModp(t *testing.T) {
+func testFpModp(t *testing.T, f tFpModp) {
 	const testTimes = 1 << 9
 	P := getModulus()
 	x := &Fp{}
@@ -103,7 +110,7 @@ func TestFpModp(t *testing.T) {
 	// Verifying x=P goes to 0
 	bigX.Set(P)
 	x.setBigInt(&bigX)
-	fpMod(x)
+	f(x)
 	got := x.toBigInt()
 	want := big.NewInt(0)
 	if got.Cmp(want) != 0 {
@@ -113,7 +120,7 @@ func TestFpModp(t *testing.T) {
 	// Verifying x=P+1 goes to 1
 	bigX.Add(P, big.NewInt(1))
 	x.setBigInt(&bigX)
-	fpMod(x)
+	f(x)
 	got = x.toBigInt()
 	want = big.NewInt(1)
 	if got.Cmp(want) != 0 {
@@ -154,7 +161,7 @@ func TestFpNeg(t *testing.T) {
 	}
 }
 
-func TestFpHlf(t *testing.T) {
+func testFpHlf(t *testing.T, f tFpHlf) {
 	const testTimes = 1 << 9
 	P := getModulus()
 	x, z := &Fp{}, &Fp{}
@@ -164,7 +171,7 @@ func TestFpHlf(t *testing.T) {
 		bigX, _ := rand.Int(rand.Reader, P)
 
 		x.setBigInt(bigX)
-		fpHlf(z, x)
+		f(z, x)
 		got := z.toBigInt()
 
 		want := bigX.Mul(bigX, invTwo)
@@ -175,7 +182,7 @@ func TestFpHlf(t *testing.T) {
 	}
 }
 
-func TestFpAdd(t *testing.T) {
+func testFpAdd(t *testing.T, f tFpAdd) {
 	const testTimes = 1 << 9
 	P := getModulus()
 	x, y, z := &Fp{}, &Fp{}, &Fp{}
@@ -185,7 +192,7 @@ func TestFpAdd(t *testing.T) {
 
 		x.setBigInt(bigX)
 		y.setBigInt(bigY)
-		fpAdd(z, x, y)
+		f(z, x, y)
 		got := z.toBigInt()
 
 		want := bigX.Add(bigX, bigY)
@@ -196,7 +203,7 @@ func TestFpAdd(t *testing.T) {
 	}
 }
 
-func TestFpSub(t *testing.T) {
+func testFpSub(t *testing.T, f tFpSub) {
 	const testTimes = 1 << 9
 	P := getModulus()
 	x, y, z := &Fp{}, &Fp{}, &Fp{}
@@ -206,7 +213,7 @@ func TestFpSub(t *testing.T) {
 
 		x.setBigInt(bigX)
 		y.setBigInt(bigY)
-		fpSub(z, x, y)
+		f(z, x, y)
 		got := z.toBigInt()
 
 		want := bigX.Sub(bigX, bigY)
@@ -217,7 +224,7 @@ func TestFpSub(t *testing.T) {
 	}
 }
 
-func TestFpMul(t *testing.T) {
+func testFpMul(t *testing.T, f tFpMul) {
 	const testTimes = 1 << 9
 	P := getModulus()
 	x, y, z := &Fp{}, &Fp{}, &Fp{}
@@ -227,7 +234,7 @@ func TestFpMul(t *testing.T) {
 
 		x.setBigInt(bigX)
 		y.setBigInt(bigY)
-		fpMul(z, x, y)
+		f(z, x, y)
 		got := z.toBigInt()
 
 		want := bigX.Mul(bigX, bigY)
@@ -238,7 +245,7 @@ func TestFpMul(t *testing.T) {
 	}
 }
 
-func TestFpSqr(t *testing.T) {
+func testFpSqr(t *testing.T, f tFpSqr) {
 	const testTimes = 1 << 9
 	P := getModulus()
 	x, z := &Fp{}, &Fp{}
@@ -246,7 +253,7 @@ func TestFpSqr(t *testing.T) {
 		bigX, _ := rand.Int(rand.Reader, P)
 
 		x.setBigInt(bigX)
-		fpSqr(z, x)
+		f(z, x)
 		got := z.toBigInt()
 
 		want := bigX.Mul(bigX, bigX)
@@ -274,6 +281,24 @@ func TestFpInv(t *testing.T) {
 			test.ReportError(t, got, want, x)
 		}
 	}
+}
+
+func TestFpGeneric(t *testing.T) {
+	t.Run("Add", func(t *testing.T) { testFpAdd(t, fpAddGeneric) })
+	t.Run("Sub", func(t *testing.T) { testFpSub(t, fpSubGeneric) })
+	t.Run("Mul", func(t *testing.T) { testFpMul(t, fpMulGeneric) })
+	t.Run("Sqr", func(t *testing.T) { testFpSqr(t, fpSqrGeneric) })
+	t.Run("Hlf", func(t *testing.T) { testFpHlf(t, fpHlfGeneric) })
+	t.Run("Modp", func(t *testing.T) { testFpModp(t, fpModGeneric) })
+}
+
+func TestFpNative(t *testing.T) {
+	t.Run("Add", func(t *testing.T) { testFpAdd(t, fpAdd) })
+	t.Run("Sub", func(t *testing.T) { testFpSub(t, fpSub) })
+	t.Run("Mul", func(t *testing.T) { testFpMul(t, fpMul) })
+	t.Run("Sqr", func(t *testing.T) { testFpSqr(t, fpSqr) })
+	t.Run("Hlf", func(t *testing.T) { testFpHlf(t, fpHlf) })
+	t.Run("Modp", func(t *testing.T) { testFpModp(t, fpMod) })
 }
 
 func BenchmarkFp(b *testing.B) {

--- a/ecc/fourq/fq.go
+++ b/ecc/fourq/fq.go
@@ -1,5 +1,3 @@
-// +build amd64
-
 package fourq
 
 import (
@@ -12,6 +10,7 @@ import (
 // An element in Fq is represented as f[0]+f[1]*i, where f[0],f[1] are in Fp.
 type Fq [2]Fp
 
+func (e *Fq) String() string              { return e[1].String() + " *i+ " + e[0].String() }
 func (e *Fq) toBigInt() (f0, f1 *big.Int) { return e[0].toBigInt(), e[1].toBigInt() }
 func (e *Fq) setBigInt(f0, f1 *big.Int)   { e[0].setBigInt(f0); e[1].setBigInt(f1) }
 func (e *Fq) setZero()                    { var z Fp; e[0] = z; e[1] = z }

--- a/ecc/fourq/fq_amd64.go
+++ b/ecc/fourq/fq_amd64.go
@@ -1,4 +1,4 @@
-// +build amd64,go1.12
+// +build amd64,!purego
 
 package fourq
 

--- a/ecc/fourq/fq_amd64.h
+++ b/ecc/fourq/fq_amd64.h
@@ -8,7 +8,7 @@
     _fpSub( 0+c, 0+a, 0+b) \
     _fpSub(16+c,16+a,16+b)
 
-#define _fqMul(c, a, b) \
+#define _fqMulBmi2(c, a, b) \
     \ // T0 = a0 * b0, R11:R10:R9:R8 <- 0+ra:8+ra * 0+rb:8+rb
     MOVQ 0+b, DX \
     MULXQ 0+a, R8, R9 \
@@ -106,7 +106,184 @@
     MOVQ R8, 16+c \
     MOVQ R9, 24+c
 
-#define _fqSqr(c,a) \
+#define _fqMulLeg(c, a, b) \
+    \ // T0 = a0 * b0, R11:R10:R9:R8 <- 0+ra:8+ra * 0+rb:8+rb
+    MOVQ 0+b, DX \
+    MULXQ 0+a, R8, R9 \ 
+    MULXQ 8+a, R10, AX \
+    ADDQ R10, R9 \
+    MOVQ 8+b, DX \
+    MULXQ 8+a, R10, R11 \
+    ADCQ AX, R10 \
+    MULXQ 0+a, DX, AX \
+    ADCQ $0, R11 \
+    ADDQ DX, R9 \
+    \
+    \ // T1 = a1 * b1, R15:R14:R13:R12 <- 16+ra:24+ra * 16+rb:24+rb
+    MOVQ 16+b, DX \
+    MULXQ 16+a, R12, R13 \
+    ADCQ AX, R10 \
+    MULXQ 24+a, R14, AX \
+    ADCQ $0, R11 \
+    MOVQ 24+b, DX \
+    ADDQ R14, R13 \
+    MULXQ 24+a, R14, R15 \
+    ADCQ AX, R14 \
+    ADCQ $0, R15 \
+    MULXQ 16+a, DX, AX \
+    ADDQ DX, R13 \
+    ADCQ AX, R14 \
+    ADCQ $0, R15 \
+    \
+    \ // c0 = T0 - T1 = a0*b0 - a1*b1
+    SUBQ R12, R8 \
+    SBBQ R13, R9 \
+    SBBQ R14, R10 \
+    SBBQ R15, R11 \
+    \
+    SHLQ $1, R10, R11 \
+    SHLQ $1, R9, R10 \
+    MOVQ 16+b, DX \
+    BTRQ $63, R9 \
+    \
+    \ // T0 = a0 * b1, R15:R14:R13:R12 <- 0+ra:8+ra * 16+rb:24+rb
+    MULXQ 0+a, R12, R13 \
+    BTRQ $63, R11 \
+    SBBQ $0, R10 \
+    SBBQ $0, R11 \
+    MULXQ 8+a, R14, AX \
+    ADDQ R14, R13 \
+    MOVQ 24+b, DX \
+    MULXQ 8+a, R14, R15 \
+    ADCQ AX, R14 \
+    ADCQ $0, R15 \
+    MULXQ 0+a, DX, AX \
+    ADDQ DX, R13 \
+    ADCQ AX, R14 \
+    ADCQ $0, R15 \
+    \
+    \ // Reducing and storing c0
+    ADDQ R8, R10 \
+    ADCQ R9, R11 \
+    BTRQ $63, R11 \
+    ADCQ $0, R10 \
+    ADCQ $0, R11 \
+    \
+    \ // T1 = a1 * b0, R12:R11:R10:R9 <- 16+ra:24+ra * 0+rb:8+rb
+    MOVQ 0+b, DX \
+    MULXQ 16+a, R8, R9 \
+    MOVQ R10, 0+c \
+    MULXQ 24+a, R10, AX \
+    ADDQ R10, R9 \
+    MOVQ 8+b, DX \
+    MOVQ R11, 8+c \
+    MULXQ 24+a, R10, R11 \
+    ADCQ AX, R10 \
+    ADCQ $0, R11 \
+    MULXQ 16+a, DX, AX \
+    ADDQ DX, R9 \
+    ADCQ AX, R10 \
+    ADCQ $0, R11 \
+    \
+    \ // c1 = T0 + T1 = a0*b1 + a1*b0
+    ADDQ R12, R8 \
+    ADCQ R13, R9 \
+    ADCQ R14, R10 \
+    ADCQ R15, R11 \
+    \
+    \ // Reducing and storing c1
+    SHLQ $1, R10, R11 \
+    SHLQ $1, R9, R10 \
+    BTRQ $63, R9 \
+    BTRQ $63, R11 \
+    ADCQ R10, R8 \
+    ADCQ R11, R9 \
+    BTRQ $63, R9 \
+    ADCQ $0, R8 \
+    ADCQ $0, R9 \
+    MOVQ R8, 16+c \
+    MOVQ R9, 24+c
+
+#define _fqSqrBmi2(c,a) \
+    \ // t0 = R9:R8 = a0 + a1, R14:CX = a1
+    MOVQ 0+a, R10 \
+    MOVQ 16+a, R14 \
+    SUBQ R14, R10 \
+    MOVQ 8+a, R11 \
+    MOVQ 24+a, CX \
+    SBBQ CX, R11 \
+    \
+    BTRQ $63, R11 \
+    SBBQ $0, R10 \
+    \
+    \ // t1 = R11:R10 = a0 - a1
+    MOVQ R10, DX \
+    MOVQ 0+a, R8 \
+    ADDQ R14, R8 \
+    MOVQ 8+a, R9 \
+    ADCQ CX, R9 \
+    \
+    \ //  c0 = t0 * t1 = (a0 + a1)*(a0 - a1), CX:R14:R13:R12 <- R9:R8 * R11:R10
+    MULXQ R8, R12, R13 \
+    SBBQ $0, R11 \
+    MULXQ R9, R14, AX \
+    MOVQ R11, DX \
+    ADDQ R14, R13 \
+    MULXQ R9, R14, CX \
+    MOVQ 8+a, R9 \
+    ADCQ AX, R14 \
+    ADCQ $0, CX \
+    MULXQ R8, DX, AX \
+    MOVQ 0+a, R8 \
+    ADDQ DX, R13 \
+    ADCQ AX, R14 \
+    ADCQ $0, CX \
+    \
+    \ // t2 = R9:R8 = 2*a0
+    ADDQ R8, R8 \
+    ADCQ R9, R9 \
+    \
+    \ // Reducing and storing c0
+    SHLQ $1, R14, CX \
+    SHLQ $1, R13, R14 \
+    BTRQ $63, R13 \
+    BTRQ $63, CX \
+    ADCQ R14, R12 \
+    ADCQ CX, R13 \
+    BTRQ $63, R13 \
+    ADCQ $0, R12 \
+    ADCQ $0, R13 \
+    MOVQ R12, 0+c \
+    MOVQ R13, 8+c \
+    \
+    \ //  c1 = 2a0 * a1, CX:R14:R11:R10 <- R9:R8 * 16+ra:24+ra
+    MOVQ 16+a, DX \
+    MULXQ R8, R10, R11 \
+    MULXQ R9, R14, AX \
+    ADDQ R14, R11 \
+    MOVQ 24+a, DX \
+    MULXQ R9, R14, CX \
+    ADCQ AX, R14 \
+    ADCQ $0, CX \
+    MULXQ R8, DX, AX \
+    ADDQ DX, R11 \
+    ADCQ AX, R14 \
+    ADCQ $0, CX \
+    \
+    \ // Reduce and store c1
+    SHLQ $1, R14, CX \
+    SHLQ $1, R11, R14 \
+    BTRQ $63, R11 \
+    BTRQ $63, CX \
+    ADCQ R14, R10 \
+    ADCQ CX, R11 \
+    BTRQ $63, R11 \
+    ADCQ $0, R10 \
+    ADCQ $0, R11 \
+    MOVQ R10, 16+c \
+    MOVQ R11, 24+c
+
+#define _fqSqrLeg(c,a) \
     \ // t0 = R9:R8 = a0 + a1, R14:CX = a1
     MOVQ 0+a, R10 \
     MOVQ 16+a, R14 \

--- a/ecc/fourq/fq_amd64.h
+++ b/ecc/fourq/fq_amd64.h
@@ -107,102 +107,32 @@
     MOVQ R9, 24+c
 
 #define _fqMulLeg(c, a, b) \
-    \ // T0 = a0 * b0, R11:R10:R9:R8 <- 0+ra:8+ra * 0+rb:8+rb
-    MOVQ 0+b, DX \
-    MULXQ 0+a, R8, R9 \ 
-    MULXQ 8+a, R10, AX \
-    ADDQ R10, R9 \
-    MOVQ 8+b, DX \
-    MULXQ 8+a, R10, R11 \
-    ADCQ AX, R10 \
-    MULXQ 0+a, DX, AX \
-    ADCQ $0, R11 \
-    ADDQ DX, R9 \
-    \
-    \ // T1 = a1 * b1, R15:R14:R13:R12 <- 16+ra:24+ra * 16+rb:24+rb
-    MOVQ 16+b, DX \
-    MULXQ 16+a, R12, R13 \
-    ADCQ AX, R10 \
-    MULXQ 24+a, R14, AX \
-    ADCQ $0, R11 \
-    MOVQ 24+b, DX \
-    ADDQ R14, R13 \
-    MULXQ 24+a, R14, R15 \
-    ADCQ AX, R14 \
-    ADCQ $0, R15 \
-    MULXQ 16+a, DX, AX \
-    ADDQ DX, R13 \
-    ADCQ AX, R14 \
-    ADCQ $0, R15 \
-    \
-    \ // c0 = T0 - T1 = a0*b0 - a1*b1
-    SUBQ R12, R8 \
-    SBBQ R13, R9 \
-    SBBQ R14, R10 \
-    SBBQ R15, R11 \
-    \
-    SHLQ $1, R10, R11 \
-    SHLQ $1, R9, R10 \
-    MOVQ 16+b, DX \
+    _fpMulLeg(R10, R9, R8, 0+a, 0+b) \
+    _fpMulLeg(R13,R12,R11,16+a,16+b) \
+    MOVQ  $0,R14 \
+    SUBQ R11, R8 \
+    SBBQ R12, R9 \
+    SBBQ R13,R10 \
+    SBBQ  $0,R14 \
+    SHLQ  $1,R10 \
     BTRQ $63, R9 \
-    \
-    \ // T0 = a0 * b1, R15:R14:R13:R12 <- 0+ra:8+ra * 16+rb:24+rb
-    MULXQ 0+a, R12, R13 \
-    BTRQ $63, R11 \
-    SBBQ $0, R10 \
-    SBBQ $0, R11 \
-    MULXQ 8+a, R14, AX \
-    ADDQ R14, R13 \
-    MOVQ 24+b, DX \
-    MULXQ 8+a, R14, R15 \
-    ADCQ AX, R14 \
-    ADCQ $0, R15 \
-    MULXQ 0+a, DX, AX \
-    ADDQ DX, R13 \
-    ADCQ AX, R14 \
-    ADCQ $0, R15 \
-    \
-    \ // Reducing and storing c0
-    ADDQ R8, R10 \
-    ADCQ R9, R11 \
-    BTRQ $63, R11 \
-    ADCQ $0, R10 \
-    ADCQ $0, R11 \
-    \
-    \ // T1 = a1 * b0, R12:R11:R10:R9 <- 16+ra:24+ra * 0+rb:8+rb
-    MOVQ 0+b, DX \
-    MULXQ 16+a, R8, R9 \
-    MOVQ R10, 0+c \
-    MULXQ 24+a, R10, AX \
-    ADDQ R10, R9 \
-    MOVQ 8+b, DX \
-    MOVQ R11, 8+c \
-    MULXQ 24+a, R10, R11 \
-    ADCQ AX, R10 \
-    ADCQ $0, R11 \
-    MULXQ 16+a, DX, AX \
-    ADDQ DX, R9 \
-    ADCQ AX, R10 \
-    ADCQ $0, R11 \
-    \
-    \ // c1 = T0 + T1 = a0*b1 + a1*b0
-    ADDQ R12, R8 \
-    ADCQ R13, R9 \
-    ADCQ R14, R10 \
-    ADCQ R15, R11 \
-    \
-    \ // Reducing and storing c1
-    SHLQ $1, R10, R11 \
-    SHLQ $1, R9, R10 \
-    BTRQ $63, R9 \
-    BTRQ $63, R11 \
     ADCQ R10, R8 \
-    ADCQ R11, R9 \
+    ADCQ R14, R9 \
+    MOVQ R8, R14 \
+    MOVQ R9, R15 \
+    _fpMulLeg(R10, R9, R8, 0+a,16+b) \
+    _fpMulLeg(R13,R12,R11,16+a, 0+b) \
+    ADDQ R11, R8 \
+    ADCQ R12, R9 \
+    ADCQ R13,R10 \
+    SHLQ  $1,R10 \
     BTRQ $63, R9 \
-    ADCQ $0, R8 \
-    ADCQ $0, R9 \
-    MOVQ R8, 16+c \
-    MOVQ R9, 24+c
+    ADCQ R10, R8 \
+    ADCQ  $0, R9 \
+    MOVQ R14, 0+c \
+    MOVQ R15, 8+c \
+    MOVQ  R8,16+c \
+    MOVQ  R9,24+c
 
 #define _fqSqrBmi2(c,a) \
     \ // t0 = R9:R8 = a0 + a1, R14:CX = a1
@@ -283,81 +213,4 @@
     MOVQ R10, 16+c \
     MOVQ R11, 24+c
 
-#define _fqSqrLeg(c,a) \
-    \ // t0 = R9:R8 = a0 + a1, R14:CX = a1
-    MOVQ 0+a, R10 \
-    MOVQ 16+a, R14 \
-    SUBQ R14, R10 \
-    MOVQ 8+a, R11 \
-    MOVQ 24+a, CX \
-    SBBQ CX, R11 \
-    \
-    BTRQ $63, R11 \
-    SBBQ $0, R10 \
-    \
-    \ // t1 = R11:R10 = a0 - a1
-    MOVQ R10, DX \
-    MOVQ 0+a, R8 \
-    ADDQ R14, R8 \
-    MOVQ 8+a, R9 \
-    ADCQ CX, R9 \
-    \
-    \ //  c0 = t0 * t1 = (a0 + a1)*(a0 - a1), CX:R14:R13:R12 <- R9:R8 * R11:R10
-    MULXQ R8, R12, R13 \
-    SBBQ $0, R11 \
-    MULXQ R9, R14, AX \
-    MOVQ R11, DX \
-    ADDQ R14, R13 \
-    MULXQ R9, R14, CX \
-    MOVQ 8+a, R9 \
-    ADCQ AX, R14 \
-    ADCQ $0, CX \
-    MULXQ R8, DX, AX \
-    MOVQ 0+a, R8 \
-    ADDQ DX, R13 \
-    ADCQ AX, R14 \
-    ADCQ $0, CX \
-    \
-    \ // t2 = R9:R8 = 2*a0
-    ADDQ R8, R8 \
-    ADCQ R9, R9 \
-    \
-    \ // Reducing and storing c0
-    SHLQ $1, R14, CX \
-    SHLQ $1, R13, R14 \
-    BTRQ $63, R13 \
-    BTRQ $63, CX \
-    ADCQ R14, R12 \
-    ADCQ CX, R13 \
-    BTRQ $63, R13 \
-    ADCQ $0, R12 \
-    ADCQ $0, R13 \
-    MOVQ R12, 0+c \
-    MOVQ R13, 8+c \
-    \
-    \ //  c1 = 2a0 * a1, CX:R14:R11:R10 <- R9:R8 * 16+ra:24+ra
-    MOVQ 16+a, DX \
-    MULXQ R8, R10, R11 \
-    MULXQ R9, R14, AX \
-    ADDQ R14, R11 \
-    MOVQ 24+a, DX \
-    MULXQ R9, R14, CX \
-    ADCQ AX, R14 \
-    ADCQ $0, CX \
-    MULXQ R8, DX, AX \
-    ADDQ DX, R11 \
-    ADCQ AX, R14 \
-    ADCQ $0, CX \
-    \
-    \ // Reduce and store c1
-    SHLQ $1, R14, CX \
-    SHLQ $1, R11, R14 \
-    BTRQ $63, R11 \
-    BTRQ $63, CX \
-    ADCQ R14, R10 \
-    ADCQ CX, R11 \
-    BTRQ $63, R11 \
-    ADCQ $0, R10 \
-    ADCQ $0, R11 \
-    MOVQ R10, 16+c \
-    MOVQ R11, 24+c
+#define _fqSqrLeg(c,a) _fqMulLeg(c,a,a)

--- a/ecc/fourq/fq_amd64.s
+++ b/ecc/fourq/fq_amd64.s
@@ -1,3 +1,5 @@
+// +build amd64,!purego
+
 #include "fq_amd64.h"
 
 // func fqCmov(c, a *fq, b int)

--- a/ecc/fourq/fq_amd64.s
+++ b/ecc/fourq/fq_amd64.s
@@ -2,6 +2,17 @@
 
 #include "fq_amd64.h"
 
+
+#define fqMulLegacy \
+    _fqMulLeg(0(DI),0(SI),0(BX))
+#define fqMulBmi2 \
+    _fqMulBmi2(0(DI),0(SI),0(BX))
+
+#define fqSqrLegacy \
+    _fqSqrLeg(0(DI),0(SI))
+#define fqSqrBmi2 \
+    _fqSqrBmi2(0(DI),0(SI))
+
 // func fqCmov(c, a *fq, b int)
 TEXT ·fqCmov(SB),0,$0-24
     MOVQ c+0(FP), DI
@@ -35,12 +46,12 @@ TEXT ·fqMul(SB),0,$0-24
     MOVQ c+0(FP), DI
     MOVQ a+8(FP), SI
     MOVQ b+16(FP), BX
-    _fqMul(0(DI), 0(SI), 0(BX))
+    CHECK_BMI2(LFQMUL, fqMulLegacy, fqMulBmi2)
     RET
 
 // func fqSqr(c, a *fq)
 TEXT ·fqSqr(SB),0,$0-16
     MOVQ c+0(FP), DI
     MOVQ a+8(FP), SI
-    _fqSqr(0(DI), 0(SI))
+    CHECK_BMI2(LFQSQR, fqSqrLegacy, fqSqrBmi2)
     RET

--- a/ecc/fourq/fq_amd64.s
+++ b/ecc/fourq/fq_amd64.s
@@ -2,7 +2,6 @@
 
 #include "fq_amd64.h"
 
-
 #define fqMulLegacy \
     _fqMulLeg(0(DI),0(SI),0(BX))
 #define fqMulBmi2 \

--- a/ecc/fourq/fq_generic.go
+++ b/ecc/fourq/fq_generic.go
@@ -1,12 +1,5 @@
 package fourq
 
-import "crypto/subtle"
-
-func fqCmovGeneric(c, a *Fq, b int) {
-	subtle.ConstantTimeCopy(b, c[0][:], a[0][:])
-	subtle.ConstantTimeCopy(b, c[1][:], a[1][:])
-}
-
 func fqAddGeneric(c, a, b *Fq) {
 	fpAddGeneric(&c[0], &a[0], &b[0])
 	fpAddGeneric(&c[1], &a[1], &b[1])

--- a/ecc/fourq/fq_generic.go
+++ b/ecc/fourq/fq_generic.go
@@ -8,30 +8,30 @@ func fqCmovGeneric(c, a *Fq, b int) {
 }
 
 func fqAddGeneric(c, a, b *Fq) {
-	fpAdd(&c[0], &a[0], &b[0])
-	fpAdd(&c[1], &a[1], &b[1])
+	fpAddGeneric(&c[0], &a[0], &b[0])
+	fpAddGeneric(&c[1], &a[1], &b[1])
 }
 
 func fqSubGeneric(c, a, b *Fq) {
-	fpSub(&c[0], &a[0], &b[0])
-	fpSub(&c[1], &a[1], &b[1])
+	fpSubGeneric(&c[0], &a[0], &b[0])
+	fpSubGeneric(&c[1], &a[1], &b[1])
 }
 
 func fqMulGeneric(c, a, b *Fq) {
 	var a0b0, a0b1, a1b0, a1b1 Fp
-	fpMul(&a0b0, &a[0], &b[0])
-	fpMul(&a0b1, &a[0], &b[1])
-	fpMul(&a1b0, &a[1], &b[0])
-	fpMul(&a1b1, &a[1], &b[1])
-	fpSub(&c[0], &a0b0, &a1b1)
-	fpAdd(&c[1], &a0b1, &a1b0)
+	fpMulGeneric(&a0b0, &a[0], &b[0])
+	fpMulGeneric(&a0b1, &a[0], &b[1])
+	fpMulGeneric(&a1b0, &a[1], &b[0])
+	fpMulGeneric(&a1b1, &a[1], &b[1])
+	fpSubGeneric(&c[0], &a0b0, &a1b1)
+	fpAddGeneric(&c[1], &a0b1, &a1b0)
 }
 
 func fqSqrGeneric(c, a *Fq) {
 	var aa0, a01, aa1 Fp
-	fpSqr(&aa0, &a[0])
-	fpMul(&a01, &a[0], &a[1])
-	fpSqr(&aa1, &a[1])
-	fpSub(&c[0], &aa0, &aa1)
-	fpAdd(&c[1], &a01, &a01)
+	fpSqrGeneric(&aa0, &a[0])
+	fpMulGeneric(&a01, &a[0], &a[1])
+	fpSqrGeneric(&aa1, &a[1])
+	fpSubGeneric(&c[0], &aa0, &aa1)
+	fpAddGeneric(&c[1], &a01, &a01)
 }

--- a/ecc/fourq/fq_generic.go
+++ b/ecc/fourq/fq_generic.go
@@ -1,0 +1,37 @@
+package fourq
+
+import "crypto/subtle"
+
+func fqCmovGeneric(c, a *Fq, b int) {
+	subtle.ConstantTimeCopy(b, c[0][:], a[0][:])
+	subtle.ConstantTimeCopy(b, c[1][:], a[1][:])
+}
+
+func fqAddGeneric(c, a, b *Fq) {
+	fpAdd(&c[0], &a[0], &b[0])
+	fpAdd(&c[1], &a[1], &b[1])
+}
+
+func fqSubGeneric(c, a, b *Fq) {
+	fpSub(&c[0], &a[0], &b[0])
+	fpSub(&c[1], &a[1], &b[1])
+}
+
+func fqMulGeneric(c, a, b *Fq) {
+	var a0b0, a0b1, a1b0, a1b1 Fp
+	fpMul(&a0b0, &a[0], &b[0])
+	fpMul(&a0b1, &a[0], &b[1])
+	fpMul(&a1b0, &a[1], &b[0])
+	fpMul(&a1b1, &a[1], &b[1])
+	fpSub(&c[0], &a0b0, &a1b1)
+	fpAdd(&c[1], &a0b1, &a1b0)
+}
+
+func fqSqrGeneric(c, a *Fq) {
+	var aa0, a01, aa1 Fp
+	fpSqr(&aa0, &a[0])
+	fpMul(&a01, &a[0], &a[1])
+	fpSqr(&aa1, &a[1])
+	fpSub(&c[0], &aa0, &aa1)
+	fpAdd(&c[1], &a01, &a01)
+}

--- a/ecc/fourq/fq_noasm.go
+++ b/ecc/fourq/fq_noasm.go
@@ -2,8 +2,13 @@
 
 package fourq
 
-func fqCmov(c, a *Fq, b int) { fqCmovGeneric(c, a, b) }
-func fqAdd(c, a, b *Fq)      { fqAddGeneric(c, a, b) }
-func fqSub(c, a, b *Fq)      { fqSubGeneric(c, a, b) }
-func fqMul(c, a, b *Fq)      { fqMulGeneric(c, a, b) }
-func fqSqr(c, a *Fq)         { fqSqrGeneric(c, a) }
+import "crypto/subtle"
+
+func fqCmov(c, a *Fq, b int) {
+	subtle.ConstantTimeCopy(b, c[0][:], a[0][:])
+	subtle.ConstantTimeCopy(b, c[1][:], a[1][:])
+}
+func fqAdd(c, a, b *Fq) { fqAddGeneric(c, a, b) }
+func fqSub(c, a, b *Fq) { fqSubGeneric(c, a, b) }
+func fqMul(c, a, b *Fq) { fqMulGeneric(c, a, b) }
+func fqSqr(c, a *Fq)    { fqSqrGeneric(c, a) }

--- a/ecc/fourq/fq_noasm.go
+++ b/ecc/fourq/fq_noasm.go
@@ -1,0 +1,9 @@
+// +build !amd64 purego
+
+package fourq
+
+func fqCmov(c, a *Fq, b int) { fqCmovGeneric(c, a, b) }
+func fqAdd(c, a, b *Fq)      { fqAddGeneric(c, a, b) }
+func fqSub(c, a, b *Fq)      { fqSubGeneric(c, a, b) }
+func fqMul(c, a, b *Fq)      { fqMulGeneric(c, a, b) }
+func fqSqr(c, a *Fq)         { fqSqrGeneric(c, a) }

--- a/ecc/fourq/fq_test.go
+++ b/ecc/fourq/fq_test.go
@@ -1,5 +1,3 @@
-// +build amd64,go1.12
-
 package fourq
 
 import (

--- a/ecc/fourq/fq_test.go
+++ b/ecc/fourq/fq_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/cloudflare/circl/internal/test"
 )
 
+type tFqAdd = func(z, x, y *Fq)
+type tFqSub = func(z, x, y *Fq)
+type tFqMul = func(z, x, y *Fq)
+type tFqSqr = func(z, x *Fq)
+
 func TestFqOne(t *testing.T) {
 	x := &Fq{}
 	x.setOne()
@@ -154,7 +159,7 @@ func TestFqNeg(t *testing.T) {
 	}
 }
 
-func TestFqAdd(t *testing.T) {
+func testFqAdd(t *testing.T, f tFqAdd) {
 	testTimes := 1 << 9
 	x, y, z := &Fq{}, &Fq{}, &Fq{}
 	P := getModulus()
@@ -166,7 +171,7 @@ func TestFqAdd(t *testing.T) {
 
 		x.setBigInt(bigX0, bigX1)
 		y.setBigInt(bigY0, bigY1)
-		fqAdd(z, x, y)
+		f(z, x, y)
 		got0, got1 := z.toBigInt()
 
 		want0 := bigX0.Add(bigX0, bigY0)
@@ -183,7 +188,7 @@ func TestFqAdd(t *testing.T) {
 	}
 }
 
-func TestFqSub(t *testing.T) {
+func testFqSub(t *testing.T, f tFqSub) {
 	testTimes := 1 << 9
 	x, y, z := &Fq{}, &Fq{}, &Fq{}
 	P := getModulus()
@@ -195,7 +200,7 @@ func TestFqSub(t *testing.T) {
 
 		x.setBigInt(bigX0, bigX1)
 		y.setBigInt(bigY0, bigY1)
-		fqSub(z, x, y)
+		f(z, x, y)
 		got0, got1 := z.toBigInt()
 
 		want0 := bigX0.Sub(bigX0, bigY0)
@@ -212,7 +217,7 @@ func TestFqSub(t *testing.T) {
 	}
 }
 
-func TestFqMul(t *testing.T) {
+func testFqMul(t *testing.T, f tFqMul) {
 	testTimes := 1 << 9
 	x, y, z := &Fq{}, &Fq{}, &Fq{}
 	P := getModulus()
@@ -224,7 +229,7 @@ func TestFqMul(t *testing.T) {
 
 		x.setBigInt(bigX0, bigX1)
 		y.setBigInt(bigY0, bigY1)
-		fqMul(z, x, y)
+		f(z, x, y)
 		got0, got1 := z.toBigInt()
 
 		x0y0 := new(big.Int).Mul(bigX0, bigY0)
@@ -245,7 +250,7 @@ func TestFqMul(t *testing.T) {
 	}
 }
 
-func TestFqSqr(t *testing.T) {
+func testFqSqr(t *testing.T, f tFqSqr) {
 	testTimes := 1 << 9
 	x, z := &Fq{}, &Fq{}
 	P := getModulus()
@@ -254,7 +259,7 @@ func TestFqSqr(t *testing.T) {
 		bigX1, _ := rand.Int(rand.Reader, P)
 
 		x.setBigInt(bigX0, bigX1)
-		fqSqr(z, x)
+		f(z, x)
 		got0, got1 := z.toBigInt()
 
 		x0x0 := new(big.Int).Mul(bigX0, bigX0)
@@ -302,6 +307,20 @@ func TestFqInv(t *testing.T) {
 			test.ReportError(t, got1, want1, x)
 		}
 	}
+}
+
+func TestFqGeneric(t *testing.T) {
+	t.Run("Add", func(t *testing.T) { testFqAdd(t, fqAddGeneric) })
+	t.Run("Sub", func(t *testing.T) { testFqSub(t, fqSubGeneric) })
+	t.Run("Mul", func(t *testing.T) { testFqMul(t, fqMulGeneric) })
+	t.Run("Sqr", func(t *testing.T) { testFqSqr(t, fqSqrGeneric) })
+}
+
+func TestFqNative(t *testing.T) {
+	t.Run("Add", func(t *testing.T) { testFqAdd(t, fqAdd) })
+	t.Run("Sub", func(t *testing.T) { testFqSub(t, fqSub) })
+	t.Run("Mul", func(t *testing.T) { testFqMul(t, fqMul) })
+	t.Run("Sqr", func(t *testing.T) { testFqSqr(t, fqSqr) })
 }
 
 func BenchmarkFq(b *testing.B) {

--- a/ecc/fourq/params.go
+++ b/ecc/fourq/params.go
@@ -1,5 +1,3 @@
-// +build amd64,go1.12
-
 package fourq
 
 //All values in little endian

--- a/ecc/fourq/point.go
+++ b/ecc/fourq/point.go
@@ -1,5 +1,3 @@
-// +build amd64,go1.12
-
 package fourq
 
 import (

--- a/ecc/fourq/point_amd64.go
+++ b/ecc/fourq/point_amd64.go
@@ -1,4 +1,4 @@
-// +build amd64,go1.12
+// +build amd64,!purego
 
 package fourq
 

--- a/ecc/fourq/point_amd64.go
+++ b/ecc/fourq/point_amd64.go
@@ -21,15 +21,15 @@ const ( // constants used in assembly implementation
 		_z2R2 + _dt2R2 + _addYXR3 + _subYXR3 + _dt2R3
 )
 
-func (P *pointR1) double()           { doubleAsm(P) }
-func (P *pointR1) add(Q *pointR2)    { addAsm(P, Q) }
-func (P *pointR1) mixAdd(Q *pointR3) { mixAddAsm(P, Q) }
+func (P *pointR1) double()           { doubleAmd64(P) }
+func (P *pointR1) add(Q *pointR2)    { addAmd64(P, Q) }
+func (P *pointR1) mixAdd(Q *pointR3) { mixAddAmd64(P, Q) }
 
 //go:noescape
-func doubleAsm(P *pointR1)
+func doubleAmd64(P *pointR1)
 
 //go:noescape
-func addAsm(P *pointR1, Q *pointR2)
+func addAmd64(P *pointR1, Q *pointR2)
 
 //go:noescape
-func mixAddAsm(P *pointR1, Q *pointR3)
+func mixAddAmd64(P *pointR1, Q *pointR3)

--- a/ecc/fourq/point_amd64.h
+++ b/ecc/fourq/point_amd64.h
@@ -1,136 +1,93 @@
-#define _double(p) \
-    #define Px  const__x +p \
-    #define Py  const__y +p \
-    #define Pz  const__z +p \
-    #define Pta const__ta+p \
-    #define Ptb const__tb+p \
-    #define a Px  \
-    #define b Py  \
-    #define c Pz  \
-    #define d Pta \
-    #define e Ptb \
-    #define f b   \
-    #define g a   \
-    _fqAdd(e,Px,Py) \
-    _fqSqr(a,Px)    \
-    _fqSqr(b,Py)    \
-    _fqSqr(c,Pz)    \
-    _fqAdd(c,c,c)   \
-    _fqAdd(d,a,b)   \
-    _fqSqr(e,e)     \
-    _fqSub(e,e,d)   \
-    _fqSub(f,b,a)   \
-    _fqSub(g,c,f)   \
-    _fqMul(Pz,f,g)  \
-    _fqMul(Px,e,g)  \
-    _fqMul(Py,d,f)  \
-    #undef Px  \
-    #undef Py  \
-    #undef Pz  \
-    #undef Pta \
-    #undef Ptb \
-    #undef a   \
-    #undef b   \
-    #undef c   \
-    #undef d   \
-    #undef e   \
-    #undef f   \
-    #undef g
+#define doubleLeg     \
+    _fqAdd(e,Px,Py)   \
+    _fqSqrLeg(a,Px)   \
+    _fqSqrLeg(b,Py)   \
+    _fqSqrLeg(c,Pz)   \
+    _fqAdd(c,c,c)     \
+    _fqAdd(d,a,b)     \
+    _fqSqrLeg(e,e)    \
+    _fqSub(e,e,d)     \
+    _fqSub(f,b,a)     \
+    _fqSub(g,c,f)     \
+    _fqMulLeg(Pz,f,g) \
+    _fqMulLeg(Px,e,g) \
+    _fqMulLeg(Py,d,f)
 
-#define _addAsm(p,q,local) \
-    #define addYX const__addYXR2+q \
-    #define subYX const__subYXR2+q \
-    #define z2    const__z2R2   +q \
-    #define dt2   const__dt2R2  +q \
-    #define Px    const__x +p \
-    #define Py    const__y +p \
-    #define Pz    const__z +p \
-    #define Pta   const__ta+p \
-    #define Ptb   const__tb+p \
-    #define a Px    \
-    #define b Py    \
-    #define c local \
-    #define d b     \
-    #define e Pta   \
-    #define f a     \
-    #define g b     \
-    #define h Ptb   \
-    _fqMul(c, Pta, Ptb) \
-    _fqSub(h, b, a)     \
-    _fqAdd(b, b, a)     \
-    _fqMul(a, h, subYX) \
-    _fqMul(b, b, addYX) \
-    _fqSub(e, b, a)     \
-    _fqAdd(h, b, a)     \
-    _fqMul(d, Pz, z2)   \
-    _fqMul(c, c, dt2)   \
-    _fqSub(f, d, c)     \
-    _fqAdd(g, d, c)     \
-    _fqMul(Pz, f, g)    \
-    _fqMul(Px, e, f)    \
-    _fqMul(Py, g, h)    \
-    #undef addYX \
-    #undef subYX \
-    #undef z2    \
-    #undef dt2   \
-    #undef Px    \
-    #undef Py    \
-    #undef Pz    \
-    #undef Pta   \
-    #undef Ptb   \
-    #undef a     \
-    #undef b     \
-    #undef c     \
-    #undef d     \
-    #undef e     \
-    #undef f     \
-    #undef g     \
-    #undef h
+#define doubleBmi2     \
+    _fqAdd(e,Px,Py)    \
+    _fqSqrBmi2(a,Px)   \
+    _fqSqrBmi2(b,Py)   \
+    _fqSqrBmi2(c,Pz)   \
+    _fqAdd(c,c,c)      \
+    _fqAdd(d,a,b)      \
+    _fqSqrBmi2(e,e)    \
+    _fqSub(e,e,d)      \
+    _fqSub(f,b,a)      \
+    _fqSub(g,c,f)      \
+    _fqMulBmi2(Pz,f,g) \
+    _fqMulBmi2(Px,e,g) \
+    _fqMulBmi2(Py,d,f)
 
-#define _mixAddAsm(p,q,local) \
-    #define addYX const__addYXR3+q \
-    #define subYX const__subYXR3+q \
-    #define dt2   const__dt2R3  +q \
-    #define Px    const__x +p \
-    #define Py    const__y +p \
-    #define Pz    const__z +p \
-    #define Pta   const__ta+p \
-    #define Ptb   const__tb+p \
-    #define a Px    \
-    #define b Py    \
-    #define c local \
-    #define d b     \
-    #define e Pta   \
-    #define f a     \
-    #define g b     \
-    #define h Ptb   \
-    _fqMul(c, Pta, Ptb) \
-    _fqSub(h, b, a)     \
-    _fqAdd(b, b, a)     \
-    _fqMul(a, h, subYX) \
-    _fqMul(b, b, addYX) \
-    _fqSub(e, b, a)     \
-    _fqAdd(h, b, a)     \
-    _fqAdd(d, Pz, Pz)   \
-    _fqMul(c, c, dt2)   \
-    _fqSub(f, d, c)     \
-    _fqAdd(g, d, c)     \
-    _fqMul(Pz, f, g)    \
-    _fqMul(Px, e, f)    \
-    _fqMul(Py, g, h)    \
-    #undef addYX \
-    #undef subYX \
-    #undef dt2   \
-    #undef Px    \
-    #undef Py    \
-    #undef Pz    \
-    #undef Pta   \
-    #undef Ptb   \
-    #undef a     \
-    #undef b     \
-    #undef c     \
-    #undef d     \
-    #undef e     \
-    #undef f     \
-    #undef g     \
-    #undef h
+#define addLeg             \
+    _fqMulLeg(c, Pta, Ptb) \
+    _fqSub(h, b, a)        \
+    _fqAdd(b, b, a)        \
+    _fqMulLeg(a, h, subYX) \
+    _fqMulLeg(b, b, addYX) \
+    _fqSub(e, b, a)        \
+    _fqAdd(h, b, a)        \
+    _fqMulLeg(d, Pz, z2)   \
+    _fqMulLeg(c, c, dt2)   \
+    _fqSub(f, d, c)        \
+    _fqAdd(g, d, c)        \
+    _fqMulLeg(Pz, f, g)    \
+    _fqMulLeg(Px, e, f)    \
+    _fqMulLeg(Py, g, h)
+
+#define addBmi2             \
+    _fqMulBmi2(c, Pta, Ptb) \
+    _fqSub(h, b, a)         \
+    _fqAdd(b, b, a)         \
+    _fqMulBmi2(a, h, subYX) \
+    _fqMulBmi2(b, b, addYX) \
+    _fqSub(e, b, a)         \
+    _fqAdd(h, b, a)         \
+    _fqMulBmi2(d, Pz, z2)   \
+    _fqMulBmi2(c, c, dt2)   \
+    _fqSub(f, d, c)         \
+    _fqAdd(g, d, c)         \
+    _fqMulBmi2(Pz, f, g)    \
+    _fqMulBmi2(Px, e, f)    \
+    _fqMulBmi2(Py, g, h)
+
+#define mixAddLeg          \
+    _fqMulLeg(c, Pta, Ptb) \
+    _fqSub(h, b, a)        \
+    _fqAdd(b, b, a)        \
+    _fqMulLeg(a, h, subYX) \
+    _fqMulLeg(b, b, addYX) \
+    _fqSub(e, b, a)        \
+    _fqAdd(h, b, a)        \
+    _fqAdd(d, Pz, Pz)      \
+    _fqMulLeg(c, c, dt2)   \
+    _fqSub(f, d, c)        \
+    _fqAdd(g, d, c)        \
+    _fqMulLeg(Pz, f, g)    \
+    _fqMulLeg(Px, e, f)    \
+    _fqMulLeg(Py, g, h)    \
+
+#define mixAddBmi2          \
+    _fqMulBmi2(c, Pta, Ptb) \
+    _fqSub(h, b, a)         \
+    _fqAdd(b, b, a)         \
+    _fqMulBmi2(a, h, subYX) \
+    _fqMulBmi2(b, b, addYX) \
+    _fqSub(e, b, a)         \
+    _fqAdd(h, b, a)         \
+    _fqAdd(d, Pz, Pz)       \
+    _fqMulBmi2(c, c, dt2)   \
+    _fqSub(f, d, c)         \
+    _fqAdd(g, d, c)         \
+    _fqMulBmi2(Pz, f, g)    \
+    _fqMulBmi2(Px, e, f)    \
+    _fqMulBmi2(Py, g, h)    \

--- a/ecc/fourq/point_amd64.h
+++ b/ecc/fourq/point_amd64.h
@@ -74,7 +74,7 @@
     _fqAdd(g, d, c)        \
     _fqMulLeg(Pz, f, g)    \
     _fqMulLeg(Px, e, f)    \
-    _fqMulLeg(Py, g, h)    \
+    _fqMulLeg(Py, g, h)
 
 #define mixAddBmi2          \
     _fqMulBmi2(c, Pta, Ptb) \
@@ -90,4 +90,4 @@
     _fqAdd(g, d, c)         \
     _fqMulBmi2(Pz, f, g)    \
     _fqMulBmi2(Px, e, f)    \
-    _fqMulBmi2(Py, g, h)    \
+    _fqMulBmi2(Py, g, h)

--- a/ecc/fourq/point_amd64.s
+++ b/ecc/fourq/point_amd64.s
@@ -1,3 +1,5 @@
+// +build amd64,!purego
+
 #include "go_asm.h"
 #include "fq_amd64.h"
 #include "point_amd64.h"

--- a/ecc/fourq/point_amd64.s
+++ b/ecc/fourq/point_amd64.s
@@ -73,7 +73,6 @@ TEXT ·addAmd64(SB),0,$32-16
     #undef g
     #undef h
 
-
 // func mixAddAmd64(P *pointR1, Q *pointR3)
 TEXT ·mixAddAmd64(SB),0,$32-16
     MOVQ P+0(FP), DI

--- a/ecc/fourq/point_amd64.s
+++ b/ecc/fourq/point_amd64.s
@@ -4,22 +4,110 @@
 #include "fq_amd64.h"
 #include "point_amd64.h"
 
-// func doubleAsm(P *pointR1)
-TEXT ·doubleAsm(SB),0,$0-8
+// func doubleAmd64(P *pointR1)
+TEXT ·doubleAmd64(SB),0,$0-8
     MOVQ P+0(FP), DI
-    _double(0(DI))
-    RET
+    #define Px  const__x +0(DI)
+    #define Py  const__y +0(DI)
+    #define Pz  const__z +0(DI)
+    #define Pta const__ta+0(DI)
+    #define Ptb const__tb+0(DI)
+    #define a Px
+    #define b Py
+    #define c Pz
+    #define d Pta
+    #define e Ptb
+    #define f b
+    #define g a
+    CHECK_BMI2(LDOUBLE, doubleLeg, doubleBmi2)
+    #undef Px
+    #undef Py
+    #undef Pz
+    #undef Pta
+    #undef Ptb
+    #undef a
+    #undef b
+    #undef c
+    #undef d
+    #undef e
+    #undef f
+    #undef g
 
-// func addAsm(P *pointR1, R *pointR2)
-TEXT ·addAsm(SB),0,$32-16
+// func addAmd64(P *pointR1, R *pointR2)
+TEXT ·addAmd64(SB),0,$32-16
     MOVQ P+0(FP), DI
     MOVQ Q+8(FP), SI
-    _addAsm(0(DI),0(SI),0(SP))
-    RET
+    #define addYX const__addYXR2+0(SI)
+    #define subYX const__subYXR2+0(SI)
+    #define z2    const__z2R2   +0(SI)
+    #define dt2   const__dt2R2  +0(SI)
+    #define Px    const__x +0(DI)
+    #define Py    const__y +0(DI)
+    #define Pz    const__z +0(DI)
+    #define Pta   const__ta+0(DI)
+    #define Ptb   const__tb+0(DI)
+    #define a Px
+    #define b Py
+    #define c 0(SP)
+    #define d b
+    #define e Pta
+    #define f a
+    #define g b
+    #define h Ptb
+    CHECK_BMI2(LDADD, addLeg, addBmi2)
+    #undef addYX
+    #undef subYX
+    #undef z2
+    #undef dt2
+    #undef Px
+    #undef Py
+    #undef Pz
+    #undef Pta
+    #undef Ptb
+    #undef a
+    #undef b
+    #undef c
+    #undef d
+    #undef e
+    #undef f
+    #undef g
+    #undef h
 
-// func mixAddAsm(P *pointR1, Q *pointR3)
-TEXT ·mixAddAsm(SB),0,$32-16
+
+// func mixAddAmd64(P *pointR1, Q *pointR3)
+TEXT ·mixAddAmd64(SB),0,$32-16
     MOVQ P+0(FP), DI
     MOVQ Q+8(FP), SI
-    _mixAddAsm(0(DI),0(SI),0(SP))
-    RET
+    #define addYX const__addYXR3+0(SI)
+    #define subYX const__subYXR3+0(SI)
+    #define dt2   const__dt2R3  +0(SI)
+    #define Px    const__x +0(DI)
+    #define Py    const__y +0(DI)
+    #define Pz    const__z +0(DI)
+    #define Pta   const__ta+0(DI)
+    #define Ptb   const__tb+0(DI)
+    #define a Px
+    #define b Py
+    #define c 0(SP)
+    #define d b
+    #define e Pta
+    #define f a
+    #define g b
+    #define h Ptb
+    CHECK_BMI2(LDMIXADD, mixAddLeg, mixAddBmi2)
+    #undef addYX
+    #undef subYX
+    #undef dt2
+    #undef Px
+    #undef Py
+    #undef Pz
+    #undef Pta
+    #undef Ptb
+    #undef a
+    #undef b
+    #undef c
+    #undef d
+    #undef e
+    #undef f
+    #undef g
+    #undef h

--- a/ecc/fourq/point_generic.go
+++ b/ecc/fourq/point_generic.go
@@ -1,0 +1,98 @@
+// +build !amd64 purego
+
+package fourq
+
+func doubleGeneric(P *pointR1) {
+	var Px = &P.X
+	var Py = &P.Y
+	var Pz = &P.Z
+	var Pta = &P.Ta
+	var Ptb = &P.Tb
+	var a = Px
+	var b = Py
+	var c = Pz
+	var d = Pta
+	var e = Ptb
+	var f = b
+	var g = a
+	fqAdd(e, Px, Py)
+	fqSqr(a, Px)
+	fqSqr(b, Py)
+	fqSqr(c, Pz)
+	fqAdd(c, c, c)
+	fqAdd(d, a, b)
+	fqSqr(e, e)
+	fqSub(e, e, d)
+	fqSub(f, b, a)
+	fqSub(g, c, f)
+	fqMul(Pz, f, g)
+	fqMul(Px, e, g)
+	fqMul(Py, d, f)
+}
+
+func addGeneric(P *pointR1, Q *pointR2) {
+	var addYX = &Q.addYX
+	var subYX = &Q.subYX
+	var z2 = &Q.z2
+	var dt2 = &Q.dt2
+	var Px = &P.X
+	var Py = &P.Y
+	var Pz = &P.Z
+	var Pta = &P.Ta
+	var Ptb = &P.Tb
+	var a = Px
+	var b = Py
+	var c = &Fq{}
+	var d = b
+	var e = Pta
+	var f = a
+	var g = b
+	var h = Ptb
+	fqMul(c, Pta, Ptb)
+	fqSub(h, b, a)
+	fqAdd(b, b, a)
+	fqMul(a, h, subYX)
+	fqMul(b, b, addYX)
+	fqSub(e, b, a)
+	fqAdd(h, b, a)
+	fqMul(d, Pz, z2)
+	fqMul(c, c, dt2)
+	fqSub(f, d, c)
+	fqAdd(g, d, c)
+	fqMul(Pz, f, g)
+	fqMul(Px, e, f)
+	fqMul(Py, g, h)
+}
+
+func mixAddGeneric(P *pointR1, Q *pointR3) {
+	var addYX = &Q.addYX
+	var subYX = &Q.subYX
+	var dt2 = &Q.dt2
+	var Px = &P.X
+	var Py = &P.Y
+	var Pz = &P.Z
+	var Pta = &P.Ta
+	var Ptb = &P.Tb
+	var a = Px
+	var b = Py
+	var c = &Fq{}
+	var d = b
+	var e = Pta
+	var f = a
+	var g = b
+	var h = Ptb
+	fqMul(c, Pta, Ptb)
+	fqSub(h, b, a)
+	fqAdd(b, b, a)
+	fqMul(a, h, subYX)
+	fqMul(b, b, addYX)
+	fqSub(e, b, a)
+	fqAdd(h, b, a)
+	fqAdd(d, Pz, Pz)
+	fqMul(c, c, dt2)
+	fqSub(f, d, c)
+	fqAdd(g, d, c)
+	fqMul(Pz, f, g)
+	fqMul(Px, e, f)
+	fqMul(Py, g, h)
+}

--- a/ecc/fourq/point_noasm.go
+++ b/ecc/fourq/point_noasm.go
@@ -1,0 +1,7 @@
+// +build !amd64 purego
+
+package fourq
+
+func (P *pointR1) double()           { doubleGeneric(P) }
+func (P *pointR1) add(Q *pointR2)    { addGeneric(P, Q) }
+func (P *pointR1) mixAdd(Q *pointR3) { mixAddGeneric(P, Q) }

--- a/ecc/fourq/point_test.go
+++ b/ecc/fourq/point_test.go
@@ -1,5 +1,3 @@
-// +build amd64,go1.12
-
 package fourq
 
 import (

--- a/ecc/fourq/tableBase.go
+++ b/ecc/fourq/tableBase.go
@@ -1,5 +1,3 @@
-// +build amd64,go1.12
-
 package fourq
 
 const (


### PR DESCRIPTION
Use math.bits package for implementing arithmetic in any architecture.
Includes support for legacy multiplication instructions.
