### PR TITLE
Updating linter version to v1.41

### DIFF
--- a/.etc/golangci.yml
+++ b/.etc/golangci.yml
@@ -1,9 +1,13 @@
+---
 linters:
   disable-all: true
   enable:
-#   - lll    
-#   - gocritic    
-#   - gocognit    
+    # - lll
+    # - gocritic
+    # - gocognit
+    # - interfacer  (deprecated since v1.38.0)
+    # - scopelint   (deprecated since v1.39.0)
+    # - golint      (deprecated since v1.41.0)
     - bodyclose
     - deadcode
     - depguard
@@ -14,15 +18,12 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - misspell
     - nakedret
-    - scopelint
     - staticcheck
     - structcheck
     - stylecheck

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Linting
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.29
+          version: v1.41
           args: --config=./.etc/golangci.yml ./...
       - name: Setup Go-${{ matrix.GOVER }}
         uses: actions/setup-go@v2

--- a/pke/kyber/internal/common/field_test.go
+++ b/pke/kyber/internal/common/field_test.go
@@ -36,29 +36,29 @@ func TestBarrettReduceFull(t *testing.T) {
 	}
 }
 
-func randSliceUint32(N uint) []uint32 {
-	bytes := make([]uint8, 4*N)
+func randSliceUint32WithMax(length uint, max uint32) []uint32 {
+	bytes := make([]uint8, 4*length)
 	n, err := rand.Read(bytes)
 	if err != nil {
 		panic(err)
 	} else if n < len(bytes) {
 		panic("short read from RNG")
 	}
-	x := make([]uint32, N)
+	x := make([]uint32, length)
 	for i := range x {
-		x[i] = binary.LittleEndian.Uint32(bytes[4*i:])
+		x[i] = binary.LittleEndian.Uint32(bytes[4*i:]) % max
 	}
 	return x
 }
 
 func TestMontReduce(t *testing.T) {
 	N := 1000
-	r := randSliceUint32(uint(N))
 	max := uint32(Q) * (1 << 16)
 	mid := int32(Q) * (1 << 15)
+	r := randSliceUint32WithMax(uint(N), max)
 
 	for i := 0; i < N; i++ {
-		x := int32(r[i]%max) - mid
+		x := int32(r[i]) - mid
 		y := montReduce(x)
 		if modQ32(x) != modQ32(int32(y)*(1<<16)) {
 			t.Fatalf("%d", x)

--- a/pke/kyber/internal/common/ntt_test.go
+++ b/pke/kyber/internal/common/ntt_test.go
@@ -31,18 +31,18 @@ func BenchmarkInvNTTGeneric(b *testing.B) {
 }
 
 func (p *Poly) Rand() {
-	r := randSliceUint32(uint(N))
 	max := uint32(Q)
+	r := randSliceUint32WithMax(uint(N), max)
 	for i := 0; i < N; i++ {
-		p[i] = int16(r[i] % max)
+		p[i] = int16(r[i])
 	}
 }
 
 func (p *Poly) RandAbsLeQ() {
-	r := randSliceUint32(uint(N))
 	max := 2 * uint32(Q)
+	r := randSliceUint32WithMax(uint(N), max)
 	for i := 0; i < N; i++ {
-		p[i] = int16(int32(r[i]%max) - int32(Q))
+		p[i] = int16(int32(r[i]) - int32(Q))
 	}
 }
 

--- a/pke/kyber/internal/common/ntt_test.go
+++ b/pke/kyber/internal/common/ntt_test.go
@@ -1,9 +1,6 @@
 package common
 
-import (
-	mathRand "math/rand"
-	"testing"
-)
+import "testing"
 
 func BenchmarkNTT(b *testing.B) {
 	var a Poly
@@ -34,14 +31,18 @@ func BenchmarkInvNTTGeneric(b *testing.B) {
 }
 
 func (p *Poly) Rand() {
+	r := randSliceUint32(uint(N))
+	max := uint32(Q)
 	for i := 0; i < N; i++ {
-		p[i] = int16(mathRand.Intn(int(Q)))
+		p[i] = int16(r[i] % max)
 	}
 }
 
 func (p *Poly) RandAbsLeQ() {
+	r := randSliceUint32(uint(N))
+	max := 2 * uint32(Q)
 	for i := 0; i < N; i++ {
-		p[i] = int16(mathRand.Intn(int(2*Q))) - Q
+		p[i] = int16(int32(r[i]%max) - int32(Q))
 	}
 }
 

--- a/pke/kyber/internal/common/poly_test.go
+++ b/pke/kyber/internal/common/poly_test.go
@@ -1,15 +1,16 @@
 package common
 
 import (
-	cryptoRand "crypto/rand"
+	"crypto/rand"
 	"fmt"
-	mathRand "math/rand"
 	"testing"
 )
 
 func (p *Poly) RandAbsLe9Q() {
+	r := randSliceUint32(uint(N))
+	max := 9 * uint32(Q)
 	for i := 0; i < N; i++ {
-		p[i] = int16(mathRand.Intn(18*int(Q) - 9*int(Q)))
+		p[i] = int16(int32(r[i] % max))
 	}
 }
 
@@ -26,7 +27,11 @@ func TestDecompressMessage(t *testing.T) {
 	var m, m2 [PlaintextSize]byte
 	var p Poly
 	for i := 0; i < 1000; i++ {
-		_, _ = cryptoRand.Read(m[:])
+		_, err := rand.Read(m[:])
+		if err != nil {
+			t.Error(err)
+		}
+
 		p.DecompressMessage(m[:])
 		p.CompressMessageTo(m2[:])
 		if m != m2 {

--- a/pke/kyber/internal/common/poly_test.go
+++ b/pke/kyber/internal/common/poly_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func (p *Poly) RandAbsLe9Q() {
-	r := randSliceUint32(uint(N))
 	max := 9 * uint32(Q)
+	r := randSliceUint32WithMax(uint(N), max)
 	for i := 0; i < N; i++ {
-		p[i] = int16(int32(r[i] % max))
+		p[i] = int16(int32(r[i]))
 	}
 }
 
@@ -27,9 +27,10 @@ func TestDecompressMessage(t *testing.T) {
 	var m, m2 [PlaintextSize]byte
 	var p Poly
 	for i := 0; i < 1000; i++ {
-		_, err := rand.Read(m[:])
-		if err != nil {
+		if n, err := rand.Read(m[:]); err != nil {
 			t.Error(err)
+		} else if n != len(m) {
+			t.Fatal("short read from RNG")
 		}
 
 		p.DecompressMessage(m[:])

--- a/sign/dilithium/internal/common/field_test.go
+++ b/sign/dilithium/internal/common/field_test.go
@@ -1,16 +1,34 @@
 package common
 
 import (
+	"crypto/rand"
+	"encoding/binary"
 	"flag"
-	"math/rand"
 	"testing"
 )
 
 var runVeryLongTest = flag.Bool("very-long", false, "runs very long tests")
 
+func randSliceUint32(N uint) []uint32 {
+	bytes := make([]uint8, 4*N)
+	n, err := rand.Read(bytes)
+	if err != nil {
+		panic(err)
+	} else if n < len(bytes) {
+		panic("short read from RNG")
+	}
+	x := make([]uint32, N)
+	for i := range x {
+		x[i] = binary.LittleEndian.Uint32(bytes[4*i:])
+	}
+	return x
+}
+
 func TestModQ(t *testing.T) {
-	for i := 0; i < 1000; i++ {
-		x := rand.Uint32()
+	const testTimes = 1000
+	r := randSliceUint32(testTimes)
+	for i := 0; i < testTimes; i++ {
+		x := r[i]
 		y := modQ(x)
 		if y > Q {
 			t.Fatalf("modQ(%d) > Q", x)
@@ -22,8 +40,10 @@ func TestModQ(t *testing.T) {
 }
 
 func TestReduceLe2Q(t *testing.T) {
-	for i := 0; i < 1000; i++ {
-		x := rand.Uint32()
+	const testTimes = 1000
+	r := randSliceUint32(testTimes)
+	for i := 0; i < testTimes; i++ {
+		x := r[i]
 		y := reduceLe2Q(x)
 		if y > 2*Q {
 			t.Fatalf("reduce_le2q(%d) > 2Q", x)

--- a/sign/dilithium/internal/common/field_test.go
+++ b/sign/dilithium/internal/common/field_test.go
@@ -4,22 +4,24 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"flag"
+	"math"
 	"testing"
 )
 
 var runVeryLongTest = flag.Bool("very-long", false, "runs very long tests")
 
-func randSliceUint32(N uint) []uint32 {
-	bytes := make([]uint8, 4*N)
-	n, err := rand.Read(bytes)
-	if err != nil {
+func randSliceUint32(length uint) []uint32 { return randSliceUint32WithMax(length, math.MaxUint32) }
+
+func randSliceUint32WithMax(length uint, max uint32) []uint32 {
+	bytes := make([]uint8, 4*length)
+	if n, err := rand.Read(bytes); err != nil {
 		panic(err)
 	} else if n < len(bytes) {
 		panic("short read from RNG")
 	}
-	x := make([]uint32, N)
+	x := make([]uint32, length)
 	for i := range x {
-		x[i] = binary.LittleEndian.Uint32(bytes[4*i:])
+		x[i] = binary.LittleEndian.Uint32(bytes[4*i:]) % max
 	}
 	return x
 }

--- a/sign/dilithium/internal/common/ntt_test.go
+++ b/sign/dilithium/internal/common/ntt_test.go
@@ -1,13 +1,12 @@
 package common
 
-import (
-	"math/rand"
-	"testing"
-)
+import "testing"
 
 func (p *Poly) RandLe2Q() {
+	r := randSliceUint32(N)
+	max := 2 * uint32(Q)
 	for i := uint(0); i < N; i++ {
-		p[i] = uint32(rand.Intn(int(2 * Q)))
+		p[i] = r[i] % max
 	}
 }
 

--- a/sign/dilithium/internal/common/ntt_test.go
+++ b/sign/dilithium/internal/common/ntt_test.go
@@ -3,11 +3,9 @@ package common
 import "testing"
 
 func (p *Poly) RandLe2Q() {
-	r := randSliceUint32(N)
 	max := 2 * uint32(Q)
-	for i := uint(0); i < N; i++ {
-		p[i] = r[i] % max
-	}
+	r := randSliceUint32WithMax(N, max)
+	copy(p[:], r)
 }
 
 func TestNTTAgainstGeneric(t *testing.T) {

--- a/sign/dilithium/internal/common/pack_test.go
+++ b/sign/dilithium/internal/common/pack_test.go
@@ -1,16 +1,19 @@
 package common
 
 import (
-	"math/rand"
+	"crypto/rand"
 	"testing"
 )
 
 func TestPackLe16AgainstGeneric(t *testing.T) {
 	var p Poly
 	var buf1, buf2 [PolyLe16Size]byte
+	pp := make([]uint8, 256)
+
 	for j := 0; j < 1000; j++ {
+		_, _ = rand.Read(pp)
 		for i := 0; i < 256; i++ {
-			p[i] = uint32(rand.Intn(16))
+			p[i] = uint32(pp[i] & 0xF)
 		}
 		p.PackLe16(buf1[:])
 		p.packLe16Generic(buf2[:])

--- a/sign/dilithium/internal/common/pack_test.go
+++ b/sign/dilithium/internal/common/pack_test.go
@@ -1,20 +1,14 @@
 package common
 
-import (
-	"crypto/rand"
-	"testing"
-)
+import "testing"
 
 func TestPackLe16AgainstGeneric(t *testing.T) {
 	var p Poly
 	var buf1, buf2 [PolyLe16Size]byte
-	pp := make([]uint8, 256)
 
 	for j := 0; j < 1000; j++ {
-		_, _ = rand.Read(pp)
-		for i := 0; i < 256; i++ {
-			p[i] = uint32(pp[i] & 0xF)
-		}
+		pp := randSliceUint32WithMax(N, 16)
+		copy(p[:], pp)
 		p.PackLe16(buf1[:])
 		p.packLe16Generic(buf2[:])
 		if buf1 != buf2 {

--- a/sign/dilithium/internal/common/poly_test.go
+++ b/sign/dilithium/internal/common/poly_test.go
@@ -1,9 +1,6 @@
 package common
 
-import (
-	"math/rand"
-	"testing"
-)
+import "testing"
 
 func TestExceeds(t *testing.T) {
 	for i := 0; i < N; i++ {
@@ -116,9 +113,8 @@ func TestMulHatAgainstGeneric(t *testing.T) {
 func TestReduceLe2QAgainstGeneric(t *testing.T) {
 	for k := 0; k < 1000; k++ {
 		var a Poly
-		for j := 0; j < N; j++ {
-			a[j] = rand.Uint32()
-		}
+		r := randSliceUint32(N)
+		copy(a[:], r)
 		p1 := a
 		p2 := a
 		p1.reduceLe2QGeneric()
@@ -132,9 +128,8 @@ func TestReduceLe2QAgainstGeneric(t *testing.T) {
 func TestNormalizeAgainstGeneric(t *testing.T) {
 	for k := 0; k < 1000; k++ {
 		var a Poly
-		for j := 0; j < N; j++ {
-			a[j] = rand.Uint32()
-		}
+		r := randSliceUint32(N)
+		copy(a[:], r)
 		p1 := a
 		p2 := a
 		p1.normalizeGeneric()


### PR DESCRIPTION
Bumping up golangci-lint version to v1.41
- replacing invocations of math/rand by crypto/rand