### PR TITLE
sign: add hybrid of Dilithium4 and Ed448

### DIFF
--- a/sign/eddilithium4/eddilithium.go
+++ b/sign/eddilithium4/eddilithium.go
@@ -1,0 +1,213 @@
+// eddilithium4 implements the hybrid signature scheme Ed448-Dilithium4.
+package eddilithium4
+
+import (
+	"crypto"
+	cryptoRand "crypto/rand"
+	"errors"
+	"io"
+
+	"github.com/cloudflare/circl/internal/shake"
+	"github.com/cloudflare/circl/sign/dilithium/mode4"
+	"github.com/cloudflare/circl/sign/ed448"
+)
+
+const (
+	// Size of seed for NewKeyFromSeed
+	SeedSize = ed448.PrivateKeySize // > mode3.SeedSize
+
+	// Size of a packed PublicKey
+	PublicKeySize = mode4.PublicKeySize + ed448.PublicKeySize
+
+	// Size of a packed PrivateKey
+	PrivateKeySize = mode4.PrivateKeySize + ed448.PrivateKeySize
+
+	// Size of a signature
+	SignatureSize = mode4.SignatureSize + ed448.SignatureSize
+)
+
+// PublicKey is the type of an EdDilithium4 public key.
+type PublicKey struct {
+	e ed448.PublicKey
+	d mode4.PublicKey
+}
+
+// PrivateKey is the type of an EdDilithium4 private key.
+type PrivateKey struct {
+	e ed448.KeyPair
+	d mode4.PrivateKey
+}
+
+// GenerateKey generates a public/private key pair using entropy from rand.
+// If rand is nil, crypto/rand.Reader will be used.
+func GenerateKey(rand io.Reader) (*PublicKey, *PrivateKey, error) {
+	var seed [SeedSize]byte
+	if rand == nil {
+		rand = cryptoRand.Reader
+	}
+	_, err := io.ReadFull(rand, seed[:])
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pk, sk := NewKeyFromSeed(&seed)
+	return pk, sk, nil
+}
+
+// NewKeyFromSeed derives a public/private key pair using the given seed.
+func NewKeyFromSeed(seed *[SeedSize]byte) (*PublicKey, *PrivateKey) {
+	var seed1 [32]byte
+	var seed2 [57]byte
+
+	h := shake.NewShake256()
+	_, _ = h.Write(seed[:])
+	_, _ = h.Read(seed1[:])
+	_, _ = h.Read(seed2[:])
+	dpk, dsk := mode4.NewKeyFromSeed(&seed1)
+	epair := ed448.NewKeyFromSeed(seed2[:])
+
+	return &PublicKey{epair.GetPublic(), *dpk}, &PrivateKey{*epair, *dsk}
+}
+
+// SignTo signs the given message and writes the signature into signature.
+// It will panic if signature is not of length at least SignatureSize.
+func SignTo(sk *PrivateKey, msg []byte, signature []byte) {
+	mode4.SignTo(
+		&sk.d,
+		msg,
+		signature[:mode4.SignatureSize],
+	)
+	esig, _ := sk.e.Sign(
+		nil,
+		msg,
+		crypto.Hash(0),
+	)
+	copy(signature[mode4.SignatureSize:], esig[:])
+}
+
+// Verify checks whether the given signature by pk on msg is valid.
+func Verify(pk *PublicKey, msg []byte, signature []byte) bool {
+	if !mode4.Verify(
+		&pk.d,
+		msg,
+		signature[:mode4.SignatureSize],
+	) {
+		return false
+	}
+	if !ed448.Verify(
+		pk.e,
+		msg,
+		[]byte{}, // context
+		signature[mode4.SignatureSize:],
+	) {
+		return false
+	}
+	return true
+}
+
+// Unpack unpacks pk to the public key encoded in buf.
+func (pk *PublicKey) Unpack(buf *[PublicKeySize]byte) {
+	var tmp [mode4.PublicKeySize]byte
+	copy(tmp[:], buf[:mode4.PublicKeySize])
+	pk.d.Unpack(&tmp)
+	pk.e = make([]byte, ed448.PublicKeySize)
+	copy(pk.e, buf[mode4.PublicKeySize:])
+}
+
+// Unpack sets sk to the private key encoded in buf.
+func (sk *PrivateKey) Unpack(buf *[PrivateKeySize]byte) {
+	var tmp [mode4.PrivateKeySize]byte
+	copy(tmp[:], buf[:mode4.PrivateKeySize])
+	sk.d.Unpack(&tmp)
+	sk.e = *ed448.NewKeyFromSeed(buf[mode4.PrivateKeySize:])
+}
+
+// Pack packs the public key into buf.
+func (pk *PublicKey) Pack(buf *[PublicKeySize]byte) {
+	var tmp [mode4.PublicKeySize]byte
+	pk.d.Pack(&tmp)
+	copy(buf[:mode4.PublicKeySize], tmp[:])
+	copy(buf[mode4.PublicKeySize:], pk.e)
+}
+
+// Pack packs the private key into buf.
+func (sk *PrivateKey) Pack(buf *[PrivateKeySize]byte) {
+	var tmp [mode4.PrivateKeySize]byte
+	sk.d.Pack(&tmp)
+	copy(buf[:mode4.PrivateKeySize], tmp[:])
+	copy(buf[mode4.PrivateKeySize:], sk.e.Seed())
+}
+
+// Bytes packs the public key.
+func (pk *PublicKey) Bytes() []byte {
+	return append(pk.d.Bytes(), pk.e...)
+}
+
+// Bytes packs the private key.
+func (sk *PrivateKey) Bytes() []byte {
+	return append(sk.d.Bytes(), sk.e.Seed()...)
+}
+
+// MarshalBinary packs the public key.
+func (pk *PublicKey) MarshalBinary() ([]byte, error) {
+	return pk.Bytes(), nil
+}
+
+// MarshalBinary packs the private key.
+func (sk *PrivateKey) MarshalBinary() ([]byte, error) {
+	return sk.Bytes(), nil
+}
+
+// UnmarshalBinary the public key from data.
+func (pk *PublicKey) UnmarshalBinary(data []byte) error {
+	if len(data) != PublicKeySize {
+		return errors.New("packed public key must be of eddilithium3.PublicKeySize bytes")
+	}
+	var buf [PublicKeySize]byte
+	copy(buf[:], data)
+	pk.Unpack(&buf)
+	return nil
+}
+
+// UnmarshalBinary unpacks the private key from data.
+func (sk *PrivateKey) UnmarshalBinary(data []byte) error {
+	if len(data) != PrivateKeySize {
+		return errors.New("packed private key must be of eddilithium3.PrivateKeySize bytes")
+	}
+	var buf [PrivateKeySize]byte
+	copy(buf[:], data)
+	sk.Unpack(&buf)
+	return nil
+}
+
+// Sign signs the given message.
+//
+// opts.HashFunc() must return zero, which can be achieved by passing
+// crypto.Hash(0) for opts.  rand is ignored.  Will only return an error
+// if opts.HashFunc() is non-zero.
+//
+// This function is used to make PrivateKey implement the crypto.Signer
+// interface.  The package-level SignTo function might be more convenient
+// to use.
+func (sk *PrivateKey) Sign(rand io.Reader, msg []byte, opts crypto.SignerOpts) (
+	signature []byte, err error) {
+	var sig [SignatureSize]byte
+
+	if opts.HashFunc() != crypto.Hash(0) {
+		return nil, errors.New("eddilithium3: cannot sign hashed message")
+	}
+
+	SignTo(sk, msg, sig[:])
+	return sig[:], nil
+}
+
+// Public computes the public key corresponding to this private key.
+//
+// Returns a *PublicKey.  The type crypto.PublicKey is used to make
+// PrivateKey implement the crypto.Signer interface.
+func (sk *PrivateKey) Public() crypto.PublicKey {
+	return &PublicKey{
+		sk.e.GetPublic(),
+		*sk.d.Public().(*mode4.PublicKey),
+	}
+}

