### PR TITLE
dilithium: NewKeyFromSeed: use SHAKE-256 instead of SHAKE-128

### DIFF
--- a/sign/dilithium/dilithium_test.go
+++ b/sign/dilithium/dilithium_test.go
@@ -20,7 +20,11 @@ func testNewKeyFromSeed(t *testing.T, name, esk, epk string) {
 	if mode == nil {
 		t.Fatal()
 	}
-	pk, sk := mode.NewKeyFromSeed(make([]byte, mode.SeedSize()))
+	var seed [96]byte
+	h := shake.NewShake128()
+	_, _ = h.Write(make([]byte, mode.SeedSize()))
+	_, _ = h.Read(seed[:])
+	pk, sk := mode.NewKeyFromExpandedSeed(&seed)
 	pkh := hexHash(pk.Bytes())
 	skh := hexHash(sk.Bytes())
 	if pkh != epk {

--- a/sign/dilithium/mode3/internal/dilithium.go
+++ b/sign/dilithium/mode3/internal/dilithium.go
@@ -218,7 +218,7 @@ func (sk *PrivateKey) computeT0andT1(t0, t1 *VecK) {
 // NewKeyFromSeed derives a public/private key pair using the given seed.
 func NewKeyFromSeed(seed *[common.SeedSize]byte) (*PublicKey, *PrivateKey) {
 	var buf [96]byte
-	h := shake.NewShake128()
+	h := shake.NewShake256()
 	_, _ = h.Write(seed[:])
 	_, _ = h.Read(buf[:])
 	return NewKeyFromExpandedSeed(&buf)


### PR DESCRIPTION
A Dilithium private key is generated from three 32 byte seeds: the
public ρ which is used to derive the matrix A, a private seed to
derive the vector s and finally a private seed key to derive the ys.

These three seeds are currently derived from a single 32 byte seed
using SHAKE-128.  On paper (but this is false in this case, see
below) this allows an attacker to compute a collision in 2^128 work.
This would entail two different seeds that generate the same private
key.  In most applications this is not an issue.

It is of great concern whether the two private seeds can be derived from ρ.
Note that it is not sufficient to derive a few bits of the seeds as
these seeds themselves are used as input to hash functions.  Assuming
no weaknesses in SHAKE-128 this would still require trying all 2^256
possible seeds.

In this case the SHAKE-128 collision takes more than 2^128 work.
Indeed, if we unroll the definition of SHAKE-128 we see that three
seeds are given by:

  f( seed ‖ 168 bytes of SHAKE-128 padding ) truncated to 96 bytes,

where f is the KeccaK-f1600 permutation on 200 bytes.  If we would have
used SHAKE-256, then we get

  f( seed ‖ 168 bytes of SHAKE-256 padding ) truncated to 96 bytes,

The only difference between the two paddings is the location of 0x80
byte that marks the start of the "capacity".  Thus using SHAKE-128 or
SHAKE-256 doesn't make any difference except that it looks bad to use
SHAKE-128 without considering the details.  As there is no real
difference in cost, we change to SHAKE-256.