### PR TITLE
kyber: bugfix: compute A^T when unpacking

### DIFF
--- a/kem/schemes/schemes_test.go
+++ b/kem/schemes/schemes_test.go
@@ -63,7 +63,7 @@ func TestApi(t *testing.T) {
 				t.Fatal()
 			}
 
-			ct, ss := scheme.Encapsulate(pk)
+			ct, ss := scheme.Encapsulate(pk2)
 
 			if len(ct) != scheme.CiphertextSize() {
 				t.Fatal()
@@ -72,7 +72,7 @@ func TestApi(t *testing.T) {
 				t.Fatal()
 			}
 
-			ss2 := scheme.Decapsulate(sk, ct)
+			ss2 := scheme.Decapsulate(sk2, ct)
 			if !bytes.Equal(ss, ss2) {
 				t.Fatal()
 			}

--- a/pke/kyber/kyber1024/internal/cpapke.go
+++ b/pke/kyber/kyber1024/internal/cpapke.go
@@ -44,6 +44,7 @@ func (pk *PublicKey) Unpack(buf []byte) {
 	pk.th.Unpack(buf)
 	pk.th.Normalize()
 	copy(pk.rho[:], buf[K*common.PolySize:])
+	pk.aT.Derive(&pk.rho, true)
 }
 
 // Derives a new Kyber.CPAPKE keypair from the given seed.

--- a/pke/kyber/kyber512/internal/cpapke.go
+++ b/pke/kyber/kyber512/internal/cpapke.go
@@ -42,6 +42,7 @@ func (pk *PublicKey) Unpack(buf []byte) {
 	pk.th.Unpack(buf)
 	pk.th.Normalize()
 	copy(pk.rho[:], buf[K*common.PolySize:])
+	pk.aT.Derive(&pk.rho, true)
 }
 
 // Derives a new Kyber.CPAPKE keypair from the given seed.

--- a/pke/kyber/kyber768/internal/cpapke.go
+++ b/pke/kyber/kyber768/internal/cpapke.go
@@ -44,6 +44,7 @@ func (pk *PublicKey) Unpack(buf []byte) {
 	pk.th.Unpack(buf)
 	pk.th.Normalize()
 	copy(pk.rho[:], buf[K*common.PolySize:])
+	pk.aT.Derive(&pk.rho, true)
 }
 
 // Derives a new Kyber.CPAPKE keypair from the given seed.


### PR DESCRIPTION
This wasn't hit in the tests, because the tests of unpacking didn't check
whether the cached A^Ts were the same.