### PR TITLE
hpke: rename algorithm identifiers

### DIFF
--- a/hpke/aead.go
+++ b/hpke/aead.go
@@ -56,7 +56,7 @@ func (c *encdecContext) increment() error {
 		allOnes &= c.sequenceNumber[i]
 	}
 	if allOnes == byte(0xFF) {
-		return errAeadSeqOverflows
+		return errAEADSeqOverflows
 	}
 
 	// performs an increment by 1 and verifies whether the sequence overflows.
@@ -67,7 +67,7 @@ func (c *encdecContext) increment() error {
 		c.sequenceNumber[i] = byte(sum & 0xFF)
 	}
 	if carry != 0 {
-		return errAeadSeqOverflows
+		return errAEADSeqOverflows
 	}
 	return nil
 }

--- a/hpke/aead_test.go
+++ b/hpke/aead_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAeadExporter(t *testing.T) {
-	suite := Suite{KdfID: HkdfSha256, AeadID: AeadAes128Gcm}
+	suite := Suite{KdfID: KDF.HKDF.SHA256, AeadID: AEAD.AES128GCM}
 	exporter := &encdecContext{suite: suite}
 	maxLength := uint(255 * suite.KdfID.Hash().Size())
 
@@ -19,7 +19,7 @@ func TestAeadExporter(t *testing.T) {
 }
 
 func TestAeadSeqOverflow(t *testing.T) {
-	suite := Suite{AeadID: AeadAes128Gcm}
+	suite := Suite{AeadID: AEAD.AES128GCM}
 
 	key := make([]byte, suite.AeadID.KeySize())
 	_, _ = rand.Read(key)

--- a/hpke/algs.go
+++ b/hpke/algs.go
@@ -5,6 +5,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/elliptic"
+	"math"
 
 	"github.com/cloudflare/circl/dh/x25519"
 	"github.com/cloudflare/circl/dh/x448"
@@ -13,205 +14,262 @@ import (
 	"golang.org/x/crypto/chacha20poly1305"
 )
 
-type KemID uint16
+// AEAD Documentation.
+//
+// AEAD.Parse
+//
+// Use function AEAD.Parse(v int) (*aeadID,error)
+//
+//  id, err := hpke.AEAD.Parse(1)
+//  fmt.Print(*id == hpke.AEAD.AES128GCM)
+//  // Outputs: true
+//
+// AEAD
+//
+// AEAD enables access to the key derivation functions supported.
+var AEAD supportedAEAD /*
+Use one of the following constants:
+ AEAD.AES128GCM        = 0x1 // AES-128 block cipher in Galois Counter Mode (GCM).
+ AEAD.AES256GCM        = 0x2 // AES-256 block cipher in Galois Counter Mode (GCM).
+ AEAD.ChaCha20Poly1305 = 0x3 // ChaCha20 stream cipher and Poly1305 MAC.
+*/
 
-const (
-	// DHKemP256HkdfSha256 is a KEM using the P256 curve with HKDF based on
-	// SHA-256.
-	DHKemP256HkdfSha256 KemID = 0x10
-	// DHKemP384HkdfSha384 is a KEM using the P384 curve with HKDF based on
-	// SHA-384.
-	DHKemP384HkdfSha384 KemID = 0x11
-	// DHKemP521HkdfSha512 is a KEM using the P521 curve with HKDF based on
-	// SHA-512.
-	DHKemP521HkdfSha512 KemID = 0x12
-	// DHKemX25519HkdfSha256 is a KEM using the X25519 Diffie-Hellman function
-	// with HKDF based on SHA-256.
-	DHKemX25519HkdfSha256 KemID = 0x20
-	// DHKemX448HkdfSha512 is a KEM using the X448 Diffie-Hellman function with
-	// HKDF based on SHA-512.
-	DHKemX448HkdfSha512 KemID = 0x21
-)
+type supportedAEAD struct {
+	AES128GCM        aeadID
+	AES256GCM        aeadID
+	ChaCha20Poly1305 aeadID
+}
 
-func (k KemID) IsValid() bool {
-	switch k {
-	case DHKemP256HkdfSha256,
-		DHKemP384HkdfSha384,
-		DHKemP521HkdfSha512,
-		DHKemX25519HkdfSha256,
-		DHKemX448HkdfSha512:
-		return true
+func (supportedAEAD) Parse(v int) (*aeadID, error) {
+	if 0 < v && v < math.MaxUint16 {
+		switch v16 := uint16(v); v16 {
+		case AEAD.AES128GCM.uint16,
+			AEAD.AES256GCM.uint16,
+			AEAD.ChaCha20Poly1305.uint16:
+			return &aeadID{v16}, nil
+		}
+	}
+	return nil, errInvalidAEAD
+}
+
+type aeadID struct{ uint16 }
+
+// New instantiates an AEAD cipher from the identifier, returns an error if the
+// identifier is not known.
+func (a aeadID) New(key []byte) (cipher.AEAD, error) {
+	switch a {
+	case AEAD.AES128GCM, AEAD.AES256GCM:
+		block, err := aes.NewCipher(key)
+		if err != nil {
+			return nil, err
+		}
+		return cipher.NewGCM(block)
+	case AEAD.ChaCha20Poly1305:
+		return chacha20poly1305.New(key)
 	default:
-		return false
+		panic(errInvalidAEAD)
 	}
 }
 
-func (k KemID) Scheme() kem.AuthScheme {
+// KeySize returns the size in bytes of the keys used by AEAD cipher.
+func (a aeadID) KeySize() uint {
+	switch a {
+	case AEAD.AES128GCM:
+		return 16
+	case AEAD.AES256GCM:
+		return 32
+	case AEAD.ChaCha20Poly1305:
+		return chacha20poly1305.KeySize
+	default:
+		panic(errInvalidAEAD)
+	}
+}
+
+// KDF Documentation.
+//
+// KDF.Parse
+//
+// Use function KDF.Parse(v int) (*kdfID, error)
+//
+//  id, err := hpke.KDF.Parse(1)
+//  fmt.Print(*id == hpke.KDF.HKDF.SHA256)
+//  // Outputs: true
+//
+// KDF
+//
+// KDF enables access to the key derivation functions supported.
+var KDF supportedKDF /*
+Use one of the following constants:
+ KDF.HKDF.SHA384 = 0x2 // Key derivation using HKDF with SHA-384.
+ KDF.HKDF.SHA256 = 0x1 // Key derivation using HKDF with SHA-256.
+ KDF.HKDF.SHA512 = 0x3 // Key derivation using HKDF with SHA-512.
+*/
+
+type supportedKDF struct {
+	HKDF struct{ SHA256, SHA384, SHA512 kdfID }
+}
+
+func (supportedKDF) Parse(v int) (*kdfID, error) {
+	if 0 < v && v < math.MaxUint16 {
+		switch v16 := uint16(v); v16 {
+		case KDF.HKDF.SHA256.uint16,
+			KDF.HKDF.SHA384.uint16,
+			KDF.HKDF.SHA512.uint16:
+			return &kdfID{v16}, nil
+		}
+	}
+	return nil, errInvalidKDF
+}
+
+type kdfID struct{ uint16 }
+
+func (k kdfID) Hash() crypto.Hash {
 	switch k {
-	case DHKemP256HkdfSha256:
-		return dhkemP256HkdfSha256
-	case DHKemP384HkdfSha384:
-		return dhkemP384HkdfSha384
-	case DHKemP521HkdfSha512:
-		return dhkemP521HkdfSha512
-	case DHKemX25519HkdfSha256:
-		return dhkemX25519HkdfSha256
-	case DHKemX448HkdfSha512:
-		return dhkemX448HkdfSha512
+	case KDF.HKDF.SHA256:
+		return crypto.SHA256
+	case KDF.HKDF.SHA384:
+		return crypto.SHA384
+	case KDF.HKDF.SHA512:
+		return crypto.SHA512
+	default:
+		panic(errInvalidKDF)
+	}
+}
+
+// KEM Documentation
+//
+// KEM.Parse
+//
+// Use function KEM.Parse(v int) (*kemID, error)
+//
+//  id, err := hpke.KEM.Parse(0x10)
+//  fmt.Print(*id == hpke.KEM.P256.HKDF.SHA256)
+//  // Outputs: true
+//
+// KEM
+//
+// KEM enables access to the key encapsulation methods supported.
+var KEM supportedKEM /*
+Use one of the following constants:
+ KEM.P256.HKDF.SHA256   = 0x10 // KEM using the P256 curve and HKDF with SHA-256.
+ KEM.P384.HKDF.SHA384   = 0x11 // KEM using the P384 curve and HKDF with SHA-384.
+ KEM.P521.HKDF.SHA512   = 0x12 // KEM using the P521 curve and HKDF with SHA-512.
+ KEM.X25519.HKDF.SHA256 = 0x20 // KEM using the X25519 Diffie-Hellman function and HKDF with SHA-256.
+ KEM.X448.HKDF.SHA512   = 0x21 // KEM using the X448 Diffie-Hellman function and HKDF with SHA-512.
+*/
+
+type supportedKEM struct {
+	P256   struct{ HKDF struct{ SHA256 kemID } }
+	P384   struct{ HKDF struct{ SHA384 kemID } }
+	P521   struct{ HKDF struct{ SHA512 kemID } }
+	X25519 struct{ HKDF struct{ SHA256 kemID } }
+	X448   struct{ HKDF struct{ SHA512 kemID } }
+}
+
+func (supportedKEM) Parse(v int) (*kemID, error) {
+	if 0 < v && v < math.MaxUint16 {
+		switch v16 := uint16(v); v16 {
+		case KEM.P256.HKDF.SHA256.uint16,
+			KEM.P384.HKDF.SHA384.uint16,
+			KEM.P521.HKDF.SHA512.uint16,
+			KEM.X25519.HKDF.SHA256.uint16,
+			KEM.X448.HKDF.SHA512.uint16:
+			return &kemID{v16}, nil
+		}
+	}
+	return nil, errInvalidKEM
+}
+
+type kemID struct{ uint16 }
+
+func (k kemID) Scheme() kem.AuthScheme {
+	switch k {
+	case KEM.P256.HKDF.SHA256:
+		return dhkemp256hkdfsha256
+	case KEM.P384.HKDF.SHA384:
+		return dhkemp384hkdfsha384
+	case KEM.P521.HKDF.SHA512:
+		return dhkemp521hkdfsha512
+	case KEM.X25519.HKDF.SHA256:
+		return dhkemx25519hkdfsha256
+	case KEM.X448.HKDF.SHA512:
+		return dhkemx448hkdfsha512
 	default:
 		return nil
 	}
 }
 
-func (k KemID) validatePublicKey(pk kem.PublicKey) bool {
+func (k kemID) validatePublicKey(pk kem.PublicKey) bool {
 	switch k {
-	case DHKemP256HkdfSha256, DHKemP384HkdfSha384, DHKemP521HkdfSha512:
+	case KEM.P256.HKDF.SHA256, KEM.P384.HKDF.SHA384, KEM.P521.HKDF.SHA512:
 		pub, ok := pk.(*shortPubKey)
 		return ok && k == pub.scheme.id && pub.Validate()
-	case DHKemX25519HkdfSha256, DHKemX448HkdfSha512:
+	case KEM.X25519.HKDF.SHA256, KEM.X448.HKDF.SHA512:
 		pub, ok := pk.(*xkemPubKey)
-		return ok && k == pub.scheme.id && pub.Validate()
+		return ok && k == pub.kemID && pub.Validate()
 	default:
-		panic("invalid KemID")
+		panic(errInvalidKEM)
 	}
 }
 
-func (k KemID) validatePrivateKey(sk kem.PrivateKey) bool {
+func (k kemID) validatePrivateKey(sk kem.PrivateKey) bool {
 	switch k {
-	case DHKemP256HkdfSha256, DHKemP384HkdfSha384, DHKemP521HkdfSha512:
+	case KEM.P256.HKDF.SHA256, KEM.P384.HKDF.SHA384, KEM.P521.HKDF.SHA512:
 		priv, ok := sk.(*shortPrivKey)
 		return ok && k == priv.scheme.id && priv.Validate()
-	case DHKemX25519HkdfSha256, DHKemX448HkdfSha512:
+	case KEM.X25519.HKDF.SHA256, KEM.X448.HKDF.SHA512:
 		priv, ok := sk.(*xkemPrivKey)
-		return ok && k == priv.scheme.id && priv.Validate()
+		return ok && k == priv.kemID && priv.Validate()
 	default:
-		panic("invalid KemID")
+		panic(errInvalidKEM)
 	}
 }
 
-type KdfID uint16
-
-const (
-	// HKDF using SHA-256 hash function.
-	HkdfSha256 KdfID = 0x01
-	// HKDF using SHA-384 hash function.
-	HkdfSha384 KdfID = 0x02
-	// HKDF using SHA-512 hash function.
-	HkdfSha512 KdfID = 0x03
-)
-
-func (k KdfID) IsValid() bool {
-	switch k {
-	case HkdfSha256,
-		HkdfSha384,
-		HkdfSha512:
-		return true
-	default:
-		return false
-	}
-}
-
-func (k KdfID) Hash() crypto.Hash {
-	switch k {
-	case HkdfSha256:
-		return crypto.SHA256
-	case HkdfSha384:
-		return crypto.SHA384
-	case HkdfSha512:
-		return crypto.SHA512
-	default:
-		panic("invalid KdfID")
-	}
-}
-
-type AeadID uint16
-
-const (
-	// AES-128 block cipher in Galois Counter Mode (GCM).
-	AeadAes128Gcm AeadID = 0x01
-	// AES-256 block cipher in Galois Counter Mode (GCM).
-	AeadAes256Gcm AeadID = 0x02
-	// ChaCha20 stream cipher and Poly1305 MAC.
-	AeadChaCha20Poly1305 AeadID = 0x03
-)
-
-// New instantiates an AEAD cipher from the identifier, returns an error if the
-// identifier is not known.
-func (a AeadID) New(key []byte) (cipher.AEAD, error) {
-	switch a {
-	case AeadAes128Gcm, AeadAes256Gcm:
-		return aesGCM(key)
-	case AeadChaCha20Poly1305:
-		return chacha20poly1305.New(key)
-	default:
-		panic("invalid AeadID")
-	}
-}
-
-func (a AeadID) IsValid() bool {
-	switch a {
-	case AeadAes128Gcm,
-		AeadAes256Gcm,
-		AeadChaCha20Poly1305:
-		return true
-	default:
-		return false
-	}
-}
-
-// KeySize returns the size in bytes of the keys used by AEAD cipher.
-func (a AeadID) KeySize() uint {
-	switch a {
-	case AeadAes128Gcm:
-		return 16
-	case AeadAes256Gcm:
-		return 32
-	case AeadChaCha20Poly1305:
-		return chacha20poly1305.KeySize
-	default:
-		panic("invalid AeadID")
-	}
-}
-
-func aesGCM(key []byte) (cipher.AEAD, error) {
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-	return cipher.NewGCM(block)
-}
-
-var dhkemP256HkdfSha256, dhkemP384HkdfSha384, dhkemP521HkdfSha512 shortKem
-var dhkemX25519HkdfSha256, dhkemX448HkdfSha512 xkem
+var dhkemp256hkdfsha256, dhkemp384hkdfsha384, dhkemp521hkdfsha512 shortKem
+var dhkemx25519hkdfsha256, dhkemx448hkdfsha512 xkem
 
 func init() {
-	dhkemP256HkdfSha256.Curve = elliptic.P256()
-	dhkemP256HkdfSha256.kemBase.id = DHKemP256HkdfSha256
-	dhkemP256HkdfSha256.kemBase.name = "HpkeDHKemP256HkdfSha256"
-	dhkemP256HkdfSha256.kemBase.Hash = crypto.SHA256
-	dhkemP256HkdfSha256.kemBase.dh = dhkemP256HkdfSha256
+	AEAD.AES128GCM.uint16 = 0x01
+	AEAD.AES256GCM.uint16 = 0x02
+	AEAD.ChaCha20Poly1305.uint16 = 0x03
 
-	dhkemP384HkdfSha384.Curve = p384.P384()
-	dhkemP384HkdfSha384.kemBase.id = DHKemP384HkdfSha384
-	dhkemP384HkdfSha384.kemBase.name = "HpkeDHKemP384HkdfSha384"
-	dhkemP384HkdfSha384.kemBase.Hash = crypto.SHA384
-	dhkemP384HkdfSha384.kemBase.dh = dhkemP384HkdfSha384
+	KDF.HKDF.SHA256.uint16 = 0x01
+	KDF.HKDF.SHA384.uint16 = 0x02
+	KDF.HKDF.SHA512.uint16 = 0x03
 
-	dhkemP521HkdfSha512.Curve = elliptic.P521()
-	dhkemP521HkdfSha512.kemBase.id = DHKemP521HkdfSha512
-	dhkemP521HkdfSha512.kemBase.name = "HpkeDHKemP521HkdfSha512"
-	dhkemP521HkdfSha512.kemBase.Hash = crypto.SHA512
-	dhkemP521HkdfSha512.kemBase.dh = dhkemP521HkdfSha512
+	KEM.P256.HKDF.SHA256.uint16 = 0x10
+	KEM.P384.HKDF.SHA384.uint16 = 0x11
+	KEM.P521.HKDF.SHA512.uint16 = 0x12
+	KEM.X25519.HKDF.SHA256.uint16 = 0x20
+	KEM.X448.HKDF.SHA512.uint16 = 0x21
 
-	dhkemX25519HkdfSha256.size = x25519.Size
-	dhkemX25519HkdfSha256.kemBase.id = DHKemX25519HkdfSha256
-	dhkemX25519HkdfSha256.kemBase.name = "HpkeDHKemX25519HkdfSha256"
-	dhkemX25519HkdfSha256.kemBase.Hash = crypto.SHA256
-	dhkemX25519HkdfSha256.kemBase.dh = dhkemX25519HkdfSha256
+	dhkemp256hkdfsha256.Curve = elliptic.P256()
+	dhkemp256hkdfsha256.kemBase.id = KEM.P256.HKDF.SHA256
+	dhkemp256hkdfsha256.kemBase.name = "HPKE_DHKEM_P256_HKDF_SHA256"
+	dhkemp256hkdfsha256.kemBase.Hash = crypto.SHA256
+	dhkemp256hkdfsha256.kemBase.dh = dhkemp256hkdfsha256
 
-	dhkemX448HkdfSha512.size = x448.Size
-	dhkemX448HkdfSha512.kemBase.id = DHKemX448HkdfSha512
-	dhkemX448HkdfSha512.kemBase.name = "HpkeDHKemX448HkdfSha512"
-	dhkemX448HkdfSha512.kemBase.Hash = crypto.SHA512
-	dhkemX448HkdfSha512.kemBase.dh = dhkemX448HkdfSha512
+	dhkemp384hkdfsha384.Curve = p384.P384()
+	dhkemp384hkdfsha384.kemBase.id = KEM.P384.HKDF.SHA384
+	dhkemp384hkdfsha384.kemBase.name = "HPKE_DHKEM_P384_HKDF_SHA384"
+	dhkemp384hkdfsha384.kemBase.Hash = crypto.SHA384
+	dhkemp384hkdfsha384.kemBase.dh = dhkemp384hkdfsha384
+
+	dhkemp521hkdfsha512.Curve = elliptic.P521()
+	dhkemp521hkdfsha512.kemBase.id = KEM.P521.HKDF.SHA512
+	dhkemp521hkdfsha512.kemBase.name = "HPKE_DHKEM_P521_HKDF_SHA512"
+	dhkemp521hkdfsha512.kemBase.Hash = crypto.SHA512
+	dhkemp521hkdfsha512.kemBase.dh = dhkemp521hkdfsha512
+
+	dhkemx25519hkdfsha256.size = x25519.Size
+	dhkemx25519hkdfsha256.kemBase.id = KEM.X25519.HKDF.SHA256
+	dhkemx25519hkdfsha256.kemBase.name = "HPKE_DHKEM_X25519_HKDF_SHA256"
+	dhkemx25519hkdfsha256.kemBase.Hash = crypto.SHA256
+	dhkemx25519hkdfsha256.kemBase.dh = dhkemx25519hkdfsha256
+
+	dhkemx448hkdfsha512.size = x448.Size
+	dhkemx448hkdfsha512.kemBase.id = KEM.X448.HKDF.SHA512
+	dhkemx448hkdfsha512.kemBase.name = "HPKE_DHKEM_X448_HKDF_SHA512"
+	dhkemx448hkdfsha512.kemBase.Hash = crypto.SHA512
+	dhkemx448hkdfsha512.kemBase.dh = dhkemx448hkdfsha512
 }

--- a/hpke/hpke_test.go
+++ b/hpke/hpke_test.go
@@ -13,11 +13,11 @@ func Example() {
 	// import "crypto/rand"
 
 	// HPKE suite is a domain parameter.
-	s := hpke.NewSuite(
-		hpke.DHKemP384HkdfSha384,
-		hpke.HkdfSha384,
-		hpke.AeadAes256Gcm,
-	)
+	s := hpke.Suite{
+		hpke.KEM.P384.HKDF.SHA384,
+		hpke.KDF.HKDF.SHA384,
+		hpke.AEAD.AES256GCM,
+	}
 	info := []byte("public info string, known to both Alice and Bob")
 
 	// Bob prepares to receive messages and announces his public key.
@@ -62,4 +62,31 @@ func Example() {
 	// Plaintext was sent successfully.
 	fmt.Println(bytes.Equal(ptAlice, ptBob))
 	// Output: true
+}
+
+func Example_kEMID() {
+	id, err := hpke.KEM.Parse(0x10)
+	if err != nil {
+		fmt.Print(err)
+	}
+	fmt.Print(*id == hpke.KEM.P256.HKDF.SHA256)
+	// Outputs: true
+}
+
+func Example_kDFID() {
+	id, err := hpke.KDF.Parse(0x1)
+	if err != nil {
+		fmt.Print(err)
+	}
+	fmt.Print(*id == hpke.KDF.HKDF.SHA256)
+	// Outputs: true
+}
+
+func Example_aEADID() {
+	id, err := hpke.AEAD.Parse(1)
+	if err != nil {
+		fmt.Print(err)
+	}
+	fmt.Print(*id == hpke.AEAD.AES128GCM)
+	// Outputs: true
 }

--- a/hpke/kembase.go
+++ b/hpke/kembase.go
@@ -22,7 +22,7 @@ type dhKem interface {
 }
 
 type kemBase struct {
-	id   KemID
+	id   kemID
 	name string
 	crypto.Hash
 	dh dhKem
@@ -33,7 +33,7 @@ func (k kemBase) SharedKeySize() int { return k.Hash.Size() }
 
 func (k kemBase) getSuiteID() (sid [5]byte) {
 	sid[0], sid[1], sid[2] = 'K', 'E', 'M'
-	binary.BigEndian.PutUint16(sid[3:5], uint16(k.id))
+	binary.BigEndian.PutUint16(sid[3:5], k.id.uint16)
 	return
 }
 

--- a/hpke/marshal_test.go
+++ b/hpke/marshal_test.go
@@ -20,7 +20,7 @@ func contextEqual(a, b *encdecContext) bool {
 }
 
 func TestContextSerialization(t *testing.T) {
-	s := NewSuite(DHKemP384HkdfSha384, HkdfSha384, AeadAes256Gcm)
+	s := Suite{KEM.P384.HKDF.SHA384, KDF.HKDF.SHA384, AEAD.AES256GCM}
 	info := []byte("some info string")
 
 	pk, sk, err := s.KemID.Scheme().GenerateKeyPair()

--- a/hpke/shortkem.go
+++ b/hpke/shortkem.go
@@ -32,7 +32,7 @@ func (s shortKem) calcDH(dh []byte, sk kem.PrivateKey, pk kem.PublicKey) error {
 	l := len(dh)
 	x, _ := s.ScalarMult(PK.x, PK.y, SK.priv) // only x-coordinate is used.
 	if x.Sign() == 0 {
-		return errKemInvalidSharedSecret
+		return errInvalidKEMSharedSecret
 	}
 	b := x.Bytes()
 	copy(dh[l-len(b):l], b)
@@ -86,7 +86,7 @@ func (s shortKem) UnmarshalBinaryPrivateKey(data []byte) (
 	kem.PrivateKey, error) {
 	l := s.PrivateKeySize()
 	if len(data) < l {
-		return nil, errKemInvalidPrivateKey
+		return nil, errInvalidKEMPrivateKey
 	}
 	sk := &shortPrivKey{s, make([]byte, l), nil}
 	copy(sk.priv[l-len(data):l], data[:l])
@@ -95,7 +95,7 @@ func (s shortKem) UnmarshalBinaryPrivateKey(data []byte) (
 func (s shortKem) UnmarshalBinaryPublicKey(data []byte) (kem.PublicKey, error) {
 	x, y := elliptic.Unmarshal(s, data)
 	if x == nil {
-		return nil, errKemInvalidPublicKey
+		return nil, errInvalidKEMPublicKey
 	}
 	return &shortPubKey{s, x, y}, nil
 }

--- a/hpke/util.go
+++ b/hpke/util.go
@@ -71,23 +71,17 @@ func (st state) verifyPSKInputs(psk, pskID []byte) error {
 
 func (suite Suite) String() string {
 	return fmt.Sprintf(
-		"kem_id: %v kdf_id: %v aead_id: %v",
+		"kem: %v kdf: %v aead: %v",
 		suite.KemID, suite.KdfID, suite.AeadID,
 	)
 }
 
 func (suite Suite) getSuiteID() (id [10]byte) {
 	id[0], id[1], id[2], id[3] = 'H', 'P', 'K', 'E'
-	binary.BigEndian.PutUint16(id[4:6], uint16(suite.KemID))
-	binary.BigEndian.PutUint16(id[6:8], uint16(suite.KdfID))
-	binary.BigEndian.PutUint16(id[8:10], uint16(suite.AeadID))
+	binary.BigEndian.PutUint16(id[4:6], suite.KemID.uint16)
+	binary.BigEndian.PutUint16(id[6:8], suite.KdfID.uint16)
+	binary.BigEndian.PutUint16(id[8:10], suite.AeadID.uint16)
 	return
-}
-
-func (suite Suite) isValid() bool {
-	return suite.KemID.IsValid() &&
-		suite.KdfID.IsValid() &&
-		suite.AeadID.IsValid()
 }
 
 func (suite Suite) labeledExtract(salt, label, ikm []byte) []byte {

--- a/hpke/xkem.go
+++ b/hpke/xkem.go
@@ -35,7 +35,7 @@ func (x xkem) calcDH(dh []byte, sk kem.PrivateKey, pk kem.PublicKey) error {
 		copy(sKey[:], SK.priv)
 		copy(pKey[:], PK.pub)
 		if !x25519.Shared(&ss, &sKey, &pKey) {
-			return errKemInvalidSharedSecret
+			return errInvalidKEMSharedSecret
 		}
 		copy(dh, ss[:])
 	case x448.Size:
@@ -43,7 +43,7 @@ func (x xkem) calcDH(dh []byte, sk kem.PrivateKey, pk kem.PublicKey) error {
 		copy(sKey[:], SK.priv)
 		copy(pKey[:], PK.pub)
 		if !x448.Shared(&ss, &sKey, &pKey) {
-			return errKemInvalidSharedSecret
+			return errInvalidKEMSharedSecret
 		}
 		copy(dh, ss[:])
 	}
@@ -60,7 +60,7 @@ func (x xkem) DeriveKeyPair(seed []byte) (kem.PublicKey, kem.PrivateKey) {
 	if len(seed) != x.SeedSize() {
 		panic(kem.ErrSeedSize)
 	}
-	sk := &xkemPrivKey{scheme: x, priv: make([]byte, x.size)}
+	sk := &xkemPrivKey{kemID: x.id, priv: make([]byte, x.PrivateKeySize())}
 	dkpPrk := x.labeledExtract(nil, []byte("dkp_prk"), seed)
 	bytes := x.labeledExpand(
 		dkpPrk,
@@ -72,7 +72,7 @@ func (x xkem) DeriveKeyPair(seed []byte) (kem.PublicKey, kem.PrivateKey) {
 	return sk.Public(), sk
 }
 func (x xkem) GenerateKeyPair() (kem.PublicKey, kem.PrivateKey, error) {
-	sk := &xkemPrivKey{scheme: x, priv: make([]byte, x.PrivateKeySize())}
+	sk := &xkemPrivKey{kemID: x.id, priv: make([]byte, x.PrivateKeySize())}
 	_, err := io.ReadFull(rand.Reader, sk.priv)
 	if err != nil {
 		return nil, nil, err
@@ -82,67 +82,67 @@ func (x xkem) GenerateKeyPair() (kem.PublicKey, kem.PrivateKey, error) {
 func (x xkem) UnmarshalBinaryPrivateKey(data []byte) (kem.PrivateKey, error) {
 	l := x.PrivateKeySize()
 	if len(data) < l {
-		return nil, errKemInvalidPrivateKey
+		return nil, errInvalidKEMPrivateKey
 	}
-	sk := &xkemPrivKey{x, make([]byte, l), nil}
+	sk := &xkemPrivKey{kemID: x.id, priv: make([]byte, l)}
 	copy(sk.priv, data[:l])
 	return sk, nil
 }
 func (x xkem) UnmarshalBinaryPublicKey(data []byte) (kem.PublicKey, error) {
 	l := x.PublicKeySize()
 	if len(data) < l {
-		return nil, errKemInvalidPublicKey
+		return nil, errInvalidKEMPublicKey
 	}
-	pk := &xkemPubKey{x, make([]byte, l)}
+	pk := &xkemPubKey{x.id, make([]byte, l)}
 	copy(pk.pub, data[:l])
 	return pk, nil
 }
 
 type xkemPubKey struct {
-	scheme xkem
-	pub    []byte
+	kemID
+	pub []byte
 }
 
 func (k *xkemPubKey) String() string     { return fmt.Sprintf("%x", k.pub) }
-func (k *xkemPubKey) Scheme() kem.Scheme { return k.scheme }
+func (k *xkemPubKey) Scheme() kem.Scheme { return k.kemID.Scheme() }
 func (k *xkemPubKey) MarshalBinary() ([]byte, error) {
-	return append(make([]byte, 0, k.scheme.PublicKeySize()), k.pub...), nil
+	return append(make([]byte, 0, k.Scheme().PublicKeySize()), k.pub...), nil
 }
 func (k *xkemPubKey) Equal(pk kem.PublicKey) bool {
 	k1, ok := pk.(*xkemPubKey)
 	return ok &&
-		k.scheme.id == k1.scheme.id &&
+		k.kemID == k1.kemID &&
 		bytes.Equal(k.pub, k1.pub)
 }
-func (k *xkemPubKey) Validate() bool { return len(k.pub) == k.scheme.PublicKeySize() }
+func (k *xkemPubKey) Validate() bool { return len(k.pub) == k.Scheme().PublicKeySize() }
 
 type xkemPrivKey struct {
-	scheme xkem
-	priv   []byte
-	pub    *xkemPubKey
+	kemID
+	priv []byte
+	pub  *xkemPubKey
 }
 
 func (k *xkemPrivKey) String() string     { return fmt.Sprintf("%x", k.priv) }
-func (k *xkemPrivKey) Scheme() kem.Scheme { return k.scheme }
+func (k *xkemPrivKey) Scheme() kem.Scheme { return k.kemID.Scheme() }
 func (k *xkemPrivKey) MarshalBinary() ([]byte, error) {
-	return append(make([]byte, 0, k.scheme.PrivateKeySize()), k.priv...), nil
+	return append(make([]byte, 0, k.Scheme().PrivateKeySize()), k.priv...), nil
 }
 func (k *xkemPrivKey) Equal(pk kem.PrivateKey) bool {
 	k1, ok := pk.(*xkemPrivKey)
 	return ok &&
-		k.scheme.id == k1.scheme.id &&
+		k.kemID == k1.kemID &&
 		subtle.ConstantTimeCompare(k.priv, k1.priv) == 1
 }
 func (k *xkemPrivKey) Public() kem.PublicKey {
 	if k.pub == nil {
-		k.pub = &xkemPubKey{scheme: k.scheme, pub: make([]byte, k.scheme.size)}
-		switch k.scheme.size {
-		case x25519.Size:
+		k.pub = &xkemPubKey{kemID: k.kemID, pub: make([]byte, k.Scheme().PublicKeySize())}
+		switch k.kemID {
+		case KEM.X25519.HKDF.SHA256:
 			var sk, pk x25519.Key
 			copy(sk[:], k.priv)
 			x25519.KeyGen(&pk, &sk)
 			copy(k.pub.pub, pk[:])
-		case x448.Size:
+		case KEM.X448.HKDF.SHA512:
 			var sk, pk x448.Key
 			copy(sk[:], k.priv)
 			x448.KeyGen(&pk, &sk)
@@ -151,4 +151,4 @@ func (k *xkemPrivKey) Public() kem.PublicKey {
 	}
 	return k.pub
 }
-func (k *xkemPrivKey) Validate() bool { return len(k.priv) == k.scheme.PrivateKeySize() }
+func (k *xkemPrivKey) Validate() bool { return len(k.priv) == k.Scheme().PrivateKeySize() }

--- a/kem/schemes/schemes.go
+++ b/kem/schemes/schemes.go
@@ -3,9 +3,9 @@
 // Schemes Implemented
 //
 // Based on standard elliptic curves:
-//  HpkeDHKemP256HkdfSha256, HpkeDHKemP384HkdfSha384, HpkeDHKemP521HkdfSha512
+//  HPKE_DHKEM_P256_HKDF_SHA256, HPKE_DHKEM_P384_HKDF_SHA384, HPKE_DHKEM_P521_HKDF_SHA512
 // Based on standard Diffie-Hellman functions:
-//  HpkeDHKemX25519HkdfSha256, HpkeDHKemX448HkdfSha512
+//  HPKE_DHKEM_X25519_HKDF_SHA256, HPKE_DHKEM_X448_HKDF_SHA512
 // Post-quantum kems:
 //  Kyber512, Kyber768, Kyber1024
 //  SIKEp434, SIKEp503, SIKEp751
@@ -25,11 +25,11 @@ import (
 )
 
 var allSchemes = [...]kem.Scheme{
-	hpke.DHKemP256HkdfSha256.Scheme(),
-	hpke.DHKemP384HkdfSha384.Scheme(),
-	hpke.DHKemP521HkdfSha512.Scheme(),
-	hpke.DHKemX25519HkdfSha256.Scheme(),
-	hpke.DHKemX448HkdfSha512.Scheme(),
+	hpke.KEM.P256.HKDF.SHA256.Scheme(),
+	hpke.KEM.P384.HKDF.SHA384.Scheme(),
+	hpke.KEM.P521.HKDF.SHA512.Scheme(),
+	hpke.KEM.X25519.HKDF.SHA256.Scheme(),
+	hpke.KEM.X448.HKDF.SHA512.Scheme(),
 	kyber512.Scheme(),
 	kyber768.Scheme(),
 	kyber1024.Scheme(),

--- a/kem/schemes/schemes_test.go
+++ b/kem/schemes/schemes_test.go
@@ -132,11 +132,11 @@ func Example_schemes() {
 		fmt.Println(sch.Name())
 	}
 	// Output:
-	// HpkeDHKemP256HkdfSha256
-	// HpkeDHKemP384HkdfSha384
-	// HpkeDHKemP521HkdfSha512
-	// HpkeDHKemX25519HkdfSha256
-	// HpkeDHKemX448HkdfSha512
+	// HPKE_DHKEM_P256_HKDF_SHA256
+	// HPKE_DHKEM_P384_HKDF_SHA384
+	// HPKE_DHKEM_P521_HKDF_SHA512
+	// HPKE_DHKEM_X25519_HKDF_SHA256
+	// HPKE_DHKEM_X448_HKDF_SHA512
 	// Kyber512
 	// Kyber768
 	// Kyber1024


### PR DESCRIPTION
Now, one can name algorithms as `KEM.P256.HKDF.SHA256`.

changes:
- identifiers using structures.
- include Parsing functions for get algorithm identifiers.
- rename errors.