### PR TITLE
hpke: Add context serialization

### DIFF
--- a/hpke/aead_test.go
+++ b/hpke/aead_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAeadExporter(t *testing.T) {
 	suite := Suite{KdfID: HkdfSha256, AeadID: AeadAes128Gcm}
-	exporter := &encdecContext{Suite: suite}
+	exporter := &encdecContext{suite: suite}
 	maxLength := uint(255 * suite.KdfID.Hash().Size())
 
 	err := test.CheckPanic(func() {
@@ -29,8 +29,8 @@ func TestAeadSeqOverflow(t *testing.T) {
 	Nn := aead.NonceSize()
 	nonce := make([]byte, Nn)
 	_, _ = rand.Read(nonce)
-	sealer := &sealContext{&encdecContext{suite, aead, nonce, make([]byte, Nn), nil}}
-	opener := &openContext{&encdecContext{suite, aead, nonce, make([]byte, Nn), nil}}
+	sealer := &sealContext{&encdecContext{aead, suite, nil, nil, nonce, make([]byte, Nn)}}
+	opener := &openContext{&encdecContext{aead, suite, nil, nil, nonce, make([]byte, Nn)}}
 
 	pt := []byte("plaintext")
 	aad := []byte("aad")

--- a/hpke/algs.go
+++ b/hpke/algs.go
@@ -33,6 +33,19 @@ const (
 	DHKemX448HkdfSha512 KemID = 0x21
 )
 
+func (k KemID) IsValid() bool {
+	switch k {
+	case DHKemP256HkdfSha256,
+		DHKemP384HkdfSha384,
+		DHKemP521HkdfSha512,
+		DHKemX25519HkdfSha256,
+		DHKemX448HkdfSha512:
+		return true
+	default:
+		return false
+	}
+}
+
 func (k KemID) Scheme() kem.AuthScheme {
 	switch k {
 	case DHKemP256HkdfSha256:
@@ -87,6 +100,17 @@ const (
 	HkdfSha512 KdfID = 0x03
 )
 
+func (k KdfID) IsValid() bool {
+	switch k {
+	case HkdfSha256,
+		HkdfSha384,
+		HkdfSha512:
+		return true
+	default:
+		return false
+	}
+}
+
 func (k KdfID) Hash() crypto.Hash {
 	switch k {
 	case HkdfSha256:
@@ -121,6 +145,17 @@ func (a AeadID) New(key []byte) (cipher.AEAD, error) {
 		return chacha20poly1305.New(key)
 	default:
 		panic("invalid AeadID")
+	}
+}
+
+func (a AeadID) IsValid() bool {
+	switch a {
+	case AeadAes128Gcm,
+		AeadAes256Gcm,
+		AeadChaCha20Poly1305:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/hpke/marshal.go
+++ b/hpke/marshal.go
@@ -1,0 +1,150 @@
+package hpke
+
+import (
+	"errors"
+
+	"golang.org/x/crypto/cryptobyte"
+)
+
+// marshal serializes an HPKE context.
+func (c *encdecContext) marshal() ([]byte, error) {
+	var b cryptobyte.Builder
+	b.AddUint16(uint16(c.suite.KemID))
+	b.AddUint16(uint16(c.suite.KdfID))
+	b.AddUint16(uint16(c.suite.AeadID))
+	b.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
+		b.AddBytes(c.exporterSecret)
+	})
+	b.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
+		b.AddBytes(c.key)
+	})
+	b.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
+		b.AddBytes(c.baseNonce)
+	})
+	b.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
+		b.AddBytes(c.sequenceNumber)
+	})
+	return b.Bytes()
+}
+
+// unmarshalContext parses an HPKE context.
+func unmarshalContext(raw []byte) (*encdecContext, error) {
+	var (
+		err error
+		t   cryptobyte.String
+	)
+
+	c := new(encdecContext)
+	s := cryptobyte.String(raw)
+	if !s.ReadUint16((*uint16)(&c.suite.KemID)) ||
+		!s.ReadUint16((*uint16)(&c.suite.KdfID)) ||
+		!s.ReadUint16((*uint16)(&c.suite.AeadID)) ||
+		!s.ReadUint8LengthPrefixed(&t) ||
+		!t.ReadBytes(&c.exporterSecret, len(t)) ||
+		!s.ReadUint8LengthPrefixed(&t) ||
+		!t.ReadBytes(&c.key, len(t)) ||
+		!s.ReadUint8LengthPrefixed(&t) ||
+		!t.ReadBytes(&c.baseNonce, len(t)) ||
+		!s.ReadUint8LengthPrefixed(&t) ||
+		!t.ReadBytes(&c.sequenceNumber, len(t)) {
+		return nil, errors.New("failed to parse context")
+	}
+
+	if !c.suite.isValid() {
+		return nil, errHpkeInvalidSuite
+	}
+
+	Nh := c.suite.KdfID.Hash().Size()
+	if len(c.exporterSecret) != Nh {
+		return nil, errors.New("invalid exporter secret length")
+	}
+
+	Nk := int(c.suite.AeadID.KeySize())
+	if len(c.key) != Nk {
+		return nil, errors.New("invalid key length")
+	}
+
+	c.AEAD, err = c.suite.AeadID.New(c.key)
+	if err != nil {
+		return nil, err
+	}
+
+	Nn := c.AEAD.NonceSize()
+	if len(c.baseNonce) != Nn {
+		return nil, errors.New("invalid base nonce length")
+	}
+	if len(c.sequenceNumber) != Nn {
+		return nil, errors.New("invalid sequence number length")
+	}
+
+	return c, nil
+}
+
+// MarshalBinary serializes an HPKE sealer according to the format specified
+// below. (Expressed in TLS syntax.) Note that this format is not defined by
+// the HPKE standard.
+//
+// enum { sealer(0), opener(1) } HpkeRole;
+//
+// struct {
+//     HpkeKemId kem_id;   // draft-irtf-cfrg-hpke-06
+//     HpkeKdfId kdf_id;   // draft-irtf-cfrg-hpke-06
+//     HpkeAeadId aead_id; // draft-irtf-cfrg-hpke-06
+//     opaque exporter_secret<0..255>;
+//     opaque key<0..255>;
+//     opaque base_nonce<0..255>;
+//     opaque seq<0..255>;
+// } HpkeContext;
+//
+// struct {
+//   HpkeRole role = 0; // sealer
+//   HpkeContext context;
+// } HpkeSealer;
+func (c *sealContext) MarshalBinary() ([]byte, error) {
+	rawContext, err := c.encdecContext.marshal()
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte{0}, rawContext...), nil
+}
+
+// UnmarshalSealer parses an HPKE sealer.
+func UnmarshalSealer(raw []byte) (Sealer, error) {
+	if raw[0] != 0 {
+		return nil, errors.New("incorrect role")
+	}
+	context, err := unmarshalContext(raw[1:])
+	if err != nil {
+		return nil, err
+	}
+	return &sealContext{context}, nil
+}
+
+// MarshalBinary serializes an HPKE opener according to the format specified
+// below. (Expressed in TLS syntax.) Note that this format is not defined by the
+// HPKE standard.
+//
+// struct {
+//   HpkeRole role = 1; // opener
+//   HpkeContext context;
+// } HpkeOpener;
+func (c *openContext) MarshalBinary() ([]byte, error) {
+	rawContext, err := c.encdecContext.marshal()
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte{1}, rawContext...), nil
+}
+
+// UnmarshalOpener parses a serialized HPKE opener and returns the corresponding
+// Opener.
+func UnmarshalOpener(raw []byte) (Opener, error) {
+	if raw[0] != 1 {
+		return nil, errors.New("incorrect role")
+	}
+	context, err := unmarshalContext(raw[1:])
+	if err != nil {
+		return nil, err
+	}
+	return &openContext{context}, nil
+}

