### PR TITLE
kem: return error instead of panic()ing

### DIFF
--- a/kem/kem.go
+++ b/kem/kem.go
@@ -38,13 +38,11 @@ type Scheme interface {
 
 	// Encapsulate generates a shared key ss for the public key  and
 	// encapsulates it into a ciphertext ct.
-	Encapsulate(pk PublicKey) (ct []byte, ss []byte)
+	Encapsulate(pk PublicKey) (ct []byte, ss []byte, err error)
 
 	// Returns the shared key encapsulated in ciphertext ct for the
 	// private key sk.
-	//
-	// Panics if ct is not of size CiphertextSize().
-	Decapsulate(sk PrivateKey, ct []byte) []byte
+	Decapsulate(sk PrivateKey, ct []byte) ([]byte, error)
 
 	// Unmarshals a PublicKey from the provided buffer.
 	UnmarshalBinaryPublicKey([]byte) (PublicKey, error)
@@ -76,9 +74,8 @@ type Scheme interface {
 	// EncapsulateDeterministically generates a shared key ss for the public
 	// key deterministically from the given seed and encapsulates it into
 	// a ciphertext ct.  If unsure, you're better off using Encapsulate().
-	//
-	// Panics if seed is not of length EncapsulationSeedSize().
-	EncapsulateDeterministically(pk PublicKey, seed []byte) (ct, ss []byte)
+	EncapsulateDeterministically(pk PublicKey, seed []byte) (
+		ct, ss []byte, err error)
 
 	// Size of seed used in EncapsulateDeterministically().
 	EncapsulationSeedSize() int
@@ -104,4 +101,10 @@ var (
 	// ErrPrivKeySize is the error used if the provided private key is of
 	// the wrong size.
 	ErrPrivKeySize = errors.New("wrong size for private key")
+
+	// ErrPubKey is the error used if the provided public key is invalid.
+	ErrPubKey = errors.New("invalid public key")
+
+	// ErrCipherText is the error used if the provided ciphertext is invalid.
+	ErrCipherText = errors.New("invalid ciphertext")
 )

--- a/kem/kyber/kat_test.go
+++ b/kem/kyber/kat_test.go
@@ -62,8 +62,8 @@ func testPQCgenKATKem(t *testing.T, name, expected string) {
 		pk, sk := scheme.DeriveKey(kseed)
 		ppk, _ := pk.MarshalBinary()
 		psk, _ := sk.MarshalBinary()
-		ct, ss := scheme.EncapsulateDeterministically(pk, eseed)
-		ss2 := scheme.Decapsulate(sk, ct)
+		ct, ss, _ := scheme.EncapsulateDeterministically(pk, eseed)
+		ss2, _ := scheme.Decapsulate(sk, ct)
 		if !bytes.Equal(ss, ss2) {
 			t.Fatal()
 		}

--- a/kem/kyber/kyber1024/kyber.go
+++ b/kem/kyber/kyber1024/kyber.go
@@ -331,22 +331,22 @@ func (*scheme) DeriveKey(seed []byte) (kem.PublicKey, kem.PrivateKey) {
 	return NewKeyFromSeed(seed[:])
 }
 
-func (*scheme) Encapsulate(pk kem.PublicKey) (ct []byte, ss []byte) {
+func (*scheme) Encapsulate(pk kem.PublicKey) (ct, ss []byte, err error) {
 	ct = make([]byte, CiphertextSize)
 	ss = make([]byte, SharedKeySize)
 
 	pub, ok := pk.(*PublicKey)
 	if !ok {
-		panic(kem.ErrTypeMismatch)
+		return nil, nil, kem.ErrTypeMismatch
 	}
 	pub.EncapsulateTo(ct, ss, nil)
 	return
 }
 
 func (*scheme) EncapsulateDeterministically(pk kem.PublicKey, seed []byte) (
-	ct []byte, ss []byte) {
+	ct, ss []byte, err error) {
 	if len(seed) != EncapsulationSeedSize {
-		panic(kem.ErrSeedSize)
+		return nil, nil, kem.ErrSeedSize
 	}
 
 	ct = make([]byte, CiphertextSize)
@@ -354,24 +354,24 @@ func (*scheme) EncapsulateDeterministically(pk kem.PublicKey, seed []byte) (
 
 	pub, ok := pk.(*PublicKey)
 	if !ok {
-		panic(kem.ErrTypeMismatch)
+		return nil, nil, kem.ErrTypeMismatch
 	}
 	pub.EncapsulateTo(ct, ss, seed)
 	return
 }
 
-func (*scheme) Decapsulate(sk kem.PrivateKey, ct []byte) []byte {
+func (*scheme) Decapsulate(sk kem.PrivateKey, ct []byte) ([]byte, error) {
 	if len(ct) != CiphertextSize {
-		panic(kem.ErrCiphertextSize)
+		return nil, kem.ErrCiphertextSize
 	}
 
 	priv, ok := sk.(*PrivateKey)
 	if !ok {
-		panic(kem.ErrTypeMismatch)
+		return nil, kem.ErrTypeMismatch
 	}
 	ss := make([]byte, SharedKeySize)
 	priv.DecapsulateTo(ss, ct)
-	return ss
+	return ss, nil
 }
 
 func (*scheme) UnmarshalBinaryPublicKey(buf []byte) (kem.PublicKey, error) {

--- a/kem/kyber/kyber512/kyber.go
+++ b/kem/kyber/kyber512/kyber.go
@@ -331,22 +331,22 @@ func (*scheme) DeriveKey(seed []byte) (kem.PublicKey, kem.PrivateKey) {
 	return NewKeyFromSeed(seed[:])
 }
 
-func (*scheme) Encapsulate(pk kem.PublicKey) (ct []byte, ss []byte) {
+func (*scheme) Encapsulate(pk kem.PublicKey) (ct, ss []byte, err error) {
 	ct = make([]byte, CiphertextSize)
 	ss = make([]byte, SharedKeySize)
 
 	pub, ok := pk.(*PublicKey)
 	if !ok {
-		panic(kem.ErrTypeMismatch)
+		return nil, nil, kem.ErrTypeMismatch
 	}
 	pub.EncapsulateTo(ct, ss, nil)
 	return
 }
 
 func (*scheme) EncapsulateDeterministically(pk kem.PublicKey, seed []byte) (
-	ct []byte, ss []byte) {
+	ct, ss []byte, err error) {
 	if len(seed) != EncapsulationSeedSize {
-		panic(kem.ErrSeedSize)
+		return nil, nil, kem.ErrSeedSize
 	}
 
 	ct = make([]byte, CiphertextSize)
@@ -354,24 +354,24 @@ func (*scheme) EncapsulateDeterministically(pk kem.PublicKey, seed []byte) (
 
 	pub, ok := pk.(*PublicKey)
 	if !ok {
-		panic(kem.ErrTypeMismatch)
+		return nil, nil, kem.ErrTypeMismatch
 	}
 	pub.EncapsulateTo(ct, ss, seed)
 	return
 }
 
-func (*scheme) Decapsulate(sk kem.PrivateKey, ct []byte) []byte {
+func (*scheme) Decapsulate(sk kem.PrivateKey, ct []byte) ([]byte, error) {
 	if len(ct) != CiphertextSize {
-		panic(kem.ErrCiphertextSize)
+		return nil, kem.ErrCiphertextSize
 	}
 
 	priv, ok := sk.(*PrivateKey)
 	if !ok {
-		panic(kem.ErrTypeMismatch)
+		return nil, kem.ErrTypeMismatch
 	}
 	ss := make([]byte, SharedKeySize)
 	priv.DecapsulateTo(ss, ct)
-	return ss
+	return ss, nil
 }
 
 func (*scheme) UnmarshalBinaryPublicKey(buf []byte) (kem.PublicKey, error) {

--- a/kem/kyber/kyber768/kyber.go
+++ b/kem/kyber/kyber768/kyber.go
@@ -331,22 +331,22 @@ func (*scheme) DeriveKey(seed []byte) (kem.PublicKey, kem.PrivateKey) {
 	return NewKeyFromSeed(seed[:])
 }
 
-func (*scheme) Encapsulate(pk kem.PublicKey) (ct []byte, ss []byte) {
+func (*scheme) Encapsulate(pk kem.PublicKey) (ct, ss []byte, err error) {
 	ct = make([]byte, CiphertextSize)
 	ss = make([]byte, SharedKeySize)
 
 	pub, ok := pk.(*PublicKey)
 	if !ok {
-		panic(kem.ErrTypeMismatch)
+		return nil, nil, kem.ErrTypeMismatch
 	}
 	pub.EncapsulateTo(ct, ss, nil)
 	return
 }
 
 func (*scheme) EncapsulateDeterministically(pk kem.PublicKey, seed []byte) (
-	ct []byte, ss []byte) {
+	ct, ss []byte, err error) {
 	if len(seed) != EncapsulationSeedSize {
-		panic(kem.ErrSeedSize)
+		return nil, nil, kem.ErrSeedSize
 	}
 
 	ct = make([]byte, CiphertextSize)
@@ -354,24 +354,24 @@ func (*scheme) EncapsulateDeterministically(pk kem.PublicKey, seed []byte) (
 
 	pub, ok := pk.(*PublicKey)
 	if !ok {
-		panic(kem.ErrTypeMismatch)
+		return nil, nil, kem.ErrTypeMismatch
 	}
 	pub.EncapsulateTo(ct, ss, seed)
 	return
 }
 
-func (*scheme) Decapsulate(sk kem.PrivateKey, ct []byte) []byte {
+func (*scheme) Decapsulate(sk kem.PrivateKey, ct []byte) ([]byte, error) {
 	if len(ct) != CiphertextSize {
-		panic(kem.ErrCiphertextSize)
+		return nil, kem.ErrCiphertextSize
 	}
 
 	priv, ok := sk.(*PrivateKey)
 	if !ok {
-		panic(kem.ErrTypeMismatch)
+		return nil, kem.ErrTypeMismatch
 	}
 	ss := make([]byte, SharedKeySize)
 	priv.DecapsulateTo(ss, ct)
-	return ss
+	return ss, nil
 }
 
 func (*scheme) UnmarshalBinaryPublicKey(buf []byte) (kem.PublicKey, error) {

--- a/kem/kyber/templates/pkg.templ.go
+++ b/kem/kyber/templates/pkg.templ.go
@@ -335,22 +335,22 @@ func (*scheme) DeriveKey(seed []byte) (kem.PublicKey, kem.PrivateKey) {
 	return NewKeyFromSeed(seed[:])
 }
 
-func (*scheme) Encapsulate(pk kem.PublicKey) (ct []byte, ss []byte) {
+func (*scheme) Encapsulate(pk kem.PublicKey) (ct, ss []byte, err error) {
 	ct = make([]byte, CiphertextSize)
 	ss = make([]byte, SharedKeySize)
 
 	pub, ok := pk.(*PublicKey)
 	if !ok {
-		panic(kem.ErrTypeMismatch)
+		return nil, nil, kem.ErrTypeMismatch
 	}
 	pub.EncapsulateTo(ct, ss, nil)
 	return
 }
 
 func (*scheme) EncapsulateDeterministically(pk kem.PublicKey, seed []byte) (
-	ct []byte, ss []byte) {
+	ct, ss []byte, err error) {
 	if len(seed) != EncapsulationSeedSize {
-		panic(kem.ErrSeedSize)
+		return nil, nil, kem.ErrSeedSize
 	}
 
 	ct = make([]byte, CiphertextSize)
@@ -358,24 +358,24 @@ func (*scheme) EncapsulateDeterministically(pk kem.PublicKey, seed []byte) (
 
 	pub, ok := pk.(*PublicKey)
 	if !ok {
-		panic(kem.ErrTypeMismatch)
+		return nil, nil, kem.ErrTypeMismatch
 	}
 	pub.EncapsulateTo(ct, ss, seed)
 	return
 }
 
-func (*scheme) Decapsulate(sk kem.PrivateKey, ct []byte) []byte {
+func (*scheme) Decapsulate(sk kem.PrivateKey, ct []byte) ([]byte, error) {
 	if len(ct) != CiphertextSize {
-		panic(kem.ErrCiphertextSize)
+		return nil, kem.ErrCiphertextSize
 	}
 
 	priv, ok := sk.(*PrivateKey)
 	if !ok {
-		panic(kem.ErrTypeMismatch)
+		return nil, kem.ErrTypeMismatch
 	}
 	ss := make([]byte, SharedKeySize)
 	priv.DecapsulateTo(ss, ct)
-	return ss
+	return ss, nil
 }
 
 func (*scheme) UnmarshalBinaryPublicKey(buf []byte) (kem.PublicKey, error) {

--- a/kem/schemes/schemes_test.go
+++ b/kem/schemes/schemes_test.go
@@ -32,7 +32,7 @@ func BenchmarkEncapsulate(b *testing.B) {
 		pk, _, _ := scheme.GenerateKey()
 		b.Run(scheme.Name(), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, _ = scheme.Encapsulate(pk)
+				_, _, _ = scheme.Encapsulate(pk)
 			}
 		})
 	}
@@ -43,10 +43,10 @@ func BenchmarkDecapsulate(b *testing.B) {
 	for _, scheme := range allSchemes {
 		scheme := scheme
 		pk, sk, _ := scheme.GenerateKey()
-		ct, _ := scheme.Encapsulate(pk)
+		ct, _, _ := scheme.Encapsulate(pk)
 		b.Run(scheme.Name(), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				scheme.Decapsulate(sk, ct)
+				_, _ = scheme.Decapsulate(sk, ct)
 			}
 		})
 	}
@@ -102,8 +102,10 @@ func TestApi(t *testing.T) {
 				t.Fatal()
 			}
 
-			ct, ss := scheme.Encapsulate(pk2)
-
+			ct, ss, err := scheme.Encapsulate(pk2)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if len(ct) != scheme.CiphertextSize() {
 				t.Fatal()
 			}
@@ -111,7 +113,10 @@ func TestApi(t *testing.T) {
 				t.Fatal()
 			}
 
-			ss2 := scheme.Decapsulate(sk2, ct)
+			ss2, err := scheme.Decapsulate(sk2, ct)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if !bytes.Equal(ss, ss2) {
 				t.Fatal()
 			}


### PR DESCRIPTION
This reverts the revert.

We don't want that third party input (cipher text for instance) is able to cause a panic.