--- a/sign/eddilithium4/eddilithium.go
+++ b/sign/eddilithium4/eddilithium.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// Size of seed for NewKeyFromSeed
-	SeedSize = ed448.PrivateKeySize // > mode3.SeedSize
+	SeedSize = ed448.PrivateKeySize // > mode4.SeedSize
 
 	// Size of a packed PublicKey
 	PublicKeySize = mode4.PublicKeySize + ed448.PublicKeySize

--- a/sign/eddilithium4/eddilithium_test.go
+++ b/sign/eddilithium4/eddilithium_test.go
@@ -1,0 +1,111 @@
+package eddilithium4_test
+
+import (
+	"github.com/cloudflare/circl/sign/eddilithium4"
+
+	"encoding/binary"
+	"testing"
+)
+
+func BenchmarkVerify(b *testing.B) {
+	// Note that Dilithium precomputes quite a bit during Unpacking/Keygen
+	// instead of at the moment of verification (as compared to the reference
+	// implementation.  A fair comparison thus should sum verification
+	// times with unpacking times.)
+	var seed [57]byte
+	var msg [8]byte
+	var sig [eddilithium4.SignatureSize]byte
+	pk, sk := eddilithium4.NewKeyFromSeed(&seed)
+	eddilithium4.SignTo(sk, msg[:], sig[:])
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// We should generate a new signature for every verify attempt,
+		// as this influences the time a little bit.  This difference, however,
+		// is small and generating a new signature in between creates a lot
+		// pressure on the allocator which makes an accurate measurement hard.
+		eddilithium4.Verify(pk, msg[:], sig[:])
+	}
+}
+
+func BenchmarkSign(b *testing.B) {
+	// Note that Dilithium precomputes quite a bit during Unpacking/Keygen
+	// instead of at the moment of signing (as compared to the reference
+	// implementation.  A fair comparison thus should sum sign times with
+	// unpacking times.)
+	var seed [57]byte
+	var msg [8]byte
+	var sig [eddilithium4.SignatureSize]byte
+	_, sk := eddilithium4.NewKeyFromSeed(&seed)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		binary.LittleEndian.PutUint64(msg[:], uint64(i))
+		eddilithium4.SignTo(sk, msg[:], sig[:])
+	}
+}
+
+func BenchmarkGenerateKey(b *testing.B) {
+	var seed [57]byte
+	for i := 0; i < b.N; i++ {
+		binary.LittleEndian.PutUint64(seed[:], uint64(i))
+		eddilithium4.NewKeyFromSeed(&seed)
+	}
+}
+
+func BenchmarkPublicFromPrivate(b *testing.B) {
+	var seed [57]byte
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		binary.LittleEndian.PutUint64(seed[:], uint64(i))
+		_, sk := eddilithium4.NewKeyFromSeed(&seed)
+		b.StartTimer()
+		sk.Public()
+	}
+}
+
+func TestSignThenVerifyAndPkSkPacking(t *testing.T) {
+	var seed [eddilithium4.SeedSize]byte
+	var sig [eddilithium4.SignatureSize]byte
+	var msg [8]byte
+	var pkb1, pkb2 [eddilithium4.PublicKeySize]byte
+	var skb1, skb2 [eddilithium4.PrivateKeySize]byte
+	var pk2 eddilithium4.PublicKey
+	var sk2 eddilithium4.PrivateKey
+	for i := uint64(0); i < 100; i++ {
+		binary.LittleEndian.PutUint64(seed[:], i)
+		pk, sk := eddilithium4.NewKeyFromSeed(&seed)
+		for j := uint64(0); j < 10; j++ {
+			binary.LittleEndian.PutUint64(msg[:], j)
+			eddilithium4.SignTo(sk, msg[:], sig[:])
+			if !eddilithium4.Verify(pk, msg[:], sig[:]) {
+				t.Fatal()
+			}
+		}
+		pk.Pack(&pkb1)
+		pk2.Unpack(&pkb1)
+		pk2.Pack(&pkb2)
+		if pkb1 != pkb2 {
+			t.Fatal()
+		}
+		sk.Pack(&skb1)
+		sk2.Unpack(&skb1)
+		sk2.Pack(&skb2)
+		if skb1 != skb2 {
+			t.Fatal()
+		}
+	}
+}
+
+func TestPublicFromPrivate(t *testing.T) {
+	var seed [eddilithium4.SeedSize]byte
+	for i := uint64(0); i < 100; i++ {
+		binary.LittleEndian.PutUint64(seed[:], i)
+		pk, sk := eddilithium4.NewKeyFromSeed(&seed)
+		pk2 := sk.Public().(*eddilithium4.PublicKey)
+		var pkb1, pkb2 [eddilithium4.PublicKeySize]byte
+		pk.Pack(&pkb1)
+		pk2.Pack(&pkb2)
+		if pkb1 != pkb2 {
+			t.Fatal()
+		}
+	}
+}

