### PR TITLE
Adding MLSBSet constant-time exponentiation algorithm

### DIFF
--- a/math/mlsbset/mlsbset.go
+++ b/math/mlsbset/mlsbset.go
@@ -1,0 +1,122 @@
+// Package mlsbset provides a constant-time exponentiation method with precomputation.
+//
+// References: "Efficient and secure algorithms for GLV-based scalar
+// multiplication and their implementation on GLV–GLS curves" by (Faz-Hernandez et al.)
+//  - https://doi.org/10.1007/s13389-014-0085-7
+//  - https://eprint.iacr.org/2013/158
+package mlsbset
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/cloudflare/circl/internal/conv"
+)
+
+// EltG is a group element.
+type EltG interface{}
+
+// EltP is a precomputed group element.
+type EltP interface{}
+
+// Group defines the operations required by MLSBSet exponentiation method.
+type Group interface {
+	Identity() EltG                    // Returns the identity of the group.
+	Sqr(x EltG)                        // Calculates x = x^2.
+	Mul(x EltG, y EltP)                // Calculates x = x*y.
+	NewEltP() EltP                     // Returns an arbitrary precomputed element.
+	ExtendedEltP() EltP                // Returns the precomputed element x^(2^(w*d)).
+	Lookup(a EltP, v uint, s, u int32) // Sets a = s*T[v][u].
+}
+
+// Params contains the parameters of the encoding.
+type Params struct {
+	T uint // T is the maximum size (in bits) of exponents.
+	V uint // V is the number of tables.
+	W uint // W is the window size.
+	E uint // E is the number of digits per table.
+	D uint // D is the number of digits in total.
+	L uint // L is the length of the code.
+}
+
+// Encoder allows to convert integers into valid powers.
+type Encoder struct{ p Params }
+
+// New produces an encoder of the MLSBSet algorithm.
+func New(t, v, w uint) (Encoder, error) {
+	if !(t > 1 && v >= 1 && w >= 2) {
+		return Encoder{}, errors.New("t>1, v>=1, w>=2")
+	}
+	e := (t + w*v - 1) / (w * v)
+	d := e * v
+	l := d * w
+	return Encoder{Params{t, v, w, e, d, l}}, nil
+}
+
+// Encode converts an odd integer k into a valid power for exponentiation.
+func (m Encoder) Encode(k []byte) (*Power, error) {
+	if len(k) == 0 {
+		return nil, errors.New("empty slice")
+	}
+	if !(len(k) <= int(m.p.L+7)>>3) {
+		return nil, errors.New("k too big")
+	}
+	if k[0]%2 == 0 {
+		return nil, errors.New("k must be odd")
+	}
+	ap := int((m.p.L+7)/8) - len(k)
+	k = append(k, make([]byte, ap)...)
+	s := m.signs(k)
+	b := make([]int32, m.p.L-m.p.D)
+	c := conv.BytesLe2BigInt(k)
+	c.Rsh(c, m.p.D)
+	var bi big.Int
+	for i := m.p.D; i < m.p.L; i++ {
+		c0 := int32(c.Bit(0))
+		b[i-m.p.D] = s[i%m.p.D] * c0
+		bi.SetInt64(int64(b[i-m.p.D] >> 1))
+		c.Rsh(c, 1)
+		c.Sub(c, &bi)
+	}
+	carry := int(c.Int64())
+	return &Power{m, s, b, carry}, nil
+}
+
+// signs calculates the set of signs.
+func (m Encoder) signs(k []byte) []int32 {
+	s := make([]int32, m.p.D)
+	s[m.p.D-1] = 1
+	for i := uint(1); i < m.p.D; i++ {
+		ki := int32((k[i>>3] >> (i & 0x7)) & 0x1)
+		s[i-1] = 2*ki - 1
+	}
+	return s
+}
+
+// GetParams returns the complementary parameters of the encoding.
+func (m Encoder) GetParams() Params { return m.p }
+
+// tableSize returns the size of each table.
+func (m Encoder) tableSize() uint { return 1 << (m.p.W - 1) }
+
+// Elts returns the total number of elements that must be precomputed.
+func (m Encoder) Elts() uint { return m.p.V * m.tableSize() }
+
+// IsExtended returns true if the element x^(2^(wd)) must be calculated.
+func (m Encoder) IsExtended() bool { q := m.p.T / (m.p.V * m.p.W); return m.p.T == q*m.p.V*m.p.W }
+
+// Ops returns the number of squares and multiplications executed during an exponentiation.
+func (m Encoder) Ops() (S uint, M uint) {
+	S = m.p.E
+	M = m.p.E * m.p.V
+	if m.IsExtended() {
+		M++
+	}
+	return
+}
+
+func (m Encoder) String() string {
+	return fmt.Sprintf("T: %v W: %v V: %v e: %v d: %v l: %v wv|t: %v",
+		m.p.T, m.p.W, m.p.V, m.p.E, m.p.D, m.p.L, m.IsExtended())
+}

