### PR TITLE
Kyber: InvNTT: reduce number of Barrett reductions

### DIFF
--- a/pke/kyber/internal/common/ntt.go
+++ b/pke/kyber/internal/common/ntt.go
@@ -27,6 +27,26 @@ var Zetas = [128]int16{
 	2459, 478, 3221, 3021, 996, 991, 958, 1869, 1522, 1628,
 }
 
+// InvNTTReductions keeps track of which coefficients to apply Barrett
+// reduction to in Poly.InvNTT().
+//
+// Generated in a lazily: once a butterfly is computed which is about to
+// overflow the int16, the largest coefficient is reduced.  If that is
+// not enough, the other coefficient is reduced as well.
+var InvNTTReductions = [...]int{
+	-1, // after layer 1
+	-1, // after layer 2
+	16, 17, 48, 49, 80, 81, 112, 113, 144, 145, 176, 177, 208, 209, 240,
+	241, -1, // after layer 3
+	0, 1, 32, 33, 34, 35, 64, 65, 96, 97, 98, 99, 128, 129, 160, 161, 162, 163,
+	192, 193, 224, 225, 226, 227, -1, // after layer 4
+	2, 3, 66, 67, 68, 69, 70, 71, 130, 131, 194, 195, 196, 197, 198,
+	199, -1, // after layer 5
+	4, 5, 6, 7, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142,
+	143, -1, // after layer 6
+	-1, //  after layer 7
+}
+
 // Executes an in-place forward "NTT" on p.
 //
 // Assumes the coefficients are in absolute value ≤q.  The resulting
@@ -119,38 +139,49 @@ func (p *Poly) NTT() {
 // if the input is in regular form, then the result is also in regular form.
 func (p *Poly) InvNTT() {
 	k := 127 // Index into Zetas
+	r := -1  // Index into InvNTTReductions.
 
 	// We basically do the oppposite of NTT, but postpone dividing by 2 in the
 	// inverse of the Cooley-Tukey butterfly and accumulate that into a big
 	// division by 2⁷ at the end.  See the comments in the NTT() function.
 
 	for l := 2; l < N; l <<= 1 {
-		// At the start of the nᵗʰ iteration of this loop, the coefficients
-		// are bounded in absolute value by nq.
-
-		// XXX Get rid of Barrett reduction?
-
 		for offset := 0; offset < N-l; offset += 2 * l {
-			// As we're inverting, we need powers of ζ⁻¹ (instead of
-			// ζ).  To be precise, we need ζᵇʳᵛ⁽ᵏ⁾⁻¹²⁸. However, as
-			// ζ⁻¹²⁸ = -1, we can use the existing Zetas table instead of
+			// As we're inverting, we need powers of ζ⁻¹ (instead of ζ).
+			// To be precise, we need ζᵇʳᵛ⁽ᵏ⁾⁻¹²⁸. However, as ζ⁻¹²⁸ = -1,
+			// we can use the existing Zetas table instead of
 			// keeping a separate InvZetas table as in Dilithium.
 
 			zeta := -int32(Zetas[k])
 			k--
 
 			for j := offset; j < offset+l; j++ {
-				t := barrettReduce(p[j]) // Gentleman-Sande butterfly
+				t := p[j] // Gentleman-Sande butterfly: (a, b) ↦ (a + b, ζ(a-b))
 				p[j] = t + p[j+l]
 				t -= p[j+l]
 				p[j+l] = montReduce(zeta * int32(t))
+
+				// Note that if we had |a| < αq and |b| < βq before the
+				// butterfly, then now we have |a| < (α+β)q and |b| < q.
 			}
+		}
+
+		// We let the InvNTTReductions instruct us which coefficients to
+		// Barrett reduce.  See TestInvNTTReductions, which tests whether
+		// there is an overflow.
+		for {
+			r++
+			i := InvNTTReductions[r]
+			if i < 0 {
+				break
+			}
+			p[i] = barrettReduce(p[i])
 		}
 	}
 
 	for j := 0; j < N; j++ {
-		// Note 1441 = (128)⁻¹ R².  The coefficients are bounded by 7q, so
-		// as 1441 * 7 ≈ 2⁹ < 2¹⁵, we're within the required bounds
+		// Note 1441 = (128)⁻¹ R².  The coefficients are bounded by 9q, so
+		// as 1441 * 9 ≈ 2¹⁴ < 2¹⁵, we're within the required bounds
 		// for montReduce().
 		p[j] = montReduce(1441 * int32(p[j]))
 	}

--- a/pke/kyber/internal/common/ntt_test.go
+++ b/pke/kyber/internal/common/ntt_test.go
@@ -58,3 +58,37 @@ func TestNTT(t *testing.T) {
 		}
 	}
 }
