### PR TITLE
Fix linting

### DIFF
--- a/.etc/golangci.yml
+++ b/.etc/golangci.yml
@@ -17,7 +17,6 @@ linters:
     - govet
     - ineffassign
     - interfacer
-    - lll
     - misspell
     - nakedret
     - scopelint

--- a/.etc/golangci.yml
+++ b/.etc/golangci.yml
@@ -1,15 +1,35 @@
 linters:
-  enable-all: true
-  disable:
-    - testpackage # it can be improved
-    - lll         # it can be improved
-    - gocritic    # it can be improved
-    - gocognit    # it can be improved
-    - gochecknoglobals
-    - gochecknoinits
-    - gomnd
-    - dupl
-    - wsl
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - errcheck
+    - funlen
+    - goconst
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - misspell
+    - nakedret
+    - scopelint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
 
 linters-settings:
   funlen:

--- a/.etc/golangci.yml
+++ b/.etc/golangci.yml
@@ -1,6 +1,9 @@
 linters:
   disable-all: true
   enable:
+#   - lll    
+#   - gocritic    
+#   - gocognit    
     - bodyclose
     - deadcode
     - depguard

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Linting
         uses: golangci/golangci-lint-action@v1
         with:
-          version: v1.25
+          version: v1.28.1
           args: --config=./.etc/golangci.yml ./...
       - name: Setup Go-${{ matrix.GOVER }}
         uses: actions/setup-go@v2

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Linting
         uses: golangci/golangci-lint-action@v1
         with:
-          version: v1.28.1
+          version: v1.27
           args: --config=./.etc/golangci.yml ./...
       - name: Setup Go-${{ matrix.GOVER }}
         uses: actions/setup-go@v2

--- a/ecc/p384/point.go
+++ b/ecc/p384/point.go
@@ -24,7 +24,7 @@ func zeroPoint() *affinePoint { return &affinePoint{} }
 
 func (ap affinePoint) String() string {
 	if ap.isZero() {
-		return fmt.Sprint("inf")
+		return "inf"
 	}
 	return fmt.Sprintf("x: %v\ny: %v", ap.x, ap.y)
 }

--- a/ecc/p384/point.go
+++ b/ecc/p384/point.go
@@ -24,7 +24,7 @@ func zeroPoint() *affinePoint { return &affinePoint{} }
 
 func (ap affinePoint) String() string {
 	if ap.isZero() {
-		return fmt.Sprintf("inf")
+		return fmt.Sprint("inf")
 	}
 	return fmt.Sprintf("x: %v\ny: %v", ap.x, ap.y)
 }


### PR DESCRIPTION
It is not encouraged anymore to use `enable-all`, as it will be deprecated and removed soon: https://golangci-lint.run/usage/configuration/