### PR TITLE
Export GroupFromID to facilitate KeyPair serialization and deserialization

### DIFF
--- a/oprf/oprf.go
+++ b/oprf/oprf.go
@@ -130,7 +130,7 @@ func assignKeyPair(suite *group.Ciphersuite, privK, pubK []byte) (*KeyPair, erro
 	return kp, nil
 }
 
-func suiteFromID(id SuiteID, context []byte) (*group.Ciphersuite, error) {
+func GroupFromID(id SuiteID, context []byte) (*group.Ciphersuite, error) {
 	var err error
 	var suite *group.Ciphersuite
 
@@ -146,7 +146,7 @@ func suiteFromID(id SuiteID, context []byte) (*group.Ciphersuite, error) {
 func NewServer(id SuiteID) (*Server, error) {
 	context := generateContext(id)
 
-	suite, err := suiteFromID(id, context)
+	suite, err := GroupFromID(id, context)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func NewServer(id SuiteID) (*Server, error) {
 func NewServerWithKeyPair(id SuiteID, privK, pubK []byte) (*Server, error) {
 	context := generateContext(id)
 
-	suite, err := suiteFromID(id, context)
+	suite, err := GroupFromID(id, context)
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ func (s *Server) VerifyFinalize(in, info, out []byte) bool {
 func NewClient(id SuiteID) (*Client, error) {
 	context := generateContext(id)
 
-	suite, err := suiteFromID(id, context)
+	suite, err := GroupFromID(id, context)
 	if err != nil {
 		return nil, err
 	}

--- a/oprf/oprf_test.go
+++ b/oprf/oprf_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestServerSerialization(t *testing.T) {
-	suite, err := suiteFromID(OPRFP256, []byte(""))
+	suite, err := GroupFromID(OPRFP256, []byte(""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +196,7 @@ var suiteMaps = map[string]SuiteID{
 }
 
 func setUpParties(t *testing.T, name string, privateKey []byte) (*Server, *Client) {
-	suite, err := suiteFromID(suiteMaps[name], []byte(""))
+	suite, err := GroupFromID(suiteMaps[name], []byte(""))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This will make it much easier to serialize OPRF state by callers.