### PR TITLE
Refactor the OPRF KeyPair interfaces, and add a serialization test.

### DIFF
--- a/oprf/group/group.go
+++ b/oprf/group/group.go
@@ -159,5 +159,5 @@ func (s *Scalar) Serialize() []byte {
 // Deserialize an octet-string into a valid Scalar object.
 func (s *Scalar) Deserialize(in []byte) {
 	byteLength := (s.c.Params().BitSize + 7) / 8
-	s.x = new(big.Int).SetBytes(in[1 : byteLength+1])
+	s.x = new(big.Int).SetBytes(in[:byteLength])
 }

--- a/oprf/oprf.go
+++ b/oprf/oprf.go
@@ -67,8 +67,8 @@ type Evaluation struct {
 
 // KeyPair is an struct containing a public and private key.
 type KeyPair struct {
-	PublicKey  *group.Element
-	PrivateKey *group.Scalar
+	publicKey  *group.Element
+	privateKey *group.Scalar
 }
 
 // Client is a representation of a Client during protocol execution.
@@ -92,7 +92,7 @@ func generateContext(id SuiteID) []byte {
 
 // Serialize serializes a KeyPair elements into byte arrays.
 func (kp *KeyPair) Serialize() []byte {
-	return kp.PrivateKey.Serialize()
+	return kp.privateKey.Serialize()
 }
 
 // Deserialize deserializes a KeyPair into an element and field element of the group.
@@ -101,8 +101,8 @@ func (kp *KeyPair) Deserialize(suite *group.Ciphersuite, encoded []byte) error {
 	privateKey.Deserialize(encoded)
 	publicKey := suite.Generator().ScalarBaseMult(privateKey)
 
-	kp.PublicKey = publicKey
-	kp.PrivateKey = privateKey
+	kp.publicKey = publicKey
+	kp.privateKey = privateKey
 
 	return nil
 }
@@ -110,9 +110,9 @@ func (kp *KeyPair) Deserialize(suite *group.Ciphersuite, encoded []byte) error {
 // GenerateKeyPair generates a KeyPair in accordance with the group.
 func GenerateKeyPair(suite *group.Ciphersuite) KeyPair {
 	privateKey := suite.RandomScalar()
-	PublicKey := suite.Generator().ScalarBaseMult(privateKey)
+	publicKey := suite.Generator().ScalarBaseMult(privateKey)
 
-	return KeyPair{PublicKey, privateKey}
+	return KeyPair{publicKey, privateKey}
 }
 
 func suiteFromID(id SuiteID, context []byte) (*group.Ciphersuite, error) {
@@ -167,7 +167,7 @@ func (s *Server) Evaluate(b BlindToken) (*Evaluation, error) {
 		return nil, err
 	}
 
-	z := p.ScalarMult(s.Kp.PrivateKey)
+	z := p.ScalarMult(s.Kp.privateKey)
 	ser := z.Serialize()
 
 	return &Evaluation{ser}, nil
@@ -223,7 +223,7 @@ func (s *Server) FullEvaluate(in, info []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	t := p.ScalarMult(s.Kp.PrivateKey)
+	t := p.ScalarMult(s.Kp.privateKey)
 	iToken := t.Serialize()
 
 	h := finalizeHash(s.suite, in, iToken, info, s.context)

--- a/oprf/oprf.go
+++ b/oprf/oprf.go
@@ -62,13 +62,13 @@ type Token struct {
 
 // Evaluation corresponds to the evaluation over a token.
 type Evaluation struct {
-	element []byte
+	Element []byte
 }
 
 // KeyPair is an struct containing a public and private key.
 type KeyPair struct {
-	pubK  *group.Element
-	PrivK *group.Scalar
+	PublicKey  *group.Element
+	PrivateKey *group.Scalar
 }
 
 // Client is a representation of a Client during protocol execution.
@@ -81,7 +81,7 @@ type Client struct {
 type Server struct {
 	suite   *group.Ciphersuite
 	context []byte
-	Kp      *KeyPair
+	Kp      KeyPair
 }
 
 func generateContext(id SuiteID) []byte {
@@ -91,43 +91,28 @@ func generateContext(id SuiteID) []byte {
 }
 
 // Serialize serializes a KeyPair elements into byte arrays.
-func (kp *KeyPair) Serialize() ([]byte, []byte) {
-	pubK := kp.pubK.Serialize()
-	privK := kp.PrivK.Serialize()
-
-	return pubK, privK
+func (kp *KeyPair) Serialize() []byte {
+	return kp.PrivateKey.Serialize()
 }
 
 // Deserialize deserializes a KeyPair into an element and field element of the group.
-func (kp *KeyPair) Deserialize(suite *group.Ciphersuite, privK, pubK []byte) error {
-	priv := group.NewScalar(suite.Curve)
-	priv.Deserialize(privK)
+func (kp *KeyPair) Deserialize(suite *group.Ciphersuite, encoded []byte) error {
+	privateKey := group.NewScalar(suite.Curve)
+	privateKey.Deserialize(encoded)
+	publicKey := suite.Generator().ScalarBaseMult(privateKey)
 
-	pub := group.NewElement(suite.Curve)
-	err := pub.Deserialize(pubK)
-	if err != nil {
-		return err
-	}
+	kp.PublicKey = publicKey
+	kp.PrivateKey = privateKey
 
 	return nil
 }
 
 // GenerateKeyPair generates a KeyPair in accordance with the group.
-func GenerateKeyPair(suite *group.Ciphersuite) *KeyPair {
-	privK := suite.RandomScalar()
-	pubK := suite.Generator().ScalarBaseMult(privK)
+func GenerateKeyPair(suite *group.Ciphersuite) KeyPair {
+	privateKey := suite.RandomScalar()
+	PublicKey := suite.Generator().ScalarBaseMult(privateKey)
 
-	return &KeyPair{pubK, privK}
-}
-
-func assignKeyPair(suite *group.Ciphersuite, privK, pubK []byte) (*KeyPair, error) {
-	kp := &KeyPair{}
-	err := kp.Deserialize(suite, privK, pubK)
-	if err != nil {
-		return nil, err
-	}
-
-	return kp, nil
+	return KeyPair{PublicKey, privateKey}
 }
 
 func suiteFromID(id SuiteID, context []byte) (*group.Ciphersuite, error) {
@@ -160,7 +145,7 @@ func NewServer(id SuiteID) (*Server, error) {
 
 // NewServerWithKeyPair creates a new instantiation of a Server. It can create
 // a server with existing keys or use pre-generated keys.
-func NewServerWithKeyPair(id SuiteID, privK, pubK []byte) (*Server, error) {
+func NewServerWithKeyPair(id SuiteID, kp KeyPair) (*Server, error) {
 	context := generateContext(id)
 
 	suite, err := suiteFromID(id, context)
@@ -168,15 +153,10 @@ func NewServerWithKeyPair(id SuiteID, privK, pubK []byte) (*Server, error) {
 		return nil, err
 	}
 
-	keyPair, err := assignKeyPair(suite, privK, pubK)
-	if err != nil {
-		return nil, err
-	}
-
 	return &Server{
 		suite:   suite,
 		context: context,
-		Kp:      keyPair}, nil
+		Kp:      kp}, nil
 }
 
 // Evaluate blindly signs a client token.
@@ -187,7 +167,7 @@ func (s *Server) Evaluate(b BlindToken) (*Evaluation, error) {
 		return nil, err
 	}
 
-	z := p.ScalarMult(s.Kp.PrivK)
+	z := p.ScalarMult(s.Kp.PrivateKey)
 	ser := z.Serialize()
 
 	return &Evaluation{ser}, nil
@@ -243,7 +223,7 @@ func (s *Server) FullEvaluate(in, info []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	t := p.ScalarMult(s.Kp.PrivK)
+	t := p.ScalarMult(s.Kp.PrivateKey)
 	iToken := t.Serialize()
 
 	h := finalizeHash(s.suite, in, iToken, info, s.context)
@@ -265,7 +245,7 @@ func (s *Server) VerifyFinalize(in, info, out []byte) bool {
 		return false
 	}
 
-	h := finalizeHash(s.suite, in, e.element, info, s.context)
+	h := finalizeHash(s.suite, in, e.Element, info, s.context)
 	return subtle.ConstantTimeCompare(h, out) == 1
 }
 
@@ -311,7 +291,7 @@ func (c *Client) Request(in []byte) (*ClientRequest, error) {
 // the output of the OPRF protocol.
 func (cr *ClientRequest) Finalize(e *Evaluation, info []byte) ([]byte, error) {
 	p := group.NewElement(cr.suite.Curve)
-	err := p.Deserialize(e.element)
+	err := p.Deserialize(e.Element)
 	if err != nil {
 		return nil, err
 	}

--- a/oprf/oprf_test.go
+++ b/oprf/oprf_test.go
@@ -12,6 +12,46 @@ import (
 	"github.com/cloudflare/circl/oprf/group"
 )
 
+func TestServerSerialization(t *testing.T) {
+	suite, err := suiteFromID(OPRFP256, []byte(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPair := GenerateKeyPair(suite)
+
+	server, err := NewServerWithKeyPair(OPRFP256, keyPair)
+	if err != nil {
+		t.Fatal("invalid setup of server: " + err.Error())
+	}
+
+	input := []byte("hello world")
+	info := []byte("info")
+	outputA, errA := server.FullEvaluate(input, info)
+	if errA != nil {
+		t.Fatal(errA)
+	}
+
+	encoded := keyPair.Serialize()
+	recoveredKeyPair := new(KeyPair)
+	err = recoveredKeyPair.Deserialize(suite, encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recoveredServer, err := NewServerWithKeyPair(OPRFP256, *recoveredKeyPair)
+	if err != nil {
+		t.Fatal("invalid setup of server: " + err.Error())
+	}
+
+	outputB, errB := recoveredServer.FullEvaluate(input, info)
+	if errB != nil {
+		t.Fatal(errB)
+	}
+	if !bytes.Equal(outputA, outputB) {
+		t.Fatal("failed to compute the same output after serializing and deserializing the key pair")
+	}
+}
+
 func TestServerSetUp(t *testing.T) {
 	srv, err := NewServer(OPRFP256)
 	if err != nil {
@@ -19,10 +59,6 @@ func TestServerSetUp(t *testing.T) {
 	}
 	if srv == nil {
 		t.Fatal("invalid setup of server: no server.")
-	}
-
-	if srv.Kp == nil {
-		t.Fatal("invalid setup of server: no keypair")
 	}
 }
 
@@ -153,9 +189,22 @@ func (s *Suite) fillVectors() [3]Vectors {
 	return v
 }
 
-func setUpParties(t *testing.T, name string) (*Server, *Client) {
+var suiteMaps = map[string]SuiteID{
+	"P256-SHA256-SSWU-RO": OPRFP256,
+	"P384-SHA512-SSWU-RO": OPRFP384,
+	"P521-SHA512-SSWU-RO": OPRFP521,
+}
+
+func setUpParties(t *testing.T, name string, privateKey []byte) (*Server, *Client) {
+	suite, err := suiteFromID(suiteMaps[name], []byte(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPair := new(KeyPair)
+	keyPair.Deserialize(suite, privateKey)
+
 	if name == "P256-SHA256-SSWU-RO" {
-		srv, err := NewServer(OPRFP256)
+		srv, err := NewServerWithKeyPair(OPRFP256, *keyPair)
 		if err != nil {
 			t.Fatal("invalid setup of server: " + err.Error())
 		}
@@ -170,7 +219,7 @@ func setUpParties(t *testing.T, name string) (*Server, *Client) {
 
 		return srv, client
 	} else if name == "P384-SHA512-SSWU-RO" {
-		srv, err := NewServer(OPRFP384)
+		srv, err := NewServerWithKeyPair(OPRFP384, *keyPair)
 		if err != nil {
 			t.Fatal("invalid setup of server: " + err.Error())
 		}
@@ -185,7 +234,7 @@ func setUpParties(t *testing.T, name string) (*Server, *Client) {
 
 		return srv, client
 	} else if name == "P521-SHA512-SSWU-RO" {
-		srv, err := NewServer(OPRFP521)
+		srv, err := NewServerWithKeyPair(OPRFP521, *keyPair)
 		if err != nil {
 			t.Fatal("invalid setup of server: " + err.Error())
 		}
@@ -220,7 +269,7 @@ func blindTest(c *group.Ciphersuite, ctx []byte, v Vector) *ClientRequest {
 
 func generateIssuedToken(c *Client, e *Evaluation, t *Token) IssuedToken {
 	p := group.NewElement(c.suite.Curve)
-	err := p.Deserialize(e.element)
+	err := p.Deserialize(e.Element)
 	if err != nil {
 		return nil
 	}
@@ -233,9 +282,11 @@ func generateIssuedToken(c *Client, e *Evaluation, t *Token) IssuedToken {
 }
 
 func (v *Vectors) run(t *testing.T) {
-	srv, client := setUpParties(t, v.SuiteName)
-	privKey, _ := hex.DecodeString(v.PrivK[2:])
-	srv.Kp.PrivK.Set(privKey)
+	privateKey, err := hex.DecodeString(v.PrivK[2:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, client := setUpParties(t, v.SuiteName, privateKey)
 
 	for _, j := range v.Vector {
 		cr := blindTest(client.suite, client.context, j)
@@ -251,8 +302,8 @@ func (v *Vectors) run(t *testing.T) {
 		}
 
 		testEval, _ := hex.DecodeString(j.Evaluation.Eval[2:])
-		if !bytes.Equal(testEval[:], eval.element[:]) {
-			test.ReportError(t, eval.element[:], testEval[:], "eval")
+		if !bytes.Equal(testEval[:], eval.Element[:]) {
+			test.ReportError(t, eval.Element[:], testEval[:], "eval")
 		}
 
 		info := []byte("test information")

--- a/oprf/oprf_test.go
+++ b/oprf/oprf_test.go
@@ -201,7 +201,10 @@ func setUpParties(t *testing.T, name string, privateKey []byte) (*Server, *Clien
 		t.Fatal(err)
 	}
 	keyPair := new(KeyPair)
-	keyPair.Deserialize(suite, privateKey)
+	err = keyPair.Deserialize(suite, privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if name == "P256-SHA256-SSWU-RO" {
 		srv, err := NewServerWithKeyPair(OPRFP256, *keyPair)


### PR DESCRIPTION
While trying to integrate this API with another library, I found some things that made it somewhat painful to use. I tried to clear those up here. I also added a test to exercise the `KeyPair` serialization logic.

cc @armfazh, @claucece 