### PR TITLE
Hash to G1 using try-and-increment.

### DIFF
--- a/ecc/bls12381/ff/fp.go
+++ b/ecc/bls12381/ff/fp.go
@@ -4,18 +4,19 @@ import "math/big"
 
 type Fp struct{ i big.Int }
 
-func (z Fp) String() string      { return "0x" + z.i.Text(16) }
-func (z *Fp) Set(x *Fp)          { z.i.Set(&x.i) }
-func (z *Fp) SetString(s string) { z.i.SetString(s, 0) }
-func (z *Fp) SetUint64(n uint64) { z.i.SetUint64(n) }
-func (z *Fp) SetInt64(n int64)   { z.i.SetInt64(n) }
-func (z *Fp) SetZero()           { z.SetUint64(0) }
-func (z *Fp) SetOne()            { z.SetUint64(1) }
-func (z *Fp) IsZero() bool       { return z.i.Mod(&z.i, blsPrime).Sign() == 0 }
-func (z *Fp) IsEqual(x *Fp) bool { return z.i.Cmp(&x.i) == 0 }
-func (z *Fp) Neg()               { z.i.Neg(&z.i).Mod(&z.i, blsPrime) }
-func (z *Fp) Add(x, y *Fp)       { z.i.Add(&x.i, &y.i).Mod(&z.i, blsPrime) }
-func (z *Fp) Sub(x, y *Fp)       { z.i.Sub(&x.i, &y.i).Mod(&z.i, blsPrime) }
-func (z *Fp) Mul(x, y *Fp)       { z.i.Mul(&x.i, &y.i).Mod(&z.i, blsPrime) }
-func (z *Fp) Sqr(x *Fp)          { z.i.Mul(&x.i, &x.i).Mod(&z.i, blsPrime) }
-func (z *Fp) Inv(x *Fp)          { z.i.ModInverse(&x.i, blsPrime) }
+func (z Fp) String() string           { return "0x" + z.i.Text(16) }
+func (z *Fp) Set(x *Fp)               { z.i.Set(&x.i) }
+func (z *Fp) SetString(s string) bool { _, ok := z.i.SetString(s, 0); return ok }
+func (z *Fp) SetUint64(n uint64)      { z.i.SetUint64(n) }
+func (z *Fp) SetInt64(n int64)        { z.i.SetInt64(n) }
+func (z *Fp) SetZero()                { z.SetUint64(0) }
+func (z *Fp) SetOne()                 { z.SetUint64(1) }
+func (z *Fp) IsZero() bool            { return z.i.Mod(&z.i, blsPrime).Sign() == 0 }
+func (z *Fp) IsEqual(x *Fp) bool      { return z.i.Cmp(&x.i) == 0 }
+func (z *Fp) Neg()                    { z.i.Neg(&z.i).Mod(&z.i, blsPrime) }
+func (z *Fp) Add(x, y *Fp)            { z.i.Add(&x.i, &y.i).Mod(&z.i, blsPrime) }
+func (z *Fp) Sub(x, y *Fp)            { z.i.Sub(&x.i, &y.i).Mod(&z.i, blsPrime) }
+func (z *Fp) Mul(x, y *Fp)            { z.i.Mul(&x.i, &y.i).Mod(&z.i, blsPrime) }
+func (z *Fp) Sqr(x *Fp)               { z.i.Mul(&x.i, &x.i).Mod(&z.i, blsPrime) }
+func (z *Fp) Inv(x *Fp)               { z.i.ModInverse(&x.i, blsPrime) }
+func (z *Fp) Sqrt(x *Fp) (isQR bool)  { r := z.i.ModSqrt(&x.i, blsPrime); return r != nil }

--- a/ecc/bls12381/g1_test.go
+++ b/ecc/bls12381/g1_test.go
@@ -1,6 +1,7 @@
 package bls12381
 
 import (
+	"crypto/rand"
 	"testing"
 
 	"github.com/cloudflare/circl/internal/test"
@@ -50,6 +51,23 @@ func TestG1ScalarMult(t *testing.T) {
 		want := true
 		if got != want {
 			test.ReportError(t, got, want, P, k)
+		}
+	}
+}
+
+func TestG1Hash(t *testing.T) {
+	const testTimes = 1 << 6
+	var P G1
+	var msg, dst [4]byte
+	for i := 0; i < testTimes; i++ {
+		_, _ = rand.Read(msg[:])
+		_, _ = rand.Read(dst[:])
+		P.Hash(msg[:], dst[:])
+		got := P.IsOnCurve()
+		want := true
+
+		if got != want {
+			test.ReportError(t, got, want, msg, dst)
 		}
 	}
 }


### PR DESCRIPTION
This is a provisional (not-constant-time) method for hashing to G1.
A secure implementation must follow the guidelines of https://datatracker.ietf.org/doc/draft-irtf-cfrg-hash-to-curve/
