### PR TITLE
Refactor and generalize the internal proof interfaces.

### DIFF
--- a/oprf/client.go
+++ b/oprf/client.go
@@ -91,10 +91,14 @@ func (c *Client) Finalize(r *ClientRequest, e *Evaluation) ([][]byte, error) {
 		return nil, errors.New("mismatch number of elements")
 	}
 
+	var err error
 	evals := make([]group.Element, len(e.Elements))
 	for i := range e.Elements {
 		evals[i] = c.suite.Group.NewElement()
-		evals[i].UnmarshalBinary(e.Elements[i])
+		err = evals[i].UnmarshalBinary(e.Elements[i])
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if c.Mode == VerifiableMode {

--- a/oprf/oprf_test.go
+++ b/oprf/oprf_test.go
@@ -93,7 +93,7 @@ func testAPI(t *testing.T, suite oprf.SuiteID, mode oprf.Mode) {
 		t.Fatal("invalid blinding of client: " + err.Error())
 	}
 
-	eval, err := server.Evaluate(cr.BlindedElements)
+	eval, err := server.Evaluate(cr.BlindedElements())
 	if err != nil {
 		t.Fatal("invalid evaluation of server: " + err.Error())
 	}

--- a/oprf/vectors_test.go
+++ b/oprf/vectors_test.go
@@ -149,13 +149,13 @@ func (v *vector) test(t *testing.T) {
 		clientReq, err := client.blind(inputs, blinds)
 		test.CheckNoErr(t, err, "invalid client request")
 		v.compareLists(t,
-			clientReq.BlindedElements,
+			clientReq.BlindedElements(),
 			toListBytes(t, vi.BlindedElement, "blindedElement"),
 		)
 
 		rr := toScalar(t, client.suite.Group, vi.EvaluationProof.R, "invalid proof random scalar")
 
-		eval, err := server.evaluateWithProofScalar(clientReq.BlindedElements, rr)
+		eval, err := server.evaluateWithProofScalar(clientReq.BlindedElements(), rr)
 		test.CheckNoErr(t, err, "invalid evaluation")
 		v.compareLists(t,
 			eval.Elements,


### PR DESCRIPTION
This implements the [corresponding change](https://github.com/cfrg/draft-irtf-cfrg-voprf/commit/d88e53c61ce7be263fb5e7f9f6beae6ffaac0e6f) in the draft, in preparation for an implementation of public attribute-based VOPRFs.