--- a/math/mlsbset/mlsbset_test.go
+++ b/math/mlsbset/mlsbset_test.go
@@ -1,0 +1,151 @@
+package mlsbset_test
+
+import (
+	"crypto/rand"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/cloudflare/circl/internal/conv"
+	"github.com/cloudflare/circl/internal/test"
+	"github.com/cloudflare/circl/math/mlsbset"
+)
+
+func TestExp(t *testing.T) {
+	T := uint(126)
+	for v := uint(1); v <= 5; v++ {
+		for w := uint(2); w <= 5; w++ {
+			m, err := mlsbset.New(T, v, w)
+			if err != nil {
+				test.ReportError(t, err, nil)
+			}
+			testExp(t, m)
+		}
+	}
+}
+
+func testExp(t *testing.T, m mlsbset.Encoder) {
+	const testTimes = 1 << 8
+	params := m.GetParams()
+	TBytes := (params.T + 7) / 8
+	topBits := (byte(1) << (params.T % 8)) - 1
+	k := make([]byte, TBytes)
+	for i := 0; i < testTimes; i++ {
+		rand.Read(k)
+		k[0] |= 1
+		k[TBytes-1] &= topBits
+
+		c, err := m.Encode(k)
+		if err != nil {
+			test.ReportError(t, err, nil)
+		}
+
+		g := zzAdd{m.GetParams()}
+		a := c.Exp(g)
+
+		got := a.(*big.Int)
+		want := conv.BytesLe2BigInt(k)
+		if got.Cmp(want) != 0 {
+			test.ReportError(t, got, want, m)
+		}
+	}
+}
+
+type zzAdd struct{ set mlsbset.Params }
+
+func (zzAdd) Identity() mlsbset.EltG { return big.NewInt(0) }
+func (zzAdd) NewEltP() mlsbset.EltP  { return new(big.Int) }
+func (zzAdd) Sqr(x mlsbset.EltG) {
+	a := x.(*big.Int)
+	a.Add(a, a)
+}
+func (zzAdd) Mul(x mlsbset.EltG, y mlsbset.EltP) {
+	a := x.(*big.Int)
+	b := y.(*big.Int)
+	a.Add(a, b)
+}
+func (z zzAdd) ExtendedEltP() mlsbset.EltP {
+	a := big.NewInt(1)
+	a.Lsh(a, z.set.W*z.set.D)
+	return a
+}
+func (z zzAdd) Lookup(x mlsbset.EltP, idTable uint, sgnElt int32, idElt int32) {
+	a := x.(*big.Int)
+	a.SetInt64(1)
+	a.Lsh(a, z.set.E*idTable) // 2^(e*v)
+	sum := big.NewInt(0)
+	for i := int(z.set.W - 2); i >= 0; i-- {
+		ui := big.NewInt(int64((idElt >> uint(i)) & 0x1))
+		sum.Add(sum, ui)
+		sum.Lsh(sum, z.set.D)
+	}
+	sum.Add(sum, big.NewInt(1))
+	a.Mul(a, sum)
+	if sgnElt == -1 {
+		a.Neg(a)
+	}
+}
+
+func TestEncodeErr(t *testing.T) {
+	t.Run("mArgs", func(t *testing.T) {
+		_, got := mlsbset.New(0, 0, 0)
+		want := errors.New("t>1, v>=1, w>=2")
+		if got.Error() != want.Error() {
+			test.ReportError(t, got, want)
+		}
+	})
+	t.Run("kOdd", func(t *testing.T) {
+		m, _ := mlsbset.New(16, 2, 2)
+		k := make([]byte, 2)
+		_, got := m.Encode(k)
+		want := errors.New("k must be odd")
+		if got.Error() != want.Error() {
+			test.ReportError(t, got, want)
+		}
+	})
+	t.Run("kBig", func(t *testing.T) {
+		m, _ := mlsbset.New(16, 2, 2)
+		k := make([]byte, 4)
+		_, got := m.Encode(k)
+		want := errors.New("k too big")
+		if got.Error() != want.Error() {
+			test.ReportError(t, got, want)
+		}
+	})
+	t.Run("kEmpty", func(t *testing.T) {
+		m, _ := mlsbset.New(16, 2, 2)
+		k := []byte{}
+		_, got := m.Encode(k)
+		want := errors.New("empty slice")
+		if got.Error() != want.Error() {
+			test.ReportError(t, got, want)
+		}
+	})
+}
+
+func BenchmarkEncode(b *testing.B) {
+	t, v, w := uint(256), uint(2), uint(3)
+	m, _ := mlsbset.New(t, v, w)
+	params := m.GetParams()
+	TBytes := (params.T + 7) / 8
+	topBits := (byte(1) << (params.T % 8)) - 1
+
+	k := make([]byte, TBytes)
+	rand.Read(k)
+	k[0] |= 1
+	k[TBytes-1] &= topBits
+
+	c, _ := m.Encode(k)
+	g := zzAdd{params}
+
+	b.Run("Encode", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			m.Encode(k)
+		}
+	})
+	b.Run("Exp", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			c.Exp(g)
+		}
+	})
+}