--- a/sign/eddilithium4/example_test.go
+++ b/sign/eddilithium4/example_test.go
@@ -1,0 +1,45 @@
+package eddilithium4_test
+
+import (
+	"fmt"
+
+	"github.com/cloudflare/circl/sign/eddilithium4"
+)
+
+func Example() {
+	// Generates a keypair.
+	pk, sk, err := eddilithium4.GenerateKey(nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// (Alternatively one can derive a keypair from a seed,
+	// see NewKeyFromSeed().)
+
+	// Packs public and private key
+	var packedSk [eddilithium4.PrivateKeySize]byte
+	var packedPk [eddilithium4.PublicKeySize]byte
+	sk.Pack(&packedSk)
+	pk.Pack(&packedPk)
+
+	// Load it again
+	var sk2 eddilithium4.PrivateKey
+	var pk2 eddilithium4.PublicKey
+	sk2.Unpack(&packedSk)
+	pk2.Unpack(&packedPk)
+
+	// Creates a signature on our message with the generated private key.
+	msg := []byte("Some message")
+	var signature [eddilithium4.SignatureSize]byte
+	eddilithium4.SignTo(&sk2, msg, signature[:])
+
+	// Checks whether a signature is correct
+	if !eddilithium4.Verify(&pk2, msg, signature[:]) {
+		panic("incorrect signature")
+	}
+
+	fmt.Printf("O.K.")
+
+	// Output:
+	// O.K.
+}


### PR DESCRIPTION
Almost the same as eddilithium3 except for generation of the seed (as Ed448 requires more entropy) and the API of ed448.  (ed448 and ed25519 aren't drop-in replacements of eachother, yet.)