--- a/hpke/marshal_test.go
+++ b/hpke/marshal_test.go
@@ -1,0 +1,82 @@
+package hpke
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+)
+
+func contextEqual(a, b *encdecContext) bool {
+	an := make([]byte, a.NonceSize())
+	bn := make([]byte, b.NonceSize())
+	ac := a.AEAD.Seal(nil, an, nil, nil)
+	bc := b.AEAD.Seal(nil, bn, nil, nil)
+	return a.suite == b.suite &&
+		bytes.Equal(a.exporterSecret, b.exporterSecret) &&
+		bytes.Equal(a.key, b.key) &&
+		bytes.Equal(a.baseNonce, b.baseNonce) &&
+		bytes.Equal(a.sequenceNumber, b.sequenceNumber) &&
+		bytes.Equal(ac, bc)
+}
+
+func TestContextSerialization(t *testing.T) {
+	s := NewSuite(DHKemP384HkdfSha384, HkdfSha384, AeadAes256Gcm)
+	info := []byte("some info string")
+
+	pk, sk, err := s.KemID.Scheme().GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiver, err := s.NewReceiver(sk, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sender, err := s.NewSender(pk, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc, sealer, err := sender.Setup(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opener, err := receiver.Setup(enc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rawSealer, err := sealer.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsedSealer, err := UnmarshalSealer(rawSealer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contextEqual(
+		sealer.(*sealContext).encdecContext,
+		parsedSealer.(*sealContext).encdecContext) {
+		t.Error("parsed sealer does not match original")
+	}
+	_, err = UnmarshalOpener(rawSealer)
+	if err == nil {
+		t.Error("parsing a sealer as an opener succeeded; want failure")
+	}
+
+	rawOpener, err := opener.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsedOpener, err := UnmarshalOpener(rawOpener)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contextEqual(
+		opener.(*openContext).encdecContext,
+		parsedOpener.(*openContext).encdecContext) {
+		t.Error("parsed opener does not match original")
+	}
+	_, err = UnmarshalSealer(rawOpener)
+	if err == nil {
+		t.Error("parsing an opener as a sealer succeeded; want failure")
+	}
+}

--- a/hpke/util.go
+++ b/hpke/util.go
@@ -1,7 +1,6 @@
 package hpke
 
 import (
-	"crypto"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -42,11 +41,12 @@ func (st state) keySchedule(ss, info, psk, pskID []byte) (*encdecContext, error)
 	)
 
 	return &encdecContext{
-		st.Suite,
 		aead,
+		st.Suite,
+		exporterSecret,
+		key,
 		baseNonce,
 		make([]byte, Nn),
-		exporterSecret,
 	}, nil
 }
 
@@ -85,9 +85,9 @@ func (suite Suite) getSuiteID() (id [10]byte) {
 }
 
 func (suite Suite) isValid() bool {
-	return suite.KemID.Scheme() != nil &&
-		suite.KdfID.Hash() != crypto.Hash(0) &&
-		suite.AeadID.KeySize() != 0
+	return suite.KemID.IsValid() &&
+		suite.KdfID.IsValid() &&
+		suite.AeadID.IsValid()
 }
 
 func (suite Suite) labeledExtract(salt, label, ikm []byte) []byte {

--- a/hpke/vectors_test.go
+++ b/hpke/vectors_test.go
@@ -156,12 +156,12 @@ func (v *vector) checkEncryptions(
 	}
 }
 
-func (v *vector) checkExports(t *testing.T, exp Exporter, m modeID, s Suite) {
+func (v *vector) checkExports(t *testing.T, context Context, m modeID, s Suite) {
 	for j, expv := range v.Exports {
 		ctx := hexB(expv.ExportContext)
 		want := hexB(expv.ExportValue)
 
-		got := exp.Export(ctx, uint(expv.ExportLength))
+		got := context.Export(ctx, uint(expv.ExportLength))
 		if !bytes.Equal(got, want) {
 			test.ReportError(t, got, want, m, s, j)
 		}


### PR DESCRIPTION
Adds support for HPKE context serialization as required by https://github.com/cloudflare/go/pull/38. The changes are summarized as follows:
- Renames Exporter to Context.
- Adds Suite() and Marshal() to Context interface.
- Adds unmarshalers for the Sealer and Opener implementations.
- Adds validators for cipher suite codepoints.
