### PR TITLE
bls12381: Includes arithmetic for scalars.

### DIFF
--- a/ecc/bls12381/constants.go
+++ b/ecc/bls12381/constants.go
@@ -17,12 +17,7 @@ var (
 	g2Param3B  = ff.Fp2{}
 	g2GenX     = ff.Fp2{}
 	g2GenY     = ff.Fp2{}
-	primeOrder = Scalar{
-		0x01, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
-		0xfe, 0x5b, 0xfe, 0xff, 0x02, 0xa4, 0xbd, 0x53,
-		0x05, 0xd8, 0xa1, 0x09, 0x08, 0xd8, 0x39, 0x33,
-		0x48, 0x7d, 0x9d, 0x29, 0x53, 0xa7, 0xed, 0x73,
-	}
+	primeOrder Scalar
 )
 
 func init() {
@@ -39,4 +34,6 @@ func init() {
 	g2GenX[1].SetString("0x13e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e")
 	g2GenY[0].SetString("0x0ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801")
 	g2GenY[1].SetString("0x0606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be")
+
+	primeOrder.SetString("0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001")
 }

--- a/ecc/bls12381/g1.go
+++ b/ecc/bls12381/g1.go
@@ -115,9 +115,10 @@ func (g *G1) Add(P, Q *G1) {
 func (g *G1) ScalarMult(k *Scalar, P *G1) {
 	var Q G1
 	Q.SetIdentity()
+	kk := k.Bytes()
 	for i := 8*ScalarSize - 1; i >= 0; i-- {
 		Q.Double()
-		bit := 0x1 & (k[i/8] >> uint(i%8))
+		bit := 0x1 & (kk[i/8] >> uint(i%8))
 		if bit != 0 {
 			Q.Add(&Q, P)
 		}

--- a/ecc/bls12381/g1_test.go
+++ b/ecc/bls12381/g1_test.go
@@ -1,7 +1,6 @@
 package bls12381
 
 import (
-	"crypto/rand"
 	"testing"
 
 	"github.com/cloudflare/circl/internal/test"
@@ -10,7 +9,7 @@ import (
 func randomG1(t testing.TB) *G1 {
 	var P G1
 	var k Scalar
-	_, _ = rand.Read(k[:])
+	k.Random()
 	P.ScalarMult(&k, G1Generator())
 	if !P.IsOnCurve() {
 		t.Helper()
@@ -44,13 +43,13 @@ func TestG1ScalarMult(t *testing.T) {
 	var Q G1
 	for i := 0; i < testTimes; i++ {
 		P := randomG1(t)
-		_, _ = rand.Read(k[:])
+		k.Random()
 		Q.ScalarMult(&k, P)
 		Q.Normalize()
 		got := Q.IsOnG1()
 		want := true
 		if got != want {
-			test.ReportError(t, got, want, P)
+			test.ReportError(t, got, want, P, k)
 		}
 	}
 }
@@ -65,7 +64,7 @@ func BenchmarkG1(b *testing.B) {
 	})
 	b.Run("Mul", func(b *testing.B) {
 		var k Scalar
-		_, _ = rand.Read(k[:])
+		k.Random()
 		for i := 0; i < b.N; i++ {
 			P.ScalarMult(&k, P)
 		}

--- a/ecc/bls12381/g2.go
+++ b/ecc/bls12381/g2.go
@@ -39,9 +39,10 @@ func (g *G2) Add(P, Q *G2) { addAndLine(g, P, Q, nil) }
 func (g *G2) ScalarMult(k *Scalar, P *G2) {
 	var Q G2
 	Q.SetIdentity()
+	kk := k.Bytes()
 	for i := 8*ScalarSize - 1; i >= 0; i-- {
 		Q.Double()
-		bit := 0x1 & (k[i/8] >> uint(i%8))
+		bit := 0x1 & (kk[i/8] >> uint(i%8))
 		if bit != 0 {
 			Q.Add(&Q, P)
 		}

--- a/ecc/bls12381/g2_test.go
+++ b/ecc/bls12381/g2_test.go
@@ -1,7 +1,6 @@
 package bls12381
 
 import (
-	"crypto/rand"
 	"testing"
 
 	"github.com/cloudflare/circl/internal/test"
@@ -10,7 +9,7 @@ import (
 func randomG2(t testing.TB) *G2 {
 	var P G2
 	var k Scalar
-	_, _ = rand.Read(k[:])
+	k.Random()
 	P.ScalarMult(&k, G2Generator())
 	if !P.IsOnCurve() {
 		t.Helper()
@@ -44,7 +43,7 @@ func TestG2ScalarMult(t *testing.T) {
 	var Q G2
 	for i := 0; i < testTimes; i++ {
 		P := randomG2(t)
-		_, _ = rand.Read(k[:])
+		k.Random()
 		Q.ScalarMult(&k, P)
 		Q.Normalize()
 		got := Q.IsOnG2()
@@ -65,7 +64,7 @@ func BenchmarkG2(b *testing.B) {
 	})
 	b.Run("Mul", func(b *testing.B) {
 		var k Scalar
-		_, _ = rand.Read(k[:])
+		k.Random()
 		for i := 0; i < b.N; i++ {
 			P.ScalarMult(&k, P)
 		}

--- a/ecc/bls12381/pair.go
+++ b/ecc/bls12381/pair.go
@@ -107,7 +107,7 @@ func ProdPair(P []*G1, Q []*G2, n []*Scalar) *Gt {
 
 	for i := range P {
 		mi := miller(P[i], Q[i])
-		ei.Exp(mi, n[i][:])
+		ei.Exp(mi, n[i].Bytes())
 		out.Mul(out, ei)
 	}
 

--- a/ecc/bls12381/pair_test.go
+++ b/ecc/bls12381/pair_test.go
@@ -1,7 +1,6 @@
 package bls12381
 
 import (
-	"crypto/rand"
 	"fmt"
 	"testing"
 
@@ -54,7 +53,7 @@ func BenchmarkPair(b *testing.B) {
 		listG2[i] = new(G2)
 		listG2[i].Set(g2)
 		listExp[i] = &Scalar{}
-		mustRead(b, listExp[i][:])
+		listExp[i].Random()
 	}
 
 	b.Run("Pair1", func(b *testing.B) {
@@ -67,14 +66,4 @@ func BenchmarkPair(b *testing.B) {
 			ProdPair(listG1[:], listG2[:], listExp[:])
 		}
 	})
-}
-
-func mustRead(t testing.TB, b []byte) {
-	n, err := rand.Read(b)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != len(b) {
-		t.Fatal("incomplete read")
-	}
 }

--- a/ecc/bls12381/scalar.go
+++ b/ecc/bls12381/scalar.go
@@ -1,7 +1,47 @@
 package bls12381
 
+import (
+	"crypto/rand"
+	"math/big"
+)
+
 // ScalarSize is the length in bytes of a Scalar.
 const ScalarSize = 32
 
-// Scalar represents an integer in little-endian order used for scalar multiplication.
-type Scalar [ScalarSize]byte
+// Scalar represents an integer used for scalar multiplication.
+type Scalar struct{ i big.Int }
+
+func (z Scalar) String() string          { return "0x" + z.i.Text(16) }
+func (z *Scalar) Set(x *Scalar)          { z.i.Set(&x.i) }
+func (z *Scalar) SetString(s string)     { z.i.SetString(s, 0) }
+func (z *Scalar) SetUint64(n uint64)     { z.i.SetUint64(n) }
+func (z *Scalar) SetInt64(n int64)       { z.i.SetInt64(n) }
+func (z *Scalar) SetZero()               { z.SetUint64(0) }
+func (z *Scalar) SetOne()                { z.SetUint64(1) }
+func (z *Scalar) IsZero() bool           { return z.i.Mod(&z.i, &primeOrder.i).Sign() == 0 }
+func (z *Scalar) IsEqual(x *Scalar) bool { return z.i.Cmp(&x.i) == 0 }
+func (z *Scalar) Neg()                   { z.i.Neg(&z.i).Mod(&z.i, &primeOrder.i) }
+func (z *Scalar) Add(x, y *Scalar)       { z.i.Add(&x.i, &y.i).Mod(&z.i, &primeOrder.i) }
+func (z *Scalar) Sub(x, y *Scalar)       { z.i.Sub(&x.i, &y.i).Mod(&z.i, &primeOrder.i) }
+func (z *Scalar) Mul(x, y *Scalar)       { z.i.Mul(&x.i, &y.i).Mod(&z.i, &primeOrder.i) }
+func (z *Scalar) Sqr(x *Scalar)          { z.i.Mul(&x.i, &x.i).Mod(&z.i, &primeOrder.i) }
+func (z *Scalar) Inv(x *Scalar)          { z.i.ModInverse(&x.i, &primeOrder.i) }
+func (z *Scalar) Random() {
+	r, err := rand.Int(rand.Reader, &primeOrder.i)
+	if err != nil {
+		panic(err)
+	}
+	z.i.Set(r)
+}
+
+// Bytes returns a positive scalar in a slice of bytes in little-endian order.
+func (z *Scalar) Bytes() []byte {
+	out := make([]byte, ScalarSize)
+	red := new(big.Int).Mod(&z.i, &primeOrder.i)
+	b := red.Bytes()
+	l := len(b)
+	for i := range b {
+		out[i] = b[l-1-i]
+	}
+	return out
+}

--- a/ecc/bls12381/scalar_test.go
+++ b/ecc/bls12381/scalar_test.go
@@ -1,0 +1,88 @@
+package bls12381
+
+import (
+	"testing"
+
+	"github.com/cloudflare/circl/internal/test"
+)
+
+func TestScalar(t *testing.T) {
+	const testTimes = 1 << 10
+	t.Run("no_alias", func(t *testing.T) {
+		var want, got Scalar
+		var x Scalar
+		x.Random()
+		got.Set(&x)
+		got.Sqr(&got)
+		want.Set(&x)
+		want.Mul(&want, &want)
+		if !got.IsEqual(&want) {
+			test.ReportError(t, got, want, x)
+		}
+	})
+	t.Run("mul_inv", func(t *testing.T) {
+		var x, y, z Scalar
+		for i := 0; i < testTimes; i++ {
+			x.Random()
+			y.Random()
+
+			// x*y*x^1 - y = 0
+			z.Inv(&x)
+			z.Mul(&z, &y)
+			z.Mul(&z, &x)
+			z.Sub(&z, &y)
+			got := z.IsZero()
+			want := true
+			if got != want {
+				test.ReportError(t, got, want, x, y)
+			}
+		}
+	})
+	t.Run("mul_sqr", func(t *testing.T) {
+		var x, y, l0, l1, r0, r1 Scalar
+		for i := 0; i < testTimes; i++ {
+			x.Random()
+			y.Random()
+
+			// (x+y)(x-y) = (x^2-y^2)
+			l0.Add(&x, &y)
+			l1.Sub(&x, &y)
+			l0.Mul(&l0, &l1)
+			r0.Sqr(&x)
+			r1.Sqr(&y)
+			r0.Sub(&r0, &r1)
+			got := &l0
+			want := &r0
+			if !got.IsEqual(want) {
+				test.ReportError(t, got, want, x, y)
+			}
+		}
+	})
+}
+
+func BenchmarkScalar(b *testing.B) {
+	var x, y, z Scalar
+	x.Random()
+	y.Random()
+	z.Random()
+	b.Run("Add", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			z.Add(&x, &y)
+		}
+	})
+	b.Run("Mul", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			z.Mul(&x, &y)
+		}
+	})
+	b.Run("Sqr", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			z.Sqr(&x)
+		}
+	})
+	b.Run("Inv", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			z.Inv(&x)
+		}
+	})
+}


### PR DESCRIPTION
Scalars are represented as a big.Int and can be converted to bytes in little-endian order. 