### PR TITLE
sidh: no return parameter on isogeny EvaluatePoint

### DIFF
--- a/dh/sidh/internal/p434/core.go
+++ b/dh/sidh/internal/p434/core.go
@@ -36,11 +36,11 @@ func traverseTreePublicKeyA(curve *ProjectiveCurveParameters, xR, phiP, phiQ, ph
 		cparam = phi.GenerateCurve(xR)
 
 		for k := 0; k < len(points); k++ {
-			points[k] = phi.EvaluatePoint(&points[k])
+			phi.EvaluatePoint(&points[k])
 		}
-		*phiP = phi.EvaluatePoint(phiP)
-		*phiQ = phi.EvaluatePoint(phiQ)
-		*phiR = phi.EvaluatePoint(phiR)
+		phi.EvaluatePoint(phiP)
+		phi.EvaluatePoint(phiQ)
+		phi.EvaluatePoint(phiR)
 
 		// pop xR from points
 		*xR, points = points[len(points)-1], points[:len(points)-1]
@@ -73,7 +73,7 @@ func traverseTreeSharedKeyA(curve *ProjectiveCurveParameters, xR *ProjectivePoin
 		cparam = phi.GenerateCurve(xR)
 
 		for k := 0; k < len(points); k++ {
-			points[k] = phi.EvaluatePoint(&points[k])
+			phi.EvaluatePoint(&points[k])
 		}
 
 		// pop xR from points
@@ -107,12 +107,12 @@ func traverseTreePublicKeyB(curve *ProjectiveCurveParameters, xR, phiP, phiQ, ph
 
 		cparam = phi.GenerateCurve(xR)
 		for k := 0; k < len(points); k++ {
-			points[k] = phi.EvaluatePoint(&points[k])
+			phi.EvaluatePoint(&points[k])
 		}
 
-		*phiP = phi.EvaluatePoint(phiP)
-		*phiQ = phi.EvaluatePoint(phiQ)
-		*phiR = phi.EvaluatePoint(phiR)
+		phi.EvaluatePoint(phiP)
+		phi.EvaluatePoint(phiQ)
+		phi.EvaluatePoint(phiR)
 
 		// pop xR from points
 		*xR, points = points[len(points)-1], points[:len(points)-1]
@@ -145,7 +145,7 @@ func traverseTreeSharedKeyB(curve *ProjectiveCurveParameters, xR *ProjectivePoin
 
 		cparam = phi.GenerateCurve(xR)
 		for k := 0; k < len(points); k++ {
-			points[k] = phi.EvaluatePoint(&points[k])
+			phi.EvaluatePoint(&points[k])
 		}
 
 		// pop xR from points
@@ -178,9 +178,12 @@ func PublicKeyGenA(pub3Pt *[3]Fp2, prvBytes []byte) {
 
 	// Secret isogeny
 	phi.GenerateCurve(&xR)
-	xPA = phi.EvaluatePoint(&xPB)
-	xQA = phi.EvaluatePoint(&xQB)
-	xRA = phi.EvaluatePoint(&xRB)
+	xPA = xPB
+	xQA = xQB
+	xRA = xRB
+	phi.EvaluatePoint(&xPA)
+	phi.EvaluatePoint(&xQA)
+	phi.EvaluatePoint(&xRA)
 	Fp2Batch3Inv(&xPA.Z, &xQA.Z, &xRA.Z, &invZP, &invZQ, &invZR)
 
 	mul(&pub3Pt[0], &xPA.X, &invZP)
@@ -211,9 +214,12 @@ func PublicKeyGenB(pub3Pt *[3]Fp2, prvBytes []byte) {
 	traverseTreePublicKeyB(&params.InitCurve, &xR, &xPA, &xQA, &xRA)
 
 	phi.GenerateCurve(&xR)
-	xPB = phi.EvaluatePoint(&xPA)
-	xQB = phi.EvaluatePoint(&xQA)
-	xRB = phi.EvaluatePoint(&xRA)
+	xPB = xPA
+	xQB = xQA
+	xRB = xRA
+	phi.EvaluatePoint(&xPB)
+	phi.EvaluatePoint(&xQB)
+	phi.EvaluatePoint(&xRB)
 	Fp2Batch3Inv(&xPB.Z, &xQB.Z, &xRB.Z, &invZP, &invZQ, &invZR)
 
 	mul(&pub3Pt[0], &xPB.X, &invZP)

--- a/dh/sidh/internal/p434/curve.go
+++ b/dh/sidh/internal/p434/curve.go
@@ -291,9 +291,8 @@ func (phi *isogeny3) GenerateCurve(p *ProjectivePoint) CurveCoefficientsEquiv {
 //
 // The output xQ = x(Q) is then a point on the curve E_(A':C'); the curve
 // parameters are returned by the GenerateCurve function used to construct phi.
-func (phi *isogeny3) EvaluatePoint(p *ProjectivePoint) ProjectivePoint {
+func (phi *isogeny3) EvaluatePoint(p *ProjectivePoint) {
 	var t0, t1, t2 Fp2
-	var q ProjectivePoint
 	var K1, K2 = &phi.K1, &phi.K2
 	var px, pz = &p.X, &p.Z
 
@@ -305,9 +304,8 @@ func (phi *isogeny3) EvaluatePoint(p *ProjectivePoint) ProjectivePoint {
 	sub(&t0, &t1, &t0) // t0 = t1 - t0
 	sqr(&t2, &t2)      // t2 = t2 ^ 2
 	sqr(&t0, &t0)      // t0 = t0 ^ 2
-	mul(&q.X, px, &t2) // XQ'= XQ * t2
-	mul(&q.Z, pz, &t0) // ZQ'= ZQ * t0
-	return q
+	mul(px, px, &t2)   // XQ'= XQ * t2
+	mul(pz, pz, &t0)   // ZQ'= ZQ * t0
 }
 
 // Given a four-torsion point p = x(PB) on the curve E_(A:C), construct the
@@ -338,10 +336,9 @@ func (phi *isogeny4) GenerateCurve(p *ProjectivePoint) CurveCoefficientsEquiv {
 //
 // Input: Isogeny returned by GenerateCurve and point q=(Qx,Qz) from E0_A/C
 // Output: Corresponding point q from E1_A'/C', where E1 is 4-isogenous to E0
-func (phi *isogeny4) EvaluatePoint(p *ProjectivePoint) ProjectivePoint {
+func (phi *isogeny4) EvaluatePoint(p *ProjectivePoint) {
 	var t0, t1 Fp2
-	var q = *p
-	var xq, zq = &q.X, &q.Z
+	var xq, zq = &p.X, &p.Z
 	var K1, K2, K3 = &phi.K1, &phi.K2, &phi.K3
 
 	add(&t0, xq, zq)
@@ -358,5 +355,4 @@ func (phi *isogeny4) EvaluatePoint(p *ProjectivePoint) ProjectivePoint {
 	sub(&t0, zq, &t0)
 	mul(xq, xq, &t1)
 	mul(zq, zq, &t0)
-	return q
 }

--- a/dh/sidh/internal/p503/core.go
+++ b/dh/sidh/internal/p503/core.go
@@ -36,11 +36,11 @@ func traverseTreePublicKeyA(curve *ProjectiveCurveParameters, xR, phiP, phiQ, ph
 		cparam = phi.GenerateCurve(xR)
 
 		for k := 0; k < len(points); k++ {
-			points[k] = phi.EvaluatePoint(&points[k])
+			phi.EvaluatePoint(&points[k])
 		}
-		*phiP = phi.EvaluatePoint(phiP)
-		*phiQ = phi.EvaluatePoint(phiQ)
-		*phiR = phi.EvaluatePoint(phiR)
+		phi.EvaluatePoint(phiP)
+		phi.EvaluatePoint(phiQ)
+		phi.EvaluatePoint(phiR)
 
 		// pop xR from points
 		*xR, points = points[len(points)-1], points[:len(points)-1]
@@ -73,7 +73,7 @@ func traverseTreeSharedKeyA(curve *ProjectiveCurveParameters, xR *ProjectivePoin
 		cparam = phi.GenerateCurve(xR)
 
 		for k := 0; k < len(points); k++ {
-			points[k] = phi.EvaluatePoint(&points[k])
+			phi.EvaluatePoint(&points[k])
 		}
 
 		// pop xR from points
@@ -107,12 +107,12 @@ func traverseTreePublicKeyB(curve *ProjectiveCurveParameters, xR, phiP, phiQ, ph
 
 		cparam = phi.GenerateCurve(xR)
 		for k := 0; k < len(points); k++ {
-			points[k] = phi.EvaluatePoint(&points[k])
+			phi.EvaluatePoint(&points[k])
 		}
 
-		*phiP = phi.EvaluatePoint(phiP)
-		*phiQ = phi.EvaluatePoint(phiQ)
-		*phiR = phi.EvaluatePoint(phiR)
+		phi.EvaluatePoint(phiP)
+		phi.EvaluatePoint(phiQ)
+		phi.EvaluatePoint(phiR)
 
 		// pop xR from points
 		*xR, points = points[len(points)-1], points[:len(points)-1]
@@ -145,7 +145,7 @@ func traverseTreeSharedKeyB(curve *ProjectiveCurveParameters, xR *ProjectivePoin
 
 		cparam = phi.GenerateCurve(xR)
 		for k := 0; k < len(points); k++ {
-			points[k] = phi.EvaluatePoint(&points[k])
+			phi.EvaluatePoint(&points[k])
 		}
 
 		// pop xR from points
@@ -178,9 +178,12 @@ func PublicKeyGenA(pub3Pt *[3]Fp2, prvBytes []byte) {
 
 	// Secret isogeny
 	phi.GenerateCurve(&xR)
-	xPA = phi.EvaluatePoint(&xPB)
-	xQA = phi.EvaluatePoint(&xQB)
-	xRA = phi.EvaluatePoint(&xRB)
+	xPA = xPB
+	xQA = xQB
+	xRA = xRB
+	phi.EvaluatePoint(&xPA)
+	phi.EvaluatePoint(&xQA)
+	phi.EvaluatePoint(&xRA)
 	Fp2Batch3Inv(&xPA.Z, &xQA.Z, &xRA.Z, &invZP, &invZQ, &invZR)
 
 	mul(&pub3Pt[0], &xPA.X, &invZP)
@@ -211,9 +214,12 @@ func PublicKeyGenB(pub3Pt *[3]Fp2, prvBytes []byte) {
 	traverseTreePublicKeyB(&params.InitCurve, &xR, &xPA, &xQA, &xRA)
 
 	phi.GenerateCurve(&xR)
-	xPB = phi.EvaluatePoint(&xPA)
-	xQB = phi.EvaluatePoint(&xQA)
-	xRB = phi.EvaluatePoint(&xRA)
+	xPB = xPA
+	xQB = xQA
+	xRB = xRA
+	phi.EvaluatePoint(&xPB)
+	phi.EvaluatePoint(&xQB)
+	phi.EvaluatePoint(&xRB)
 	Fp2Batch3Inv(&xPB.Z, &xQB.Z, &xRB.Z, &invZP, &invZQ, &invZR)
 
 	mul(&pub3Pt[0], &xPB.X, &invZP)

--- a/dh/sidh/internal/p503/curve.go
+++ b/dh/sidh/internal/p503/curve.go
@@ -291,9 +291,8 @@ func (phi *isogeny3) GenerateCurve(p *ProjectivePoint) CurveCoefficientsEquiv {
 //
 // The output xQ = x(Q) is then a point on the curve E_(A':C'); the curve
 // parameters are returned by the GenerateCurve function used to construct phi.
-func (phi *isogeny3) EvaluatePoint(p *ProjectivePoint) ProjectivePoint {
+func (phi *isogeny3) EvaluatePoint(p *ProjectivePoint) {
 	var t0, t1, t2 Fp2
-	var q ProjectivePoint
 	var K1, K2 = &phi.K1, &phi.K2
 	var px, pz = &p.X, &p.Z
 
@@ -305,9 +304,8 @@ func (phi *isogeny3) EvaluatePoint(p *ProjectivePoint) ProjectivePoint {
 	sub(&t0, &t1, &t0) // t0 = t1 - t0
 	sqr(&t2, &t2)      // t2 = t2 ^ 2
 	sqr(&t0, &t0)      // t0 = t0 ^ 2
-	mul(&q.X, px, &t2) // XQ'= XQ * t2
-	mul(&q.Z, pz, &t0) // ZQ'= ZQ * t0
-	return q
+	mul(px, px, &t2)   // XQ'= XQ * t2
+	mul(pz, pz, &t0)   // ZQ'= ZQ * t0
 }
 
 // Given a four-torsion point p = x(PB) on the curve E_(A:C), construct the
@@ -338,10 +336,9 @@ func (phi *isogeny4) GenerateCurve(p *ProjectivePoint) CurveCoefficientsEquiv {
 //
 // Input: Isogeny returned by GenerateCurve and point q=(Qx,Qz) from E0_A/C
 // Output: Corresponding point q from E1_A'/C', where E1 is 4-isogenous to E0
-func (phi *isogeny4) EvaluatePoint(p *ProjectivePoint) ProjectivePoint {
+func (phi *isogeny4) EvaluatePoint(p *ProjectivePoint) {
 	var t0, t1 Fp2
-	var q = *p
-	var xq, zq = &q.X, &q.Z
+	var xq, zq = &p.X, &p.Z
 	var K1, K2, K3 = &phi.K1, &phi.K2, &phi.K3
 
 	add(&t0, xq, zq)
@@ -358,5 +355,4 @@ func (phi *isogeny4) EvaluatePoint(p *ProjectivePoint) ProjectivePoint {
 	sub(&t0, zq, &t0)
 	mul(xq, xq, &t1)
 	mul(zq, zq, &t0)
-	return q
 }

--- a/dh/sidh/internal/p751/core.go
+++ b/dh/sidh/internal/p751/core.go
@@ -36,11 +36,11 @@ func traverseTreePublicKeyA(curve *ProjectiveCurveParameters, xR, phiP, phiQ, ph
 		cparam = phi.GenerateCurve(xR)
 
 		for k := 0; k < len(points); k++ {
-			points[k] = phi.EvaluatePoint(&points[k])
+			phi.EvaluatePoint(&points[k])
 		}
-		*phiP = phi.EvaluatePoint(phiP)
-		*phiQ = phi.EvaluatePoint(phiQ)
-		*phiR = phi.EvaluatePoint(phiR)
+		phi.EvaluatePoint(phiP)
+		phi.EvaluatePoint(phiQ)
+		phi.EvaluatePoint(phiR)
 
 		// pop xR from points
 		*xR, points = points[len(points)-1], points[:len(points)-1]
@@ -73,7 +73,7 @@ func traverseTreeSharedKeyA(curve *ProjectiveCurveParameters, xR *ProjectivePoin
 		cparam = phi.GenerateCurve(xR)
 
 		for k := 0; k < len(points); k++ {
-			points[k] = phi.EvaluatePoint(&points[k])
+			phi.EvaluatePoint(&points[k])
 		}
 
 		// pop xR from points
@@ -107,12 +107,12 @@ func traverseTreePublicKeyB(curve *ProjectiveCurveParameters, xR, phiP, phiQ, ph
 
 		cparam = phi.GenerateCurve(xR)
 		for k := 0; k < len(points); k++ {
-			points[k] = phi.EvaluatePoint(&points[k])
+			phi.EvaluatePoint(&points[k])
 		}
 
-		*phiP = phi.EvaluatePoint(phiP)
-		*phiQ = phi.EvaluatePoint(phiQ)
-		*phiR = phi.EvaluatePoint(phiR)
+		phi.EvaluatePoint(phiP)
+		phi.EvaluatePoint(phiQ)
+		phi.EvaluatePoint(phiR)
 
 		// pop xR from points
 		*xR, points = points[len(points)-1], points[:len(points)-1]
@@ -145,7 +145,7 @@ func traverseTreeSharedKeyB(curve *ProjectiveCurveParameters, xR *ProjectivePoin
 
 		cparam = phi.GenerateCurve(xR)
 		for k := 0; k < len(points); k++ {
-			points[k] = phi.EvaluatePoint(&points[k])
+			phi.EvaluatePoint(&points[k])
 		}
 
 		// pop xR from points
@@ -178,9 +178,12 @@ func PublicKeyGenA(pub3Pt *[3]Fp2, prvBytes []byte) {
 
 	// Secret isogeny
 	phi.GenerateCurve(&xR)
-	xPA = phi.EvaluatePoint(&xPB)
-	xQA = phi.EvaluatePoint(&xQB)
-	xRA = phi.EvaluatePoint(&xRB)
+	xPA = xPB
+	xQA = xQB
+	xRA = xRB
+	phi.EvaluatePoint(&xPA)
+	phi.EvaluatePoint(&xQA)
+	phi.EvaluatePoint(&xRA)
 	Fp2Batch3Inv(&xPA.Z, &xQA.Z, &xRA.Z, &invZP, &invZQ, &invZR)
 
 	mul(&pub3Pt[0], &xPA.X, &invZP)
@@ -211,9 +214,12 @@ func PublicKeyGenB(pub3Pt *[3]Fp2, prvBytes []byte) {
 	traverseTreePublicKeyB(&params.InitCurve, &xR, &xPA, &xQA, &xRA)
 
 	phi.GenerateCurve(&xR)
-	xPB = phi.EvaluatePoint(&xPA)
-	xQB = phi.EvaluatePoint(&xQA)
-	xRB = phi.EvaluatePoint(&xRA)
+	xPB = xPA
+	xQB = xQA
+	xRB = xRA
+	phi.EvaluatePoint(&xPB)
+	phi.EvaluatePoint(&xQB)
+	phi.EvaluatePoint(&xRB)
 	Fp2Batch3Inv(&xPB.Z, &xQB.Z, &xRB.Z, &invZP, &invZQ, &invZR)
 
 	mul(&pub3Pt[0], &xPB.X, &invZP)

--- a/dh/sidh/internal/p751/curve.go
+++ b/dh/sidh/internal/p751/curve.go
@@ -291,9 +291,8 @@ func (phi *isogeny3) GenerateCurve(p *ProjectivePoint) CurveCoefficientsEquiv {
 //
 // The output xQ = x(Q) is then a point on the curve E_(A':C'); the curve
 // parameters are returned by the GenerateCurve function used to construct phi.
-func (phi *isogeny3) EvaluatePoint(p *ProjectivePoint) ProjectivePoint {
+func (phi *isogeny3) EvaluatePoint(p *ProjectivePoint) {
 	var t0, t1, t2 Fp2
-	var q ProjectivePoint
 	var K1, K2 = &phi.K1, &phi.K2
 	var px, pz = &p.X, &p.Z
 
@@ -305,9 +304,8 @@ func (phi *isogeny3) EvaluatePoint(p *ProjectivePoint) ProjectivePoint {
 	sub(&t0, &t1, &t0) // t0 = t1 - t0
 	sqr(&t2, &t2)      // t2 = t2 ^ 2
 	sqr(&t0, &t0)      // t0 = t0 ^ 2
-	mul(&q.X, px, &t2) // XQ'= XQ * t2
-	mul(&q.Z, pz, &t0) // ZQ'= ZQ * t0
-	return q
+	mul(px, px, &t2)   // XQ'= XQ * t2
+	mul(pz, pz, &t0)   // ZQ'= ZQ * t0
 }
 
 // Given a four-torsion point p = x(PB) on the curve E_(A:C), construct the
@@ -338,10 +336,9 @@ func (phi *isogeny4) GenerateCurve(p *ProjectivePoint) CurveCoefficientsEquiv {
 //
 // Input: Isogeny returned by GenerateCurve and point q=(Qx,Qz) from E0_A/C
 // Output: Corresponding point q from E1_A'/C', where E1 is 4-isogenous to E0
-func (phi *isogeny4) EvaluatePoint(p *ProjectivePoint) ProjectivePoint {
+func (phi *isogeny4) EvaluatePoint(p *ProjectivePoint) {
 	var t0, t1 Fp2
-	var q = *p
-	var xq, zq = &q.X, &q.Z
+	var xq, zq = &p.X, &p.Z
 	var K1, K2, K3 = &phi.K1, &phi.K2, &phi.K3
 
 	add(&t0, xq, zq)
@@ -358,5 +355,4 @@ func (phi *isogeny4) EvaluatePoint(p *ProjectivePoint) ProjectivePoint {
 	sub(&t0, zq, &t0)
 	mul(xq, xq, &t1)
 	mul(zq, zq, &t0)
-	return q
 }

--- a/dh/sidh/internal/templates/core.gotemp
+++ b/dh/sidh/internal/templates/core.gotemp
@@ -36,11 +36,11 @@ func traverseTreePublicKeyA(curve *ProjectiveCurveParameters, xR, phiP, phiQ, ph
 		cparam = phi.GenerateCurve(xR)
 
 		for k := 0; k < len(points); k++ {
-			points[k] = phi.EvaluatePoint(&points[k])
+			phi.EvaluatePoint(&points[k])
 		}
-		*phiP = phi.EvaluatePoint(phiP)
-		*phiQ = phi.EvaluatePoint(phiQ)
-		*phiR = phi.EvaluatePoint(phiR)
+		phi.EvaluatePoint(phiP)
+		phi.EvaluatePoint(phiQ)
+		phi.EvaluatePoint(phiR)
 
 		// pop xR from points
 		*xR, points = points[len(points)-1], points[:len(points)-1]
@@ -73,7 +73,7 @@ func traverseTreeSharedKeyA(curve *ProjectiveCurveParameters, xR *ProjectivePoin
 		cparam = phi.GenerateCurve(xR)
 
 		for k := 0; k < len(points); k++ {
-			points[k] = phi.EvaluatePoint(&points[k])
+			phi.EvaluatePoint(&points[k])
 		}
 
 		// pop xR from points
@@ -107,12 +107,12 @@ func traverseTreePublicKeyB(curve *ProjectiveCurveParameters, xR, phiP, phiQ, ph
 
 		cparam = phi.GenerateCurve(xR)
 		for k := 0; k < len(points); k++ {
-			points[k] = phi.EvaluatePoint(&points[k])
+			phi.EvaluatePoint(&points[k])
 		}
 
-		*phiP = phi.EvaluatePoint(phiP)
-		*phiQ = phi.EvaluatePoint(phiQ)
-		*phiR = phi.EvaluatePoint(phiR)
+		phi.EvaluatePoint(phiP)
+		phi.EvaluatePoint(phiQ)
+		phi.EvaluatePoint(phiR)
 
 		// pop xR from points
 		*xR, points = points[len(points)-1], points[:len(points)-1]
@@ -145,7 +145,7 @@ func traverseTreeSharedKeyB(curve *ProjectiveCurveParameters, xR *ProjectivePoin
 
 		cparam = phi.GenerateCurve(xR)
 		for k := 0; k < len(points); k++ {
-			points[k] = phi.EvaluatePoint(&points[k])
+			phi.EvaluatePoint(&points[k])
 		}
 
 		// pop xR from points
@@ -178,9 +178,12 @@ func PublicKeyGenA(pub3Pt *[3]Fp2, prvBytes []byte) {
 
 	// Secret isogeny
 	phi.GenerateCurve(&xR)
-	xPA = phi.EvaluatePoint(&xPB)
-	xQA = phi.EvaluatePoint(&xQB)
-	xRA = phi.EvaluatePoint(&xRB)
+	xPA = xPB
+	xQA = xQB
+	xRA = xRB
+	phi.EvaluatePoint(&xPA)
+	phi.EvaluatePoint(&xQA)
+	phi.EvaluatePoint(&xRA)
 	Fp2Batch3Inv(&xPA.Z, &xQA.Z, &xRA.Z, &invZP, &invZQ, &invZR)
 
 	mul(&pub3Pt[0], &xPA.X, &invZP)
@@ -211,9 +214,12 @@ func PublicKeyGenB(pub3Pt *[3]Fp2, prvBytes []byte) {
 	traverseTreePublicKeyB(&params.InitCurve, &xR, &xPA, &xQA, &xRA)
 
 	phi.GenerateCurve(&xR)
-	xPB = phi.EvaluatePoint(&xPA)
-	xQB = phi.EvaluatePoint(&xQA)
-	xRB = phi.EvaluatePoint(&xRA)
+	xPB = xPA
+	xQB = xQA
+	xRB = xRA
+	phi.EvaluatePoint(&xPB)
+	phi.EvaluatePoint(&xQB)
+	phi.EvaluatePoint(&xRB)
 	Fp2Batch3Inv(&xPB.Z, &xQB.Z, &xRB.Z, &invZP, &invZQ, &invZR)
 
 	mul(&pub3Pt[0], &xPB.X, &invZP)

--- a/dh/sidh/internal/templates/curve.gotemp
+++ b/dh/sidh/internal/templates/curve.gotemp
@@ -291,9 +291,8 @@ func (phi *isogeny3) GenerateCurve(p *ProjectivePoint) CurveCoefficientsEquiv {
 //
 // The output xQ = x(Q) is then a point on the curve E_(A':C'); the curve
 // parameters are returned by the GenerateCurve function used to construct phi.
-func (phi *isogeny3) EvaluatePoint(p *ProjectivePoint) ProjectivePoint {
+func (phi *isogeny3) EvaluatePoint(p *ProjectivePoint) {
 	var t0, t1, t2 Fp2
-	var q ProjectivePoint
 	var K1, K2 = &phi.K1, &phi.K2
 	var px, pz = &p.X, &p.Z
 
@@ -305,9 +304,8 @@ func (phi *isogeny3) EvaluatePoint(p *ProjectivePoint) ProjectivePoint {
 	sub(&t0, &t1, &t0) // t0 = t1 - t0
 	sqr(&t2, &t2)      // t2 = t2 ^ 2
 	sqr(&t0, &t0)      // t0 = t0 ^ 2
-	mul(&q.X, px, &t2) // XQ'= XQ * t2
-	mul(&q.Z, pz, &t0) // ZQ'= ZQ * t0
-	return q
+	mul(px, px, &t2)   // XQ'= XQ * t2
+	mul(pz, pz, &t0)   // ZQ'= ZQ * t0
 }
 
 // Given a four-torsion point p = x(PB) on the curve E_(A:C), construct the
@@ -338,10 +336,9 @@ func (phi *isogeny4) GenerateCurve(p *ProjectivePoint) CurveCoefficientsEquiv {
 //
 // Input: Isogeny returned by GenerateCurve and point q=(Qx,Qz) from E0_A/C
 // Output: Corresponding point q from E1_A'/C', where E1 is 4-isogenous to E0
-func (phi *isogeny4) EvaluatePoint(p *ProjectivePoint) ProjectivePoint {
+func (phi *isogeny4) EvaluatePoint(p *ProjectivePoint) {
 	var t0, t1 Fp2
-	var q = *p
-	var xq, zq = &q.X, &q.Z
+	var xq, zq = &p.X, &p.Z
 	var K1, K2, K3 = &phi.K1, &phi.K2, &phi.K3
 
 	add(&t0, xq, zq)
@@ -358,5 +355,4 @@ func (phi *isogeny4) EvaluatePoint(p *ProjectivePoint) ProjectivePoint {
 	sub(&t0, zq, &t0)
 	mul(xq, xq, &t1)
 	mul(zq, zq, &t0)
-	return q
 }


### PR DESCRIPTION
avoids to copy data when returning from isogeny evaluation.

Updates the template and three instances generated with it.