--- a/math/mlsbset/power.go
+++ b/math/mlsbset/power.go
@@ -1,0 +1,64 @@
+package mlsbset
+
+import "fmt"
+
+// Power is a valid exponent produced by the MLSBSet encoding algorithm.
+type Power struct {
+	set Encoder // parameters of code.
+	s   []int32 // set of signs.
+	b   []int32 // set of digits.
+	c   int     // carry is {0,1}.
+}
+
+// Exp is calculates x^k, where x is a predetermined element of a group G.
+func (p *Power) Exp(G Group) EltG {
+	a, b := G.Identity(), G.NewEltP()
+	for e := int(p.set.p.E - 1); e >= 0; e-- {
+		G.Sqr(a)
+		for v := uint(0); v < p.set.p.V; v++ {
+			sgnElt, idElt := p.Digit(v, uint(e))
+			G.Lookup(b, v, sgnElt, idElt)
+			G.Mul(a, b)
+		}
+	}
+	if p.set.IsExtended() && p.c == 1 {
+		G.Mul(a, G.ExtendedEltP())
+	}
+	return a
+}
+
+// Digit returns the (v,e)-th digit and its sign.
+func (p *Power) Digit(v, e uint) (sgn, dig int32) {
+	sgn = p.bit(0, v, e)
+	dig = 0
+	for i := p.set.p.W - 1; i > 0; i-- {
+		dig = 2*dig + p.bit(i, v, e)
+	}
+	mask := dig >> 31
+	dig = (dig + mask) ^ mask
+	return sgn, dig
+}
+
+// bit returns the (w,v,e)-th bit of the code.
+func (p *Power) bit(w, v, e uint) int32 {
+	if !(0 <= w && w < p.set.p.W &&
+		0 <= v && v < p.set.p.V &&
+		0 <= e && e < p.set.p.E) {
+		panic(fmt.Errorf("indexes outside (%v,%v,%v)", w, v, e))
+	}
+	if w == 0 {
+		return p.s[p.set.p.E*v+e]
+	}
+	return p.b[p.set.p.D*(w-1)+p.set.p.E*v+e]
+}
+
+func (p *Power) String() string {
+	dig := ""
+	for j := uint(0); j < p.set.p.V; j++ {
+		for i := uint(0); i < p.set.p.E; i++ {
+			s, d := p.Digit(j, i)
+			dig += fmt.Sprintf("(%2v,%2v) = %+2v %+2v\n", j, i, s, d)
+		}
+	}
+	return fmt.Sprintf("len: %v\ncarry: %v\ndigits:\n%v", len(p.b)+len(p.s), p.c, dig)
+}


### PR DESCRIPTION
This PR includes the MLSBSet constant-time exponentiation algorithm.
It allows fixed-point scalar multiplication.
Reference: https://eprint.iacr.org/2013/158