### PR TITLE
kyber: sorting input parameters of EncryptTo function.

### DIFF
--- a/kem/kyber/kyber1024/kyber.go
+++ b/kem/kyber/kyber1024/kyber.go
@@ -135,7 +135,7 @@ func (pk *PublicKey) EncapsulateTo(ct, ss []byte, seed []byte) {
 	g.Sum(kr[:0])
 
 	// c = Kyber.CPAPKE.Enc(pk, m, r)
-	pk.pk.EncryptTo(ct, kr[32:], m[:])
+	pk.pk.EncryptTo(ct, m[:], kr[32:])
 
 	// Compute H(c) and put in second slot of kr, which will be (K', H(c)).
 	h.Reset()
@@ -175,7 +175,7 @@ func (sk *PrivateKey) DecapsulateTo(ss, ct []byte) {
 
 	// c' = Kyber.CPAPKE.Enc(pk, m', r')
 	var ct2 [CiphertextSize]byte
-	sk.pk.EncryptTo(ct2[:], kr2[32:], m2[:])
+	sk.pk.EncryptTo(ct2[:], m2[:], kr2[32:])
 
 	// Compute H(c) and put in second slot of kr2, which will be (K'', H(c)).
 	h := sha3.New256()

--- a/kem/kyber/kyber512/kyber.go
+++ b/kem/kyber/kyber512/kyber.go
@@ -135,7 +135,7 @@ func (pk *PublicKey) EncapsulateTo(ct, ss []byte, seed []byte) {
 	g.Sum(kr[:0])
 
 	// c = Kyber.CPAPKE.Enc(pk, m, r)
-	pk.pk.EncryptTo(ct, kr[32:], m[:])
+	pk.pk.EncryptTo(ct, m[:], kr[32:])
 
 	// Compute H(c) and put in second slot of kr, which will be (K', H(c)).
 	h.Reset()
@@ -175,7 +175,7 @@ func (sk *PrivateKey) DecapsulateTo(ss, ct []byte) {
 
 	// c' = Kyber.CPAPKE.Enc(pk, m', r')
 	var ct2 [CiphertextSize]byte
-	sk.pk.EncryptTo(ct2[:], kr2[32:], m2[:])
+	sk.pk.EncryptTo(ct2[:], m2[:], kr2[32:])
 
 	// Compute H(c) and put in second slot of kr2, which will be (K'', H(c)).
 	h := sha3.New256()

--- a/kem/kyber/kyber768/kyber.go
+++ b/kem/kyber/kyber768/kyber.go
@@ -135,7 +135,7 @@ func (pk *PublicKey) EncapsulateTo(ct, ss []byte, seed []byte) {
 	g.Sum(kr[:0])
 
 	// c = Kyber.CPAPKE.Enc(pk, m, r)
-	pk.pk.EncryptTo(ct, kr[32:], m[:])
+	pk.pk.EncryptTo(ct, m[:], kr[32:])
 
 	// Compute H(c) and put in second slot of kr, which will be (K', H(c)).
 	h.Reset()
@@ -175,7 +175,7 @@ func (sk *PrivateKey) DecapsulateTo(ss, ct []byte) {
 
 	// c' = Kyber.CPAPKE.Enc(pk, m', r')
 	var ct2 [CiphertextSize]byte
-	sk.pk.EncryptTo(ct2[:], kr2[32:], m2[:])
+	sk.pk.EncryptTo(ct2[:], m2[:], kr2[32:])
 
 	// Compute H(c) and put in second slot of kr2, which will be (K'', H(c)).
 	h := sha3.New256()

--- a/kem/kyber/templates/pkg.templ.go
+++ b/kem/kyber/templates/pkg.templ.go
@@ -139,7 +139,7 @@ func (pk *PublicKey) EncapsulateTo(ct, ss []byte, seed []byte) {
 	g.Sum(kr[:0])
 
 	// c = Kyber.CPAPKE.Enc(pk, m, r)
-	pk.pk.EncryptTo(ct, kr[32:], m[:])
+	pk.pk.EncryptTo(ct, m[:], kr[32:])
 
 	// Compute H(c) and put in second slot of kr, which will be (K', H(c)).
 	h.Reset()
@@ -179,7 +179,7 @@ func (sk *PrivateKey) DecapsulateTo(ss, ct []byte) {
 
 	// c' = Kyber.CPAPKE.Enc(pk, m', r')
 	var ct2 [CiphertextSize]byte
-	sk.pk.EncryptTo(ct2[:], kr2[32:], m2[:])
+	sk.pk.EncryptTo(ct2[:], m2[:], kr2[32:])
 
 	// Compute H(c) and put in second slot of kr2, which will be (K'', H(c)).
 	h := sha3.New256()

--- a/pke/kyber/kyber1024/internal/cpapke.go
+++ b/pke/kyber/kyber1024/internal/cpapke.go
@@ -119,7 +119,7 @@ func (sk *PrivateKey) DecryptTo(pt, ct []byte) {
 //
 // seed has to be of length SeedSize, pt of PlaintextSize and ct of
 // CiphertextSize.
-func (pk *PublicKey) EncryptTo(ct, seed, pt []byte) {
+func (pk *PublicKey) EncryptTo(ct, pt, seed []byte) {
 	var rh, e1, u Vec
 	var e2, v, m common.Poly
 

--- a/pke/kyber/kyber1024/internal/cpapke_test.go
+++ b/pke/kyber/kyber1024/internal/cpapke_test.go
@@ -27,7 +27,7 @@ func TestEncryptThenDecrypt(t *testing.T) {
 			_, _ = rand.Read(msg[:])
 			_, _ = rand.Read(coin[:])
 
-			pk.EncryptTo(ct[:], coin[:], msg[:])
+			pk.EncryptTo(ct[:], msg[:], coin[:])
 			sk.DecryptTo(msg2[:], ct[:])
 
 			if msg != msg2 {

--- a/pke/kyber/kyber1024/kyber.go
+++ b/pke/kyber/kyber1024/kyber.go
@@ -69,8 +69,8 @@ func NewKeyFromSeed(seed []byte) (*PublicKey, *PrivateKey) {
 // EncryptTo encrypts message pt for the public key and writes the ciphertext
 // to ct using randomness from seed.
 //
-// This function panics if the lengths of pt, seed and ct are not
-// PlaintextSize, EncryptionSeedSize and CiphertextSize respectively.
+// This function panics if the lengths of pt, seed, and ct are not
+// PlaintextSize, EncryptionSeedSize, and CiphertextSize respectively.
 func (pk *PublicKey) EncryptTo(ct []byte, pt []byte, seed []byte) {
 	if len(pt) != PlaintextSize {
 		panic("pt must be of length PlaintextSize")

--- a/pke/kyber/kyber512/internal/cpapke.go
+++ b/pke/kyber/kyber512/internal/cpapke.go
@@ -117,7 +117,7 @@ func (sk *PrivateKey) DecryptTo(pt, ct []byte) {
 //
 // seed has to be of length SeedSize, pt of PlaintextSize and ct of
 // CiphertextSize.
-func (pk *PublicKey) EncryptTo(ct, seed, pt []byte) {
+func (pk *PublicKey) EncryptTo(ct, pt, seed []byte) {
 	var rh, e1, u Vec
 	var e2, v, m common.Poly
 

--- a/pke/kyber/kyber512/internal/cpapke_test.go
+++ b/pke/kyber/kyber512/internal/cpapke_test.go
@@ -25,7 +25,7 @@ func TestEncryptThenDecrypt(t *testing.T) {
 			_, _ = rand.Read(msg[:])
 			_, _ = rand.Read(coin[:])
 
-			pk.EncryptTo(ct[:], coin[:], msg[:])
+			pk.EncryptTo(ct[:], msg[:], coin[:])
 			sk.DecryptTo(msg2[:], ct[:])
 
 			if msg != msg2 {

--- a/pke/kyber/kyber512/kyber.go
+++ b/pke/kyber/kyber512/kyber.go
@@ -69,8 +69,8 @@ func NewKeyFromSeed(seed []byte) (*PublicKey, *PrivateKey) {
 // EncryptTo encrypts message pt for the public key and writes the ciphertext
 // to ct using randomness from seed.
 //
-// This function panics if the lengths of pt, seed and ct are not
-// PlaintextSize, EncryptionSeedSize and CiphertextSize respectively.
+// This function panics if the lengths of pt, seed, and ct are not
+// PlaintextSize, EncryptionSeedSize, and CiphertextSize respectively.
 func (pk *PublicKey) EncryptTo(ct []byte, pt []byte, seed []byte) {
 	if len(pt) != PlaintextSize {
 		panic("pt must be of length PlaintextSize")

--- a/pke/kyber/kyber768/internal/cpapke.go
+++ b/pke/kyber/kyber768/internal/cpapke.go
@@ -119,7 +119,7 @@ func (sk *PrivateKey) DecryptTo(pt, ct []byte) {
 //
 // seed has to be of length SeedSize, pt of PlaintextSize and ct of
 // CiphertextSize.
-func (pk *PublicKey) EncryptTo(ct, seed, pt []byte) {
+func (pk *PublicKey) EncryptTo(ct, pt, seed []byte) {
 	var rh, e1, u Vec
 	var e2, v, m common.Poly
 

--- a/pke/kyber/kyber768/internal/cpapke_test.go
+++ b/pke/kyber/kyber768/internal/cpapke_test.go
@@ -27,7 +27,7 @@ func TestEncryptThenDecrypt(t *testing.T) {
 			_, _ = rand.Read(msg[:])
 			_, _ = rand.Read(coin[:])
 
-			pk.EncryptTo(ct[:], coin[:], msg[:])
+			pk.EncryptTo(ct[:], msg[:], coin[:])
 			sk.DecryptTo(msg2[:], ct[:])
 
 			if msg != msg2 {

--- a/pke/kyber/kyber768/kyber.go
+++ b/pke/kyber/kyber768/kyber.go
@@ -69,8 +69,8 @@ func NewKeyFromSeed(seed []byte) (*PublicKey, *PrivateKey) {
 // EncryptTo encrypts message pt for the public key and writes the ciphertext
 // to ct using randomness from seed.
 //
-// This function panics if the lengths of pt, seed and ct are not
-// PlaintextSize, EncryptionSeedSize and CiphertextSize respectively.
+// This function panics if the lengths of pt, seed, and ct are not
+// PlaintextSize, EncryptionSeedSize, and CiphertextSize respectively.
 func (pk *PublicKey) EncryptTo(ct []byte, pt []byte, seed []byte) {
 	if len(pt) != PlaintextSize {
 		panic("pt must be of length PlaintextSize")

--- a/pke/kyber/templates/pkg.templ.go
+++ b/pke/kyber/templates/pkg.templ.go
@@ -73,8 +73,8 @@ func NewKeyFromSeed(seed []byte) (*PublicKey, *PrivateKey) {
 // EncryptTo encrypts message pt for the public key and writes the ciphertext
 // to ct using randomness from seed.
 //
-// This function panics if the lengths of pt, seed and ct are not
-// PlaintextSize, EncryptionSeedSize and CiphertextSize respectively.
+// This function panics if the lengths of pt, seed, and ct are not
+// PlaintextSize, EncryptionSeedSize, and CiphertextSize respectively.
 func (pk *PublicKey) EncryptTo(ct []byte, pt []byte, seed []byte) {
 	if len(pt) != PlaintextSize {
 		panic("pt must be of length PlaintextSize")


### PR DESCRIPTION
It fixes a bad parameter passing to pke.EncryptTo function. 
Error wasn't detect as two nested callls both passed parameters in the wrong order. 
Fixes #232 