### PR TITLE
[WIP] hpke: Add "Export-Only" mode

### DIFF
--- a/hpke/aead.go
+++ b/hpke/aead.go
@@ -2,13 +2,11 @@ package hpke
 
 import (
 	"crypto/cipher"
-	"fmt"
 )
 
 type encdecContext struct {
 	// Serialized parameters
-	suite          Suite
-	exporterSecret []byte
+	expContext
 	key            []byte
 	baseNonce      []byte
 	sequenceNumber []byte
@@ -20,24 +18,6 @@ type encdecContext struct {
 
 type sealContext struct{ *encdecContext }
 type openContext struct{ *encdecContext }
-
-// Export takes a context string exporterContext and a desired length (in
-// bytes), and produces a secret derived from the internal exporter secret
-// using the corresponding KDF Expand function. It panics if length is
-// greater than 255*N bytes, where N is the size (in bytes) of the KDF's
-// output.
-func (c *encdecContext) Export(exporterContext []byte, length uint) []byte {
-	maxLength := uint(255 * c.suite.kdfID.ExtractSize())
-	if length > maxLength {
-		panic(fmt.Errorf("output length must be lesser than %v bytes", maxLength))
-	}
-	return c.suite.labeledExpand(c.exporterSecret, []byte("sec"),
-		exporterContext, uint16(length))
-}
-
-func (c *encdecContext) Suite() Suite {
-	return c.suite
-}
 
 func (c *encdecContext) calcNonce() []byte {
 	for i := range c.baseNonce {

--- a/hpke/aead_test.go
+++ b/hpke/aead_test.go
@@ -9,17 +9,6 @@ import (
 	"github.com/cloudflare/circl/internal/test"
 )
 
-func TestAeadExporter(t *testing.T) {
-	suite := Suite{kdfID: KDF_HKDF_SHA256, aeadID: AEAD_AES128GCM}
-	exporter := &encdecContext{suite: suite}
-	maxLength := uint(255 * suite.kdfID.ExtractSize())
-
-	err := test.CheckPanic(func() {
-		exporter.Export([]byte("exporter"), maxLength+1)
-	})
-	test.CheckNoErr(t, err, "exporter max size")
-}
-
 func setupAeadTest() (*sealContext, *openContext, error) {
 	suite := Suite{aeadID: AEAD_AES128GCM}
 	key := make([]byte, suite.aeadID.KeySize())
@@ -42,11 +31,25 @@ func setupAeadTest() (*sealContext, *openContext, error) {
 		return nil, nil, fmt.Errorf("unexpected base nonce size: got %d; want %d", n, len(baseNonce))
 	}
 
-	sealer := &sealContext{&encdecContext{
-		suite, nil, nil, baseNonce, make([]byte, Nn), aead, make([]byte, Nn)},
+	sealer := &sealContext{
+		&encdecContext{
+			expContext{suite, nil},
+			nil,
+			baseNonce,
+			make([]byte, Nn),
+			aead,
+			make([]byte, Nn),
+		},
 	}
-	opener := &openContext{&encdecContext{
-		suite, nil, nil, baseNonce, make([]byte, Nn), aead, make([]byte, Nn)},
+	opener := &openContext{
+		&encdecContext{
+			expContext{suite, nil},
+			nil,
+			baseNonce,
+			make([]byte, Nn),
+			aead,
+			make([]byte, Nn),
+		},
 	}
 	return sealer, opener, nil
 }

--- a/hpke/algs.go
+++ b/hpke/algs.go
@@ -183,6 +183,8 @@ const (
 	AEAD_AES256GCM AEAD = 0x02
 	// AEAD_ChaCha20Poly1305 is ChaCha20 stream cipher and Poly1305 MAC.
 	AEAD_ChaCha20Poly1305 AEAD = 0x03
+	// AEAD_ExportOnly signifies that the HPKE context not used for encryption.
+	AEAD_ExportOnly = 0xffff
 )
 
 // New instantiates an AEAD cipher from the identifier, returns an error if the
@@ -206,7 +208,8 @@ func (a AEAD) IsValid() bool {
 	switch a {
 	case AEAD_AES128GCM,
 		AEAD_AES256GCM,
-		AEAD_ChaCha20Poly1305:
+		AEAD_ChaCha20Poly1305,
+		AEAD_ExportOnly:
 		return true
 	default:
 		return false
@@ -222,6 +225,8 @@ func (a AEAD) KeySize() uint {
 		return 32
 	case AEAD_ChaCha20Poly1305:
 		return chacha20poly1305.KeySize
+	case AEAD_ExportOnly:
+		panic("AEAD key size undefined")
 	default:
 		panic(errInvalidAEAD)
 	}

--- a/hpke/export.go
+++ b/hpke/export.go
@@ -1,0 +1,27 @@
+package hpke
+
+import (
+	"fmt"
+)
+
+type expContext struct {
+	suite          Suite
+	exporterSecret []byte
+}
+
+// Export takes a context string exporterContext and a desired length (in
+// bytes), and produces a secret derived from the internal exporter secret
+// using the corresponding KDF Expand function. It panics if length is greater
+// than 255*N bytes, where N is the size (in bytes) of the KDF's output.
+func (c *expContext) Export(exporterContext []byte, length uint) []byte {
+	maxLength := uint(255 * c.suite.kdfID.ExtractSize())
+	if length > maxLength {
+		panic(fmt.Errorf("size greater than %v", maxLength))
+	}
+	return c.suite.labeledExpand(c.exporterSecret, []byte("sec"),
+		exporterContext, uint16(length))
+}
+
+func (c *expContext) Suite() Suite {
+	return c.suite
+}

--- a/hpke/export_test.go
+++ b/hpke/export_test.go
@@ -1,0 +1,18 @@
+package hpke
+
+import (
+	"testing"
+
+	"github.com/cloudflare/circl/internal/test"
+)
+
+func TestExport(t *testing.T) {
+	suite := Suite{kdfID: KDF_HKDF_SHA256, aeadID: AEAD_AES128GCM}
+	exporter := &expContext{suite: suite}
+	maxLength := uint(255 * suite.kdfID.ExtractSize())
+
+	err := test.CheckPanic(func() {
+		exporter.Export([]byte("exporter"), maxLength+1)
+	})
+	test.CheckNoErr(t, err, "exporter max size")
+}

--- a/hpke/hpke.go
+++ b/hpke/hpke.go
@@ -7,10 +7,6 @@
 //
 // Specification in
 // https://datatracker.ietf.org/doc/draft-irtf-cfrg-hpke
-//
-// BUG(cjpatton): This package does not implement the "Export-Only" mode of the
-// HPKE context. In particular, it does not recognize the AEAD codepoint
-// reserved for this purpose (0xFFFF).
 package hpke
 
 import (
@@ -26,7 +22,6 @@ const versionLabel = "HPKE-07"
 
 // Context defines the capabilities of an HPKE context.
 type Context interface {
-	encoding.BinaryMarshaler
 	// Export takes a context string exporterContext and a desired length (in
 	// bytes), and produces a secret derived from the internal exporter secret
 	// using the corresponding KDF Expand function. It panics if length is
@@ -39,6 +34,7 @@ type Context interface {
 
 // Sealer encrypts a plaintext using an AEAD encryption.
 type Sealer interface {
+	encoding.BinaryMarshaler
 	Context
 	// Seal takes a plaintext and associated data to produce a ciphertext.
 	// The nonce is handled by the Sealer and incremented after each call.
@@ -47,6 +43,7 @@ type Sealer interface {
 
 // Opener decrypts a ciphertext using an AEAD encryption.
 type Opener interface {
+	encoding.BinaryMarshaler
 	Context
 	// Open takes a ciphertext and associated data to recover, if successful,
 	// the plaintext. The nonce is handled by the Opener and incremented after


### PR DESCRIPTION
Based on #204.

Adds support for the new 0xFFFF codepoint for AEAD. This signifies that the context isn't used for `Seal()` or `Open()`, but for `Export()` only.