+
+func TestInvNTTReductions(t *testing.T) {
+	// Simulates bounds on coefficients in InvNTT.
+
+	xs := [256]int{}
+	for i := 0; i < 256; i++ {
+		xs[i] = 1
+	}
+
+	r := -1
+	for layer := 1; layer < 8; layer++ {
+		w := 1 << uint(layer)
+		i := 0
+		for i+w < 256 {
+			xs[i] = xs[i] + xs[i+w]
+			if xs[i] > 9 {
+				t.Fatal()
+			}
+			xs[i+w] = 1
+			i++
+			if i%w == 0 {
+				i += w
+			}
+		}
+		for {
+			r++
+			i := InvNTTReductions[r]
+			if i < 0 {
+				break
+			}
+			xs[i] = 1
+		}
+	}
+}

--- a/pke/kyber/internal/common/poly.go
+++ b/pke/kyber/internal/common/poly.go
@@ -53,7 +53,7 @@ func (p *Poly) ToMont() {
 // That is: InvNTT(p) = InvNTT(a) * InvNTT(b).  Assumes a and b are in
 // Montgomery form.  Products between coefficients of a and b must be strictly
 // bounded in absolute value by 2¹⁵q.  p will be in Montgomery form and
-// bounded in absolute value by q.
+// bounded in absolute value by 2q.
 func (p *Poly) MulHat(a, b *Poly) {
 	// Recall from the discussion in NTT(), that a transformed polynomial is
 	// an element of ℤ_q[x]/(x²-ζ) x … x  ℤ_q[x]/(x²+ζ¹²⁷);

--- a/pke/kyber/internal/common/poly_test.go
+++ b/pke/kyber/internal/common/poly_test.go
@@ -95,6 +95,7 @@ func TestMulHat(t *testing.T) {
 		ah.NTT()
 		bh.NTT()
 		ph.MulHat(&ah, &bh)
+		ph.BarrettReduce()
 		ph.InvNTT()
 
 		for i := 0; i < N; i++ {

--- a/pke/kyber/kyber1024/internal/cpapke.go
+++ b/pke/kyber/kyber1024/internal/cpapke.go
@@ -106,6 +106,7 @@ func (sk *PrivateKey) DecryptTo(pt, ct []byte) {
 	// Compute m = v - <s, u>
 	u.NTT()
 	PolyDotHat(&m, &sk.sh, &u)
+	m.BarrettReduce()
 	m.InvNTT()
 	m.Sub(&v, &m)
 	m.Normalize()
@@ -139,8 +140,6 @@ func (pk *PublicKey) EncryptTo(ct, seed, pt []byte) {
 		PolyDotHat(&u[i], &pk.aT[i], &rh)
 	}
 
-	// XXX InvNTT actually works with inputs only bounded by ~3q so we might
-	//     be able to remove this reduction for some K.
 	u.BarrettReduce()
 
 	// Aᵀ and r were not in Montgomery form, so the Montgomery

--- a/pke/kyber/kyber1024/internal/vec.go
+++ b/pke/kyber/kyber1024/internal/vec.go
@@ -21,7 +21,7 @@ func (v *Vec) DeriveNoise(seed []byte, nonce uint8) {
 //
 // See MulHat() and NTT() for a description of the multiplication.
 // Assumes a and b are in Montgomery form.  p will be in Montgomery form,
-// and its coefficients will be bounded in absolute value by kq.
+// and its coefficients will be bounded in absolute value by 2kq.
 // If a and b are not in Montgomery form, then the action is the same
 // as "pointwise" multiplication followed by multiplying by R⁻¹, the inverse
 // of the Montgomery factor.

--- a/pke/kyber/kyber512/internal/cpapke.go
+++ b/pke/kyber/kyber512/internal/cpapke.go
@@ -104,6 +104,7 @@ func (sk *PrivateKey) DecryptTo(pt, ct []byte) {
 	// Compute m = v - <s, u>
 	u.NTT()
 	PolyDotHat(&m, &sk.sh, &u)
+	m.BarrettReduce()
 	m.InvNTT()
 	m.Sub(&v, &m)
 	m.Normalize()
@@ -137,8 +138,6 @@ func (pk *PublicKey) EncryptTo(ct, seed, pt []byte) {
 		PolyDotHat(&u[i], &pk.aT[i], &rh)
 	}
 
-	// XXX InvNTT actually works with inputs only bounded by ~3q so we might
-	//     be able to remove this reduction for some K.
 	u.BarrettReduce()
 
 	// Aᵀ and r were not in Montgomery form, so the Montgomery

--- a/pke/kyber/kyber512/internal/vec.go
+++ b/pke/kyber/kyber512/internal/vec.go
@@ -19,7 +19,7 @@ func (v *Vec) DeriveNoise(seed []byte, nonce uint8) {
 //
 // See MulHat() and NTT() for a description of the multiplication.
 // Assumes a and b are in Montgomery form.  p will be in Montgomery form,
-// and its coefficients will be bounded in absolute value by kq.
+// and its coefficients will be bounded in absolute value by 2kq.
 // If a and b are not in Montgomery form, then the action is the same
 // as "pointwise" multiplication followed by multiplying by R⁻¹, the inverse
 // of the Montgomery factor.

--- a/pke/kyber/kyber768/internal/cpapke.go
+++ b/pke/kyber/kyber768/internal/cpapke.go
@@ -106,6 +106,7 @@ func (sk *PrivateKey) DecryptTo(pt, ct []byte) {
 	// Compute m = v - <s, u>
 	u.NTT()
 	PolyDotHat(&m, &sk.sh, &u)
+	m.BarrettReduce()
 	m.InvNTT()
 	m.Sub(&v, &m)
 	m.Normalize()
@@ -139,8 +140,6 @@ func (pk *PublicKey) EncryptTo(ct, seed, pt []byte) {
 		PolyDotHat(&u[i], &pk.aT[i], &rh)
 	}
 
-	// XXX InvNTT actually works with inputs only bounded by ~3q so we might
-	//     be able to remove this reduction for some K.
 	u.BarrettReduce()
 
 	// Aᵀ and r were not in Montgomery form, so the Montgomery

--- a/pke/kyber/kyber768/internal/vec.go
+++ b/pke/kyber/kyber768/internal/vec.go
@@ -21,7 +21,7 @@ func (v *Vec) DeriveNoise(seed []byte, nonce uint8) {
 //
 // See MulHat() and NTT() for a description of the multiplication.
 // Assumes a and b are in Montgomery form.  p will be in Montgomery form,
-// and its coefficients will be bounded in absolute value by kq.
+// and its coefficients will be bounded in absolute value by 2kq.
 // If a and b are not in Montgomery form, then the action is the same
 // as "pointwise" multiplication followed by multiplying by R⁻¹, the inverse
 // of the Montgomery factor.


### PR DESCRIPTION
InvNTT was more forgiving with its bounds than documented and this was used
in one spot.  After this change InvNTT is less forgiving and so we need
to change that callsite.

Old:

    BenchmarkInvNTT-4         431370          2768 ns/op

New:

    BenchmarkInvNTT-4         494037          2400 ns/op