### PR TITLE
Use functions for exposing kem and signature schemes

### DIFF
--- a/kem/kem.go
+++ b/kem/kem.go
@@ -36,7 +36,7 @@ type Scheme interface {
 	// GenerateKey creates a new key pair.
 	GenerateKey() (PublicKey, PrivateKey, error)
 
-	// Encapsulate generates a shared key ss for the public key  and
+	// Encapsulate generates a shared key ss for the public key and
 	// encapsulates it into a ciphertext ct.
 	Encapsulate(pk PublicKey) (ct []byte, ss []byte, err error)
 
@@ -62,7 +62,7 @@ type Scheme interface {
 	// Size of packed public keys.
 	PublicKeySize() int
 
-	// Deterministicallly derives a keypair from a seed.  If you're unsure,
+	// Deterministicallly derives a keypair from a seed. If you're unsure,
 	// you're better off using GenerateKey().
 	//
 	// Panics if seed is not of length SeedSize().
@@ -73,7 +73,7 @@ type Scheme interface {
 
 	// EncapsulateDeterministically generates a shared key ss for the public
 	// key deterministically from the given seed and encapsulates it into
-	// a ciphertext ct.  If unsure, you're better off using Encapsulate().
+	// a ciphertext ct. If unsure, you're better off using Encapsulate().
 	EncapsulateDeterministically(pk PublicKey, seed []byte) (
 		ct, ss []byte, err error)
 

--- a/kem/kyber/kyber1024/kyber.go
+++ b/kem/kyber/kyber1024/kyber.go
@@ -263,7 +263,10 @@ func (pk *PublicKey) Unpack(buf []byte) {
 
 type scheme struct{}
 
-var Scheme kem.Scheme = &scheme{}
+var sch kem.Scheme = &scheme{}
+
+// Scheme returns a KEM interface.
+func Scheme() kem.Scheme { return sch }
 
 func (*scheme) Name() string               { return "Kyber1024" }
 func (*scheme) PublicKeySize() int         { return PublicKeySize }
@@ -273,8 +276,8 @@ func (*scheme) SharedKeySize() int         { return SharedKeySize }
 func (*scheme) CiphertextSize() int        { return CiphertextSize }
 func (*scheme) EncapsulationSeedSize() int { return EncapsulationSeedSize }
 
-func (sk *PrivateKey) Scheme() kem.Scheme { return Scheme }
-func (pk *PublicKey) Scheme() kem.Scheme  { return Scheme }
+func (sk *PrivateKey) Scheme() kem.Scheme { return sch }
+func (pk *PublicKey) Scheme() kem.Scheme  { return sch }
 
 func (sk *PrivateKey) MarshalBinary() ([]byte, error) {
 	var ret [PrivateKeySize]byte

--- a/kem/kyber/kyber512/kyber.go
+++ b/kem/kyber/kyber512/kyber.go
@@ -263,7 +263,10 @@ func (pk *PublicKey) Unpack(buf []byte) {
 
 type scheme struct{}
 
-var Scheme kem.Scheme = &scheme{}
+var sch kem.Scheme = &scheme{}
+
+// Scheme returns a KEM interface.
+func Scheme() kem.Scheme { return sch }
 
 func (*scheme) Name() string               { return "Kyber512" }
 func (*scheme) PublicKeySize() int         { return PublicKeySize }
@@ -273,8 +276,8 @@ func (*scheme) SharedKeySize() int         { return SharedKeySize }
 func (*scheme) CiphertextSize() int        { return CiphertextSize }
 func (*scheme) EncapsulationSeedSize() int { return EncapsulationSeedSize }
 
-func (sk *PrivateKey) Scheme() kem.Scheme { return Scheme }
-func (pk *PublicKey) Scheme() kem.Scheme  { return Scheme }
+func (sk *PrivateKey) Scheme() kem.Scheme { return sch }
+func (pk *PublicKey) Scheme() kem.Scheme  { return sch }
 
 func (sk *PrivateKey) MarshalBinary() ([]byte, error) {
 	var ret [PrivateKeySize]byte

--- a/kem/kyber/kyber768/kyber.go
+++ b/kem/kyber/kyber768/kyber.go
@@ -263,7 +263,10 @@ func (pk *PublicKey) Unpack(buf []byte) {
 
 type scheme struct{}
 
-var Scheme kem.Scheme = &scheme{}
+var sch kem.Scheme = &scheme{}
+
+// Scheme returns a KEM interface.
+func Scheme() kem.Scheme { return sch }
 
 func (*scheme) Name() string               { return "Kyber768" }
 func (*scheme) PublicKeySize() int         { return PublicKeySize }
@@ -273,8 +276,8 @@ func (*scheme) SharedKeySize() int         { return SharedKeySize }
 func (*scheme) CiphertextSize() int        { return CiphertextSize }
 func (*scheme) EncapsulationSeedSize() int { return EncapsulationSeedSize }
 
-func (sk *PrivateKey) Scheme() kem.Scheme { return Scheme }
-func (pk *PublicKey) Scheme() kem.Scheme  { return Scheme }
+func (sk *PrivateKey) Scheme() kem.Scheme { return sch }
+func (pk *PublicKey) Scheme() kem.Scheme  { return sch }
 
 func (sk *PrivateKey) MarshalBinary() ([]byte, error) {
 	var ret [PrivateKeySize]byte

--- a/kem/kyber/templates/pkg.templ.go
+++ b/kem/kyber/templates/pkg.templ.go
@@ -267,7 +267,10 @@ func (pk *PublicKey) Unpack(buf []byte) {
 
 type scheme struct{}
 
-var Scheme kem.Scheme = &scheme{}
+var sch kem.Scheme = &scheme{}
+
+// Scheme returns a KEM interface.
+func Scheme() kem.Scheme { return sch }
 
 func (*scheme) Name() string               { return "{{ .Name }}" }
 func (*scheme) PublicKeySize() int         { return PublicKeySize }
@@ -277,8 +280,8 @@ func (*scheme) SharedKeySize() int         { return SharedKeySize }
 func (*scheme) CiphertextSize() int        { return CiphertextSize }
 func (*scheme) EncapsulationSeedSize() int { return EncapsulationSeedSize }
 
-func (sk *PrivateKey) Scheme() kem.Scheme { return Scheme }
-func (pk *PublicKey) Scheme() kem.Scheme  { return Scheme }
+func (sk *PrivateKey) Scheme() kem.Scheme { return sch }
+func (pk *PublicKey) Scheme() kem.Scheme  { return sch }
 
 func (sk *PrivateKey) MarshalBinary() ([]byte, error) {
 	var ret [PrivateKeySize]byte

--- a/kem/schemes/schemes.go
+++ b/kem/schemes/schemes.go
@@ -14,12 +14,12 @@ import (
 )
 
 var allSchemes = [...]kem.Scheme{
-	kyber512.Scheme,
-	kyber768.Scheme,
-	kyber1024.Scheme,
-	sikep434.Scheme,
-	sikep503.Scheme,
-	sikep751.Scheme,
+	kyber512.Scheme(),
+	kyber768.Scheme(),
+	kyber1024.Scheme(),
+	sikep434.Scheme(),
+	sikep503.Scheme(),
+	sikep751.Scheme(),
 }
 
 var allSchemeNames map[string]kem.Scheme

--- a/kem/sike/sikep434/sike.go
+++ b/kem/sike/sikep434/sike.go
@@ -24,7 +24,10 @@ const (
 
 type scheme struct{}
 
-var Scheme kem.Scheme = &scheme{}
+var sch kem.Scheme = &scheme{}
+
+// Scheme returns a KEM interface.
+func Scheme() kem.Scheme { return sch }
 
 var params *sidh.KEM
 
@@ -36,8 +39,8 @@ func (*scheme) SharedKeySize() int         { return params.SharedSecretSize() }
 func (*scheme) CiphertextSize() int        { return params.CiphertextSize() }
 func (*scheme) EncapsulationSeedSize() int { return EncapsulationSeedSize }
 
-func (sk *PrivateKey) Scheme() kem.Scheme { return Scheme }
-func (pk *PublicKey) Scheme() kem.Scheme  { return Scheme }
+func (sk *PrivateKey) Scheme() kem.Scheme { return sch }
+func (pk *PublicKey) Scheme() kem.Scheme  { return sch }
 
 func (sk *PrivateKey) MarshalBinary() ([]byte, error) {
 	csk := (*sidh.PrivateKey)(sk)

--- a/kem/sike/sikep503/sike.go
+++ b/kem/sike/sikep503/sike.go
@@ -24,7 +24,10 @@ const (
 
 type scheme struct{}
 
-var Scheme kem.Scheme = &scheme{}
+var sch kem.Scheme = &scheme{}
+
+// Scheme returns a KEM interface.
+func Scheme() kem.Scheme { return sch }
 
 var params *sidh.KEM
 
@@ -36,8 +39,8 @@ func (*scheme) SharedKeySize() int         { return params.SharedSecretSize() }
 func (*scheme) CiphertextSize() int        { return params.CiphertextSize() }
 func (*scheme) EncapsulationSeedSize() int { return EncapsulationSeedSize }
 
-func (sk *PrivateKey) Scheme() kem.Scheme { return Scheme }
-func (pk *PublicKey) Scheme() kem.Scheme  { return Scheme }
+func (sk *PrivateKey) Scheme() kem.Scheme { return sch }
+func (pk *PublicKey) Scheme() kem.Scheme  { return sch }
 
 func (sk *PrivateKey) MarshalBinary() ([]byte, error) {
 	csk := (*sidh.PrivateKey)(sk)

--- a/kem/sike/sikep751/sike.go
+++ b/kem/sike/sikep751/sike.go
@@ -24,7 +24,10 @@ const (
 
 type scheme struct{}
 
-var Scheme kem.Scheme = &scheme{}
+var sch kem.Scheme = &scheme{}
+
+// Scheme returns a KEM interface.
+func Scheme() kem.Scheme { return sch }
 
 var params *sidh.KEM
 
@@ -36,8 +39,8 @@ func (*scheme) SharedKeySize() int         { return params.SharedSecretSize() }
 func (*scheme) CiphertextSize() int        { return params.CiphertextSize() }
 func (*scheme) EncapsulationSeedSize() int { return EncapsulationSeedSize }
 
-func (sk *PrivateKey) Scheme() kem.Scheme { return Scheme }
-func (pk *PublicKey) Scheme() kem.Scheme  { return Scheme }
+func (sk *PrivateKey) Scheme() kem.Scheme { return sch }
+func (pk *PublicKey) Scheme() kem.Scheme  { return sch }
 
 func (sk *PrivateKey) MarshalBinary() ([]byte, error) {
 	csk := (*sidh.PrivateKey)(sk)

--- a/kem/sike/templates/pkg.templ.go
+++ b/kem/sike/templates/pkg.templ.go
@@ -28,7 +28,10 @@ const (
 
 type scheme struct{}
 
-var Scheme kem.Scheme = &scheme{}
+var sch kem.Scheme = &scheme{}
+
+// Scheme returns a KEM interface.
+func Scheme() kem.Scheme { return sch }
 
 var params *sidh.KEM
 
@@ -40,8 +43,8 @@ func (*scheme) SharedKeySize() int         { return params.SharedSecretSize() }
 func (*scheme) CiphertextSize() int        { return params.CiphertextSize() }
 func (*scheme) EncapsulationSeedSize() int { return EncapsulationSeedSize }
 
-func (sk *PrivateKey) Scheme() kem.Scheme { return Scheme }
-func (pk *PublicKey) Scheme() kem.Scheme  { return Scheme }
+func (sk *PrivateKey) Scheme() kem.Scheme { return sch }
+func (pk *PublicKey) Scheme() kem.Scheme  { return sch }
 
 func (sk *PrivateKey) MarshalBinary() ([]byte, error) {
 	csk := (*sidh.PrivateKey)(sk)

--- a/sign/ed25519/ed25519.go
+++ b/sign/ed25519/ed25519.go
@@ -116,9 +116,9 @@ func (priv PrivateKey) Seed() []byte {
 	return seed
 }
 
-func (priv PrivateKey) Scheme() sign.Scheme { return Scheme }
+func (priv PrivateKey) Scheme() sign.Scheme { return sch }
 
-func (pub PublicKey) Scheme() sign.Scheme { return Scheme }
+func (pub PublicKey) Scheme() sign.Scheme { return sch }
 
 func (priv PrivateKey) MarshalBinary() (data []byte, err error) {
 	privateKey := make(PrivateKey, PrivateKeySize)

--- a/sign/ed25519/signapi.go
+++ b/sign/ed25519/signapi.go
@@ -7,7 +7,10 @@ import (
 	"github.com/cloudflare/circl/sign"
 )
 
-var Scheme sign.Scheme = &scheme{}
+var sch sign.Scheme = &scheme{}
+
+// Scheme returns a signature interface.
+func Scheme() sign.Scheme { return sch }
 
 type scheme struct{}
 

--- a/sign/ed448/ed448.go
+++ b/sign/ed448/ed448.go
@@ -112,9 +112,9 @@ func (priv PrivateKey) Seed() []byte {
 	return seed
 }
 
-func (priv PrivateKey) Scheme() sign.Scheme { return Scheme }
+func (priv PrivateKey) Scheme() sign.Scheme { return sch }
 
-func (pub PublicKey) Scheme() sign.Scheme { return Scheme }
+func (pub PublicKey) Scheme() sign.Scheme { return sch }
 
 func (priv PrivateKey) MarshalBinary() (data []byte, err error) {
 	privateKey := make(PrivateKey, PrivateKeySize)

--- a/sign/ed448/signapi.go
+++ b/sign/ed448/signapi.go
@@ -7,7 +7,10 @@ import (
 	"github.com/cloudflare/circl/sign"
 )
 
-var Scheme sign.Scheme = &scheme{}
+var sch sign.Scheme = &scheme{}
+
+// Scheme returns a signature interface.
+func Scheme() sign.Scheme { return sch }
 
 type scheme struct{}
 

--- a/sign/eddilithium3/eddilithium.go
+++ b/sign/eddilithium3/eddilithium.go
@@ -186,8 +186,8 @@ func (sk *PrivateKey) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
-func (sk *PrivateKey) Scheme() sign.Scheme { return Scheme }
-func (pk *PublicKey) Scheme() sign.Scheme  { return Scheme }
+func (sk *PrivateKey) Scheme() sign.Scheme { return sch }
+func (pk *PublicKey) Scheme() sign.Scheme  { return sch }
 
 func (sk *PrivateKey) Equal(other crypto.PrivateKey) bool {
 	castOther, ok := other.(*PrivateKey)

--- a/sign/eddilithium3/signapi.go
+++ b/sign/eddilithium3/signapi.go
@@ -7,7 +7,10 @@ import (
 	"github.com/cloudflare/circl/sign"
 )
 
-var Scheme sign.Scheme = &scheme{}
+var sch sign.Scheme = &scheme{}
+
+// Scheme returns a signature interface.
+func Scheme() sign.Scheme { return sch }
 
 type scheme struct{}
 

--- a/sign/eddilithium4/eddilithium.go
+++ b/sign/eddilithium4/eddilithium.go
@@ -181,8 +181,8 @@ func (sk *PrivateKey) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
-func (sk *PrivateKey) Scheme() sign.Scheme { return Scheme }
-func (pk *PublicKey) Scheme() sign.Scheme  { return Scheme }
+func (sk *PrivateKey) Scheme() sign.Scheme { return sch }
+func (pk *PublicKey) Scheme() sign.Scheme  { return sch }
 
 func (sk *PrivateKey) Equal(other crypto.PrivateKey) bool {
 	castOther, ok := other.(*PrivateKey)

--- a/sign/eddilithium4/signapi.go
+++ b/sign/eddilithium4/signapi.go
@@ -7,7 +7,10 @@ import (
 	"github.com/cloudflare/circl/sign"
 )
 
-var Scheme sign.Scheme = &scheme{}
+var sch sign.Scheme = &scheme{}
+
+// Scheme returns a signature interface.
+func Scheme() sign.Scheme { return sch }
 
 type scheme struct{}
 

--- a/sign/schemes/schemes.go
+++ b/sign/schemes/schemes.go
@@ -12,10 +12,10 @@ import (
 )
 
 var allSchemes = [...]sign.Scheme{
-	ed25519.Scheme,
-	ed448.Scheme,
-	eddilithium3.Scheme,
-	eddilithium4.Scheme,
+	ed25519.Scheme(),
+	ed448.Scheme(),
+	eddilithium3.Scheme(),
+	eddilithium4.Scheme(),
 }
 
 var allSchemeNames map[string]sign.Scheme

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -41,7 +41,7 @@ type PrivateKey interface {
 
 // A Scheme represents a specific instance of a signature scheme.
 type Scheme interface {
-	// Name of the scheme
+	// Name of the scheme.
 	Name() string
 
 	// GenerateKey creates a new key-pair.
@@ -56,7 +56,7 @@ type Scheme interface {
 	// given message. opts are additional options which can be nil.
 	Verify(pk PublicKey, message []byte, signature []byte, opts *SignatureOpts) bool
 
-	// Deterministically derives a keypair from a seed.  If you're unsure,
+	// Deterministically derives a keypair from a seed. If you're unsure,
 	// you're better off using GenerateKey().
 	//
 	// Panics if seed is not of length SeedSize().
@@ -68,25 +68,25 @@ type Scheme interface {
 	// Unmarshals a PublicKey from the provided buffer.
 	UnmarshalBinaryPrivateKey([]byte) (PrivateKey, error)
 
-	// Size of binary marshalled public keys
+	// Size of binary marshalled public keys.
 	PublicKeySize() int
 
-	// Size of binary marshalled public keys
+	// Size of binary marshalled public keys.
 	PrivateKeySize() int
 
-	// Size of signatures
+	// Size of signatures.
 	SignatureSize() int
 
-	// Size of seeds
+	// Size of seeds.
 	SeedSize() int
 
-	// Returns whether contexts are supported
+	// Returns whether contexts are supported.
 	SupportsContext() bool
 }
 
 var (
 	// ErrTypeMismatch is the error used if types of, for instance, private
-	// and public keys don't match
+	// and public keys don't match.
 	ErrTypeMismatch = errors.New("types mismatch")
 
 	// ErrSeedSize is the error used if the provided seed is of the wrong
@@ -102,6 +102,6 @@ var (
 	ErrPrivKeySize = errors.New("wrong size for private key")
 
 	// ErrContextNotSupported is the error used if a context is not
-	// supported
+	// supported.
 	ErrContextNotSupported = errors.New("context not supported")
 )


### PR DESCRIPTION
The registry of algorithms must be read-only, otherwise: 
```go
package main
import (
	"fmt"
	"github.com/cloudflare/circl/kem/kyber/kyber1024"
	"github.com/cloudflare/circl/kem/kyber/kyber512"
)
func main() {
	fmt.Println(kyber1024.Scheme.Name())
	kyber1024.Scheme = kyber512.Scheme
	fmt.Println(kyber1024.Scheme.Name())
}
```
Outputs 
```sh
Kyber1024
Kyber512
```

cc: @bwesterb 