### PR TITLE
Updates API for signatures.

### DIFF
--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -49,12 +49,12 @@ func CheckIsErr(t testing.TB, err error, msg string) { t.Helper(); checkErr(t, e
 
 // CheckPanic returns true if call to function 'f' caused panic
 func CheckPanic(f func()) error {
-	var hasPaniced = errors.New("no panic detected")
+	var hasPanicked = errors.New("no panic detected")
 	defer func() {
 		if r := recover(); r != nil {
-			hasPaniced = nil
+			hasPanicked = nil
 		}
 	}()
 	f()
-	return hasPaniced
+	return hasPanicked
 }

--- a/sign/ed25519/doc.go
+++ b/sign/ed25519/doc.go
@@ -1,7 +1,0 @@
-// Package ed25519 implements Ed25519 signature scheme as described in RFC-8032.
-//
-// References:
-//  - RFC8032 https://rfc-editor.org/rfc/rfc8032.txt
-//  - Ed25519 https://ed25519.cr.yp.to/
-//  - High-speed high-security signatures. https://doi.org/10.1007/s13389-012-0027-1
-package ed25519

--- a/sign/ed25519/ed25519.go
+++ b/sign/ed25519/ed25519.go
@@ -1,16 +1,26 @@
+// Package ed25519 implements Ed25519 signature scheme as described in RFC-8032.
+//
+// References:
+//  - RFC8032 https://rfc-editor.org/rfc/rfc8032.txt
+//  - Ed25519 https://ed25519.cr.yp.to/
+//  - High-speed high-security signatures. https://doi.org/10.1007/s13389-012-0027-1
 package ed25519
 
 import (
 	"bytes"
 	"crypto"
-	"crypto/rand"
+	cryptoRand "crypto/rand"
 	"crypto/sha512"
 	"errors"
 	"io"
 )
 
-// Size is the length in bytes of Ed25519 keys.
-const Size = 32
+const (
+	// Size is the length in bytes of Ed25519 keys.
+	Size = 32
+	// SignatureSize is the length in bytes of signatures.
+	SignatureSize = 2 * Size
+)
 
 // PublicKey represents a public key of Ed25519.
 type PublicKey []byte
@@ -22,19 +32,22 @@ type PrivateKey []byte
 type KeyPair struct{ private, public [Size]byte }
 
 // GetPrivate returns a copy of the private key.
-func (k *KeyPair) GetPrivate() PrivateKey { return makeCopy(&k.private) }
+func (k *KeyPair) GetPrivate() PrivateKey { z := k.private; return z[:] }
 
-// GetPublic returns the public key corresponding to the private key.
-func (k *KeyPair) GetPublic() PublicKey { return makeCopy(&k.public) }
+// GetPublic returns a copy of the public key.
+func (k *KeyPair) GetPublic() PublicKey { z := k.public; return z[:] }
 
-// Public returns a crypto.PublicKey corresponding to the private key.
+// Seed returns the private key seed.
+func (k *KeyPair) Seed() []byte { return k.GetPrivate() }
+
+// Public returns a crypto.PublicKey.
 func (k *KeyPair) Public() crypto.PublicKey { return k.GetPublic() }
 
-// Sign signs the given message with priv.
+// Sign creates a signature of a message given a key pair.
 // Ed25519 performs two passes over messages to be signed and therefore cannot
-// handle pre-hashed messages. Thus opts.HashFunc() must return zero to
-// indicate the message hasn't been hashed. This can be achieved by passing
-// crypto.Hash(0) as the value for opts.
+// handle pre-hashed messages.
+// The opts.HashFunc() must return zero to indicate the message hasn't been
+// hashed. This can be achieved by passing crypto.Hash(0) as the value for opts.
 func (k *KeyPair) Sign(rand io.Reader, message []byte, opts crypto.SignerOpts) ([]byte, error) {
 	if opts.HashFunc() != crypto.Hash(0) {
 		return nil, errors.New("ed25519: cannot sign hashed message")
@@ -42,88 +55,104 @@ func (k *KeyPair) Sign(rand io.Reader, message []byte, opts crypto.SignerOpts) (
 	return Sign(k, message), nil
 }
 
-// GenerateKey generates a public/private key pair using entropy from rand.
+// GenerateKey produces public and private keys using entropy from rand.
 // If rand is nil, crypto/rand.Reader will be used.
-func GenerateKey(rnd io.Reader) (*KeyPair, error) {
-	if rnd == nil {
-		rnd = rand.Reader
+func GenerateKey(rand io.Reader) (*KeyPair, error) {
+	if rand == nil {
+		rand = cryptoRand.Reader
 	}
-	private := make(PrivateKey, Size)
-	if _, err := io.ReadFull(rnd, private); err != nil {
+	seed := make(PrivateKey, Size)
+	if _, err := io.ReadFull(rand, seed); err != nil {
 		return nil, err
 	}
-	return NewKeyFromSeed(private), nil
+	return NewKeyFromSeed(seed), nil
 }
 
-// NewKeyFromSeed generates a pair of Ed25519 signing keys given a
-// previously-generated private key.
-func NewKeyFromSeed(private PrivateKey) *KeyPair {
-	if l := len(private); l != Size {
+// NewKeyFromSeed generates a pair of Ed25519 keys given a private key.
+func NewKeyFromSeed(seed PrivateKey) *KeyPair {
+	if l := len(seed); l != Size {
 		panic("ed25519: bad private key length")
 	}
 	var P pointR1
-	pk := new(KeyPair)
-	k := sha512.Sum512(private)
+	k := sha512.Sum512(seed)
 	clamp(k[:])
 	reduceModOrder(k[:Size], false)
 	P.fixedMult(k[:Size])
-	P.ToBytes(pk.public[:])
-	copy(pk.private[:], private[:Size])
-	return pk
+
+	pair := &KeyPair{}
+	copy(pair.private[:], seed)
+	P.ToBytes(pair.public[:])
+	return pair
 }
 
-// Sign returns the signature of a message using both the private and public
-// keys of the signer.
-func Sign(k *KeyPair, message []byte) []byte {
-	h := sha512.Sum512(k.private[:])
-	clamp(h[:])
+// Sign creates a signature of a message given a key pair.
+func Sign(kp *KeyPair, message []byte) []byte {
+	// 1.  Hash the 32-byte private key using SHA-512.
 	H := sha512.New()
-	_, _ = H.Write(h[Size:])
+	_, _ = H.Write(kp.private[:])
+	h := H.Sum(nil)
+	clamp(h[:])
+	prefix, s := h[Size:], h[:Size]
+
+	// 2.  Compute SHA-512(dom2(F, C) || prefix || PH(M))
+	H.Reset()
+	_, _ = H.Write(prefix)
 	_, _ = H.Write(message)
 	r := H.Sum(nil)
 	reduceModOrder(r[:], true)
 
+	// 3.  Compute the point [r]B.
 	var P pointR1
 	P.fixedMult(r[:Size])
-	signature := make([]byte, 2*Size)
-	P.ToBytes(signature[:Size])
+	R := (&[Size]byte{})[:]
+	P.ToBytes(R)
 
+	// 4.  Compute SHA512(dom2(F, C) || R || A || PH(M)).
 	H.Reset()
-	_, _ = H.Write(signature[:Size])
-	_, _ = H.Write(k.public[:])
+	_, _ = H.Write(R)
+	_, _ = H.Write(kp.public[:])
 	_, _ = H.Write(message)
 	hRAM := H.Sum(nil)
+
 	reduceModOrder(hRAM[:], true)
-	calculateS(signature[Size:], r[:Size], hRAM[:Size], h[:Size])
-	return signature
+	// 5.  Compute S = (r + k * s) mod L.
+	S := (&[Size]byte{})[:]
+	calculateS(S, r[:Size], hRAM[:Size], s)
+
+	// 6.  The signature is the concatenation of R and S.
+	var signature [SignatureSize]byte
+	copy(signature[:Size], R[:])
+	copy(signature[Size:], S[:])
+	return signature[:]
 }
 
 // Verify returns true if the signature is valid. Failure cases are invalid
 // signature, or when the public key cannot be decoded.
 func Verify(public PublicKey, message, signature []byte) bool {
 	if len(public) != Size ||
-		len(signature) != 2*Size ||
-		!isLessThan(signature[Size:], order[:Size]) {
+		len(signature) != SignatureSize ||
+		!isLessThanOrder(signature[Size:]) {
 		return false
 	}
 	var P pointR1
 	if ok := P.FromBytes(public); !ok {
 		return false
 	}
-	P.neg()
 
+	R := signature[:Size]
 	H := sha512.New()
-	_, _ = H.Write(signature[:Size])
+	_, _ = H.Write(R)
 	_, _ = H.Write(public)
 	_, _ = H.Write(message)
 	hRAM := H.Sum(nil)
 	reduceModOrder(hRAM[:], true)
 
 	var Q pointR1
+	encR := (&[Size]byte{})[:]
+	P.neg()
 	Q.doubleMult(&P, signature[Size:], hRAM[:Size])
-	var enc [Size]byte
-	Q.ToBytes(enc[:])
-	return bytes.Equal(enc[:], signature[:Size])
+	Q.ToBytes(encR)
+	return bytes.Equal(R, encR)
 }
 
 func clamp(k []byte) {
@@ -131,8 +160,11 @@ func clamp(k []byte) {
 	k[Size-1] = (k[Size-1] & 127) | 64
 }
 
-func makeCopy(in *[Size]byte) []byte {
-	out := make([]byte, Size)
-	copy(out, in[:])
-	return out
+// isLessThanOrder returns true if 0 <= x < order.
+func isLessThanOrder(x []byte) bool {
+	i := len(order) - 1
+	for i > 0 && x[i] == order[i] {
+		i--
+	}
+	return x[i] < order[i]
 }

--- a/sign/ed25519/ed25519_test.go
+++ b/sign/ed25519/ed25519_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestWrongPublicKey(t *testing.T) {
-	wrongPublicKeys := [...][ed25519.Size]byte{
+	wrongPublicKeys := [...][ed25519.PublicKeySize]byte{
 		{ // y = p
 			0xed, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -56,7 +56,7 @@ func TestWrongPublicKey(t *testing.T) {
 }
 
 func TestSigner(t *testing.T) {
-	seed := make(ed25519.PrivateKey, ed25519.Size)
+	seed := make(ed25519.PrivateKey, ed25519.PrivateKeySize)
 	_, _ = rand.Read(seed)
 	key := ed25519.NewKeyFromSeed(seed)
 
@@ -147,19 +147,19 @@ func BenchmarkEd25519(b *testing.B) {
 
 	b.Run("keygen", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ed25519.GenerateKey(rand.Reader)
+			_, _ = ed25519.GenerateKey(rand.Reader)
 		}
 	})
 	b.Run("sign", func(b *testing.B) {
 		key, _ := ed25519.GenerateKey(rand.Reader)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			ed25519.Sign(key, msg)
+			_, _ = key.SignPure(msg)
 		}
 	})
 	b.Run("verify", func(b *testing.B) {
 		key, _ := ed25519.GenerateKey(rand.Reader)
-		sig := ed25519.Sign(key, msg)
+		sig, _ := key.SignPure(msg)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			ed25519.Verify(key.GetPublic(), msg, sig)
@@ -178,7 +178,10 @@ func Example_ed25519() {
 
 	// Alice signs a message.
 	message := []byte("A message to be signed")
-	signature := ed25519.Sign(keys, message)
+	signature, err := keys.SignPure(message)
+	if err != nil {
+		panic("error on signing message")
+	}
 
 	// Anyone can verify the signature using Alice's public key.
 	ok := ed25519.Verify(keys.GetPublic(), message, signature)

--- a/sign/ed25519/modular.go
+++ b/sign/ed25519/modular.go
@@ -5,7 +5,7 @@ import (
 	"math/bits"
 )
 
-var order = [Size]byte{
+var order = [paramB]byte{
 	0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58,
 	0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
 	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -23,7 +23,7 @@ func isLessThan(x, y []byte) bool {
 
 // reduceModOrder calculates k = k mod order of the curve.
 func reduceModOrder(k []byte, is512Bit bool) {
-	var X [((2 * Size) * 8) / 64]uint64
+	var X [((2 * paramB) * 8) / 64]uint64
 	numWords := len(k) >> 3
 	for i := 0; i < numWords; i++ {
 		X[i] = binary.LittleEndian.Uint64(k[i*8 : (i+1)*8])

--- a/sign/ed25519/modular_test.go
+++ b/sign/ed25519/modular_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestCalculateS(t *testing.T) {
 	const testTimes = 1 << 10
-	s := make([]byte, Size)
-	k := make([]byte, Size)
-	r := make([]byte, Size)
-	a := make([]byte, Size)
+	s := make([]byte, paramB)
+	k := make([]byte, paramB)
+	r := make([]byte, paramB)
+	a := make([]byte, paramB)
 	orderBig := conv.BytesLe2BigInt(order[:])
 
 	for i := 0; i < testTimes; i++ {
@@ -38,11 +38,11 @@ func TestCalculateS(t *testing.T) {
 
 func TestReduction(t *testing.T) {
 	const testTimes = 1 << 10
-	var x, y [Size * 2]byte
+	var x, y [paramB * 2]byte
 	orderBig := conv.BytesLe2BigInt(order[:])
 
 	for i := 0; i < testTimes; i++ {
-		for _, j := range []int{Size, 2 * Size} {
+		for _, j := range []int{paramB, 2 * paramB} {
 			_, _ = rand.Read(x[:j])
 			bigX := conv.BytesLe2BigInt(x[:j])
 			copy(y[:j], x[:j])
@@ -60,7 +60,7 @@ func TestReduction(t *testing.T) {
 }
 
 func TestRangeOrder(t *testing.T) {
-	aboveOrder := [...][Size]byte{
+	aboveOrder := [...][paramB]byte{
 		{ // order
 			0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58,
 			0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,

--- a/sign/ed25519/modular_test.go
+++ b/sign/ed25519/modular_test.go
@@ -82,7 +82,7 @@ func TestRangeOrder(t *testing.T) {
 	}
 
 	for i := range aboveOrder {
-		got := isLessThan(aboveOrder[i][:], order[:])
+		got := isLessThanOrder(aboveOrder[i][:])
 		want := false
 		if got != want {
 			test.ReportError(t, got, want, i, aboveOrder[i])

--- a/sign/ed25519/mult.go
+++ b/sign/ed25519/mult.go
@@ -23,7 +23,7 @@ const (
 	fxV        = 2
 	fxW        = 3
 	fx2w1      = 1 << (uint(fxW) - 1)
-	numWords64 = (Size * 8 / 64)
+	numWords64 = (paramB * 8 / 64)
 )
 
 // mLSBRecoding is the odd-only modified LSB-set.
@@ -106,7 +106,7 @@ func div2subY(x []uint64, y int64, l int) {
 }
 
 func (P *pointR1) fixedMult(scalar []byte) {
-	if len(scalar) != Size {
+	if len(scalar) != paramB {
 		panic("wrong scalar size")
 	}
 	const ee = (fxT + fxW*fxV - 1) / (fxW * fxV)

--- a/sign/ed25519/point.go
+++ b/sign/ed25519/point.go
@@ -39,14 +39,14 @@ func (P *pointR1) ToBytes(k []byte) {
 	fp.ToBytes(k[:fp.Size], &P.y)
 	fp.ToBytes(x[:], &P.x)
 	b := x[0] & 1
-	k[Size-1] = k[Size-1] | (b << 7)
+	k[paramB-1] = k[paramB-1] | (b << 7)
 }
 
 func (P *pointR1) FromBytes(k []byte) bool {
-	if len(k) != Size {
+	if len(k) != paramB {
 		panic("wrong size")
 	}
-	signX := k[Size-1] >> 7
+	signX := k[paramB-1] >> 7
 	copy(P.y[:], k[:fp.Size])
 	P.y[fp.Size-1] &= 0x7F
 	p := fp.P()

--- a/sign/ed25519/point_test.go
+++ b/sign/ed25519/point_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func randomPoint(P *pointR1) {
-	k := make([]byte, Size)
+	k := make([]byte, paramB)
 	_, _ = rand.Read(k[:])
 	P.fixedMult(k)
 }
@@ -45,8 +45,8 @@ func TestPoint(t *testing.T) {
 
 	t.Run("fixed", func(t *testing.T) {
 		var P, Q, R pointR1
-		k := make([]byte, Size)
-		l := make([]byte, Size)
+		k := make([]byte, paramB)
+		l := make([]byte, paramB)
 		for i := 0; i < testTimes; i++ {
 			randomPoint(&P)
 			_, _ = rand.Read(k[:])
@@ -71,8 +71,8 @@ func BenchmarkPoint(b *testing.B) {
 		b.SkipNow()
 	}
 
-	k := make([]byte, Size)
-	l := make([]byte, Size)
+	k := make([]byte, paramB)
+	l := make([]byte, paramB)
 	_, _ = rand.Read(k)
 	_, _ = rand.Read(l)
 

--- a/sign/ed25519/rfc8032_test.go
+++ b/sign/ed25519/rfc8032_test.go
@@ -93,7 +93,7 @@ type vector struct {
 	ctxLen uint
 }
 
-var vectorsed25519 = [...]vector{
+var vectorsEd25519 = [...]vector{
 	{
 		name:   "-----TEST 1",
 		scheme: "Ed25519Pure",
@@ -290,7 +290,7 @@ func (v vector) testPublicKey(t *testing.T) {
 	want := v.pk
 
 	if !bytes.Equal(got, want) {
-		test.ReportError(t, got, want, v.sk)
+		test.ReportError(t, got, want, v.name)
 	}
 }
 
@@ -313,7 +313,7 @@ func (v vector) testVerify(t *testing.T) {
 }
 
 func TestEd25519(t *testing.T) {
-	for _, v := range vectorsed25519 {
+	for _, v := range vectorsEd25519 {
 		got := v.isPure() && v.matchMsgLen() && v.matchCtxLen()
 		want := true
 		if got != want {

--- a/sign/ed25519/rfc8032_test.go
+++ b/sign/ed25519/rfc8032_test.go
@@ -29,8 +29,8 @@ func (v *rfc8032Vector) fetch(line string) {
 	v.public, _ = hex.DecodeString(values[1])
 	v.message, _ = hex.DecodeString(values[2])
 	v.signature, _ = hex.DecodeString(values[3])
-	v.private = v.private[:ed25519.Size]
-	v.signature = v.signature[:2*ed25519.Size]
+	v.private = v.private[:ed25519.PrivateKeySize]
+	v.signature = v.signature[:ed25519.SignatureSize]
 }
 
 func (v *rfc8032Vector) test(t *testing.T, lineNum int) {
@@ -42,9 +42,9 @@ func (v *rfc8032Vector) test(t *testing.T, lineNum int) {
 			test.ReportError(t, got, want, lineNum, v)
 		}
 
-		got = ed25519.Sign(keys, v.message)
+		got, err := keys.SignPure(v.message)
 		want = v.signature
-		if !bytes.Equal(got, want) {
+		if !bytes.Equal(got, want) || err != nil {
 			test.ReportError(t, got, want, lineNum, v)
 		}
 	}
@@ -296,9 +296,9 @@ func (v vector) testPublicKey(t *testing.T) {
 
 func (v vector) testSign(t *testing.T) {
 	private := ed25519.NewKeyFromSeed(v.sk)
-	got := ed25519.Sign(private, v.msg)
+	got, err := private.SignPure(v.msg)
 	want := v.sig
-	if !bytes.Equal(got, want) {
+	if !bytes.Equal(got, want) || err != nil {
 		test.ReportError(t, got, want, v.name)
 	}
 }

--- a/sign/ed25519/wycheproof_test.go
+++ b/sign/ed25519/wycheproof_test.go
@@ -86,9 +86,9 @@ func (kat *Wycheproof) verify(t *testing.T) {
 				test.ReportError(t, got, want, i, gT.TcID)
 			}
 			if isValid {
-				got := ed25519.Sign(keys, msg)
+				got, err := keys.SignPure(msg)
 				want := sig
-				if !bytes.Equal(got, want) {
+				if !bytes.Equal(got, want) || err != nil {
 					test.ReportError(t, got, want, i, gT.TcID)
 				}
 			}

--- a/sign/ed448/ed448_test.go
+++ b/sign/ed448/ed448_test.go
@@ -60,7 +60,7 @@ func TestWrongPublicKey(t *testing.T) {
 			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x80,
 		},
 	}
-	sig := make([]byte, 2*ed448.Size)
+	sig := (&[ed448.SignatureSize]byte{})[:]
 	for _, public := range wrongPublicKeys {
 		got := ed448.Verify(public[:], []byte(""), []byte(""), sig)
 		want := false
@@ -129,13 +129,6 @@ type badReader struct{}
 func (badReader) Read([]byte) (n int, err error) { return 0, errors.New("cannot read") }
 
 func TestErrors(t *testing.T) {
-	shouldPanic := func(t *testing.T) {
-		t.Helper()
-		if r := recover(); r == nil {
-			t.Errorf("it should panic")
-		}
-	}
-
 	t.Run("badHash", func(t *testing.T) {
 		var msg [16]byte
 		ops := crypto.SHA224
@@ -154,16 +147,22 @@ func TestErrors(t *testing.T) {
 		}
 	})
 	t.Run("wrongSeedSize", func(t *testing.T) {
-		defer shouldPanic(t)
 		var seed [256]byte
-		ed448.NewKeyFromSeed(seed[:])
+		var want error
+		got := test.CheckPanic(func() { ed448.NewKeyFromSeed(seed[:]) })
+		if got != want {
+			test.ReportError(t, got, want)
+		}
 	})
 	t.Run("bigContext", func(t *testing.T) {
-		defer shouldPanic(t)
 		var msg [16]byte
 		var ctx [256]byte
+		var want error
 		key, _ := ed448.GenerateKey(nil)
-		ed448.Sign(key, msg[:], ctx[:])
+		got := test.CheckPanic(func() { ed448.Sign(key, msg[:], ctx[:]) })
+		if got != want {
+			test.ReportError(t, got, want)
+		}
 	})
 }
 
@@ -173,23 +172,24 @@ func BenchmarkEd448(b *testing.B) {
 	_, _ = rand.Read(msg)
 	_, _ = rand.Read(ctx)
 
-	key, _ := ed448.GenerateKey(rand.Reader)
-	pub := key.GetPublic()
-	sig := ed448.Sign(key, msg, ctx)
-
 	b.Run("keygen", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			ed448.GenerateKey(rand.Reader)
 		}
 	})
 	b.Run("sign", func(b *testing.B) {
+		key, _ := ed448.GenerateKey(rand.Reader)
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			ed448.Sign(key, msg, ctx)
 		}
 	})
 	b.Run("verify", func(b *testing.B) {
+		key, _ := ed448.GenerateKey(rand.Reader)
+		sig := ed448.Sign(key, msg, ctx)
+		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			ed448.Verify(pub, msg, ctx, sig)
+			ed448.Verify(key.GetPublic(), msg, ctx, sig)
 		}
 	})
 }
@@ -198,7 +198,7 @@ func Example_ed448() {
 	// import "github.com/cloudflare/circl/sign/ed448"
 
 	// Generating Alice's key pair
-	key, err := ed448.GenerateKey(rand.Reader)
+	keys, err := ed448.GenerateKey(rand.Reader)
 	if err != nil {
 		panic("error on generating keys")
 	}
@@ -206,10 +206,10 @@ func Example_ed448() {
 	// Alice signs a message.
 	message := []byte("A message to be signed")
 	context := []byte("This is a context string")
-	signature := ed448.Sign(key, message, context)
+	signature := ed448.Sign(keys, message, context)
 
 	// Anyone can verify the signature using Alice's public key.
-	ok := ed448.Verify(key.GetPublic(), message, context, signature)
+	ok := ed448.Verify(keys.GetPublic(), message, context, signature)
 	fmt.Println(ok)
 	// Output: true
 }

--- a/sign/ed448/rfc8032_test.go
+++ b/sign/ed448/rfc8032_test.go
@@ -167,9 +167,9 @@ func (v vector) testPublicKey(t *testing.T) {
 
 func (v vector) testSign(t *testing.T) {
 	private := ed448.NewKeyFromSeed(v.sk)
-	got := ed448.Sign(private, v.msg, v.ctx)
+	got, err := private.SignWithContext(v.msg, v.ctx)
 	want := v.sig
-	if !bytes.Equal(got, want) {
+	if !bytes.Equal(got, want) || err != nil {
 		test.ReportError(t, got, want, v.name)
 	}
 }

--- a/sign/ed448/wycheproof_test.go
+++ b/sign/ed448/wycheproof_test.go
@@ -87,9 +87,9 @@ func (kat *Wycheproof) verify(t *testing.T) {
 				test.ReportError(t, got, want, i, gT.TcID)
 			}
 			if isValid {
-				got := ed448.Sign(keys, msg, ctx)
+				got, err := keys.SignWithContext(msg, ctx)
 				want := sig
-				if !bytes.Equal(got, want) {
+				if !bytes.Equal(got, want) || err != nil {
 					test.ReportError(t, got, want, i, gT.TcID)
 				}
 			}


### PR DESCRIPTION
Changes:
 - Unifies the API for EdDSA signatures.
 - Both packages implement `crypto.Signer` so it can be used with other signature schemes.
 - Added tests for ed25519.

Future changes (not this PR)
 - extract edwards25519 arithmetic to the `circl/ecc` package.

