### PR TITLE
bls12: hash to G1 complaint with h2c draft

### DIFF
--- a/ecc/bls12381/constants.go
+++ b/ecc/bls12381/constants.go
@@ -9,34 +9,110 @@ type Scalar = ff.Scalar
 const ScalarSize = ff.ScalarSize
 
 var (
-	g1ParamB  = ff.Fp{ /*4*/ }  // 4
-	g1Param3B = ff.Fp{ /*12*/ } // 3*G1ParamB
-	g1GenX    = ff.Fp{
-		// 0xfb3af00adb22c6bb, 0x6c55e83ff97a1aef, 0xa14e3a3f171bac58,
-		// 0xc3688c4f9774b905, 0x2695638c4fa9ac0f, 0x17f1d3a73197d794,
+	g1Params struct{ b, _3b, genX, genY ff.Fp }
+	g2Params struct{ b, _3b, genX, genY ff.Fp2 }
+	g1Isog11 struct {
+		a, b, c2 ff.Fp
+		c1       [ff.FpSize]byte
+		cofactor Scalar
+		xNum     [12]ff.Fp
+		xDen     [11]ff.Fp
+		yNum     [16]ff.Fp
+		yDen     [16]ff.Fp
 	}
-	g1GenY = ff.Fp{
-		// 0xcaa232946c5e7e1, 0xd03cc744a2888ae4, 0xdb18cb2c04b3ed,
-		// 0xfcf5e095d5d00af6, 0xa09e30ed741d8ae4, 0x8b3f481e3aaa0f1,
-	}
-	g2ParamB  = ff.Fp2{}
-	g2Param3B = ff.Fp2{}
-	g2GenX    = ff.Fp2{}
-	g2GenY    = ff.Fp2{}
 )
 
-func init() {
-	g1ParamB.SetUint64(4)
-	g1Param3B.SetUint64(12)
-	_ = g1GenX.SetString("0x17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb")
-	_ = g1GenY.SetString("0x08b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1")
+func err(e error) {
+	if e != nil {
+		panic(e)
+	}
+}
 
-	g2ParamB[0].SetUint64(4)
-	g2ParamB[1].SetUint64(4)
-	g2Param3B[0].SetUint64(12)
-	g2Param3B[1].SetUint64(12)
-	_ = g2GenX[0].SetString("0x024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8")
-	_ = g2GenX[1].SetString("0x13e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e")
-	_ = g2GenY[0].SetString("0x0ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801")
-	_ = g2GenY[1].SetString("0x0606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be")
+func init() {
+	g1Params.b.SetUint64(4)
+	g1Params._3b.SetUint64(12)
+	err(g1Params.genX.SetString("0x17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"))
+	err(g1Params.genY.SetString("0x08b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e1"))
+
+	g2Params.b[0].SetUint64(4)
+	g2Params.b[1].SetUint64(4)
+	g2Params._3b[0].SetUint64(12)
+	g2Params._3b[1].SetUint64(12)
+	err(g2Params.genX[0].SetString("0x024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8"))
+	err(g2Params.genX[1].SetString("0x13e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e"))
+	err(g2Params.genY[0].SetString("0x0ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801"))
+	err(g2Params.genY[1].SetString("0x0606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be"))
+
+	g1Isog11.c1 = [ff.FpSize]byte{
+		0xaa, 0xea, 0xff, 0xff, 0xff, 0xbf, 0x7f, 0xee,
+		0xff, 0xff, 0x54, 0xac, 0xff, 0xff, 0xaa, 0x07,
+		0x89, 0x3d, 0xac, 0x3d, 0xa8, 0x34, 0xcc, 0xd9,
+		0xaf, 0x44, 0xe1, 0x3c, 0xe1, 0xd2, 0x1d, 0xd9,
+		0x35, 0xeb, 0xd2, 0x90, 0xed, 0xe9, 0xc6, 0x92,
+		0xa6, 0xf9, 0x5f, 0x8e, 0x7a, 0x44, 0x80, 0x06,
+	}
+
+	err(g1Isog11.cofactor.SetString("0xd201000000010001"))
+	err(g1Isog11.a.SetString("0x144698a3b8e9433d693a02c96d4982b0ea985383ee66a8d8e8981aefd881ac98936f8da0e0f97f5cf428082d584c1d"))
+	err(g1Isog11.b.SetString("0x12e2908d11688030018b12e8753eee3b2016c1f0f24f4070a0b9c14fcef35ef55a23215a316ceaa5d1cc48e98e172be0"))
+	err(g1Isog11.c2.SetString("0x3d689d1e0e762cef9f2bec6130316806b4c80eda6fc10ce77ae83eab1ea8b8b8a407c9c6db195e06f2dbeabc2baeff5"))
+
+	err(g1Isog11.xNum[0].SetString("0x11a05f2b1e833340b809101dd99815856b303e88a2d7005ff2627b56cdb4e2c85610c2d5f2e62d6eaeac1662734649b7"))
+	err(g1Isog11.xNum[1].SetString("0x17294ed3e943ab2f0588bab22147a81c7c17e75b2f6a8417f565e33c70d1e86b4838f2a6f318c356e834eef1b3cb83bb"))
+	err(g1Isog11.xNum[2].SetString("0x0d54005db97678ec1d1048c5d10a9a1bce032473295983e56878e501ec68e25c958c3e3d2a09729fe0179f9dac9edcb0"))
+	err(g1Isog11.xNum[3].SetString("0x1778e7166fcc6db74e0609d307e55412d7f5e4656a8dbf25f1b33289f1b330835336e25ce3107193c5b388641d9b6861"))
+	err(g1Isog11.xNum[4].SetString("0x0e99726a3199f4436642b4b3e4118e5499db995a1257fb3f086eeb65982fac18985a286f301e77c451154ce9ac8895d9"))
+	err(g1Isog11.xNum[5].SetString("0x1630c3250d7313ff01d1201bf7a74ab5db3cb17dd952799b9ed3ab9097e68f90a0870d2dcae73d19cd13c1c66f652983"))
+	err(g1Isog11.xNum[6].SetString("0x0d6ed6553fe44d296a3726c38ae652bfb11586264f0f8ce19008e218f9c86b2a8da25128c1052ecaddd7f225a139ed84"))
+	err(g1Isog11.xNum[7].SetString("0x17b81e7701abdbe2e8743884d1117e53356de5ab275b4db1a682c62ef0f2753339b7c8f8c8f475af9ccb5618e3f0c88e"))
+	err(g1Isog11.xNum[8].SetString("0x080d3cf1f9a78fc47b90b33563be990dc43b756ce79f5574a2c596c928c5d1de4fa295f296b74e956d71986a8497e317"))
+	err(g1Isog11.xNum[9].SetString("0x169b1f8e1bcfa7c42e0c37515d138f22dd2ecb803a0c5c99676314baf4bb1b7fa3190b2edc0327797f241067be390c9e"))
+	err(g1Isog11.xNum[10].SetString("0x10321da079ce07e272d8ec09d2565b0dfa7dccdde6787f96d50af36003b14866f69b771f8c285decca67df3f1605fb7b"))
+	err(g1Isog11.xNum[11].SetString("0x06e08c248e260e70bd1e962381edee3d31d79d7e22c837bc23c0bf1bc24c6b68c24b1b80b64d391fa9c8ba2e8ba2d229"))
+
+	err(g1Isog11.xDen[0].SetString("0x08ca8d548cff19ae18b2e62f4bd3fa6f01d5ef4ba35b48ba9c9588617fc8ac62b558d681be343df8993cf9fa40d21b1c"))
+	err(g1Isog11.xDen[1].SetString("0x12561a5deb559c4348b4711298e536367041e8ca0cf0800c0126c2588c48bf5713daa8846cb026e9e5c8276ec82b3bff"))
+	err(g1Isog11.xDen[2].SetString("0x0b2962fe57a3225e8137e629bff2991f6f89416f5a718cd1fca64e00b11aceacd6a3d0967c94fedcfcc239ba5cb83e19"))
+	err(g1Isog11.xDen[3].SetString("0x03425581a58ae2fec83aafef7c40eb545b08243f16b1655154cca8abc28d6fd04976d5243eecf5c4130de8938dc62cd8"))
+	err(g1Isog11.xDen[4].SetString("0x13a8e162022914a80a6f1d5f43e7a07dffdfc759a12062bb8d6b44e833b306da9bd29ba81f35781d539d395b3532a21e"))
+	err(g1Isog11.xDen[5].SetString("0x0e7355f8e4e667b955390f7f0506c6e9395735e9ce9cad4d0a43bcef24b8982f7400d24bc4228f11c02df9a29f6304a5"))
+	err(g1Isog11.xDen[6].SetString("0x0772caacf16936190f3e0c63e0596721570f5799af53a1894e2e073062aede9cea73b3538f0de06cec2574496ee84a3a"))
+	err(g1Isog11.xDen[7].SetString("0x14a7ac2a9d64a8b230b3f5b074cf01996e7f63c21bca68a81996e1cdf9822c580fa5b9489d11e2d311f7d99bbdcc5a5e"))
+	err(g1Isog11.xDen[8].SetString("0x0a10ecf6ada54f825e920b3dafc7a3cce07f8d1d7161366b74100da67f39883503826692abba43704776ec3a79a1d641"))
+	err(g1Isog11.xDen[9].SetString("0x095fc13ab9e92ad4476d6e3eb3a56680f682b4ee96f7d03776df533978f31c1593174e4b4b7865002d6384d168ecdd0a"))
+	g1Isog11.xDen[10].SetOne()
+
+	err(g1Isog11.yNum[0].SetString("0x090d97c81ba24ee0259d1f094980dcfa11ad138e48a869522b52af6c956543d3cd0c7aee9b3ba3c2be9845719707bb33"))
+	err(g1Isog11.yNum[1].SetString("0x134996a104ee5811d51036d776fb46831223e96c254f383d0f906343eb67ad34d6c56711962fa8bfe097e75a2e41c696"))
+	err(g1Isog11.yNum[2].SetString("0x00cc786baa966e66f4a384c86a3b49942552e2d658a31ce2c344be4b91400da7d26d521628b00523b8dfe240c72de1f6"))
+	err(g1Isog11.yNum[3].SetString("0x01f86376e8981c217898751ad8746757d42aa7b90eeb791c09e4a3ec03251cf9de405aba9ec61deca6355c77b0e5f4cb"))
+	err(g1Isog11.yNum[4].SetString("0x08cc03fdefe0ff135caf4fe2a21529c4195536fbe3ce50b879833fd221351adc2ee7f8dc099040a841b6daecf2e8fedb"))
+	err(g1Isog11.yNum[5].SetString("0x16603fca40634b6a2211e11db8f0a6a074a7d0d4afadb7bd76505c3d3ad5544e203f6326c95a807299b23ab13633a5f0"))
+	err(g1Isog11.yNum[6].SetString("0x04ab0b9bcfac1bbcb2c977d027796b3ce75bb8ca2be184cb5231413c4d634f3747a87ac2460f415ec961f8855fe9d6f2"))
+	err(g1Isog11.yNum[7].SetString("0x0987c8d5333ab86fde9926bd2ca6c674170a05bfe3bdd81ffd038da6c26c842642f64550fedfe935a15e4ca31870fb29"))
+	err(g1Isog11.yNum[8].SetString("0x09fc4018bd96684be88c9e221e4da1bb8f3abd16679dc26c1e8b6e6a1f20cabe69d65201c78607a360370e577bdba587"))
+	err(g1Isog11.yNum[9].SetString("0x0e1bba7a1186bdb5223abde7ada14a23c42a0ca7915af6fe06985e7ed1e4d43b9b3f7055dd4eba6f2bafaaebca731c30"))
+	err(g1Isog11.yNum[10].SetString("0x19713e47937cd1be0dfd0b8f1d43fb93cd2fcbcb6caf493fd1183e416389e61031bf3a5cce3fbafce813711ad011c132"))
+	err(g1Isog11.yNum[11].SetString("0x18b46a908f36f6deb918c143fed2edcc523559b8aaf0c2462e6bfe7f911f643249d9cdf41b44d606ce07c8a4d0074d8e"))
+	err(g1Isog11.yNum[12].SetString("0x0b182cac101b9399d155096004f53f447aa7b12a3426b08ec02710e807b4633f06c851c1919211f20d4c04f00b971ef8"))
+	err(g1Isog11.yNum[13].SetString("0x0245a394ad1eca9b72fc00ae7be315dc757b3b080d4c158013e6632d3c40659cc6cf90ad1c232a6442d9d3f5db980133"))
+	err(g1Isog11.yNum[14].SetString("0x05c129645e44cf1102a159f748c4a3fc5e673d81d7e86568d9ab0f5d396a7ce46ba1049b6579afb7866b1e715475224b"))
+	err(g1Isog11.yNum[15].SetString("0x15e6be4e990f03ce4ea50b3b42df2eb5cb181d8f84965a3957add4fa95af01b2b665027efec01c7704b456be69c8b604"))
+
+	err(g1Isog11.yDen[0].SetString("0x16112c4c3a9c98b252181140fad0eae9601a6de578980be6eec3232b5be72e7a07f3688ef60c206d01479253b03663c1"))
+	err(g1Isog11.yDen[1].SetString("0x1962d75c2381201e1a0cbd6c43c348b885c84ff731c4d59ca4a10356f453e01f78a4260763529e3532f6102c2e49a03d"))
+	err(g1Isog11.yDen[2].SetString("0x058df3306640da276faaae7d6e8eb15778c4855551ae7f310c35a5dd279cd2eca6757cd636f96f891e2538b53dbf67f2"))
+	err(g1Isog11.yDen[3].SetString("0x16b7d288798e5395f20d23bf89edb4d1d115c5dbddbcd30e123da489e726af41727364f2c28297ada8d26d98445f5416"))
+	err(g1Isog11.yDen[4].SetString("0x0be0e079545f43e4b00cc912f8228ddcc6d19c9f0f69bbb0542eda0fc9dec916a20b15dc0fd2ededda39142311a5001d"))
+	err(g1Isog11.yDen[5].SetString("0x08d9e5297186db2d9fb266eaac783182b70152c65550d881c5ecd87b6f0f5a6449f38db9dfa9cce202c6477faaf9b7ac"))
+	err(g1Isog11.yDen[6].SetString("0x166007c08a99db2fc3ba8734ace9824b5eecfdfa8d0cf8ef5dd365bc400a0051d5fa9c01a58b1fb93d1a1399126a775c"))
+	err(g1Isog11.yDen[7].SetString("0x16a3ef08be3ea7ea03bcddfabba6ff6ee5a4375efa1f4fd7feb34fd206357132b920f5b00801dee460ee415a15812ed9"))
+	err(g1Isog11.yDen[8].SetString("0x1866c8ed336c61231a1be54fd1d74cc4f9fb0ce4c6af5920abc5750c4bf39b4852cfe2f7bb9248836b233d9d55535d4a"))
+	err(g1Isog11.yDen[9].SetString("0x167a55cda70a6e1cea820597d94a84903216f763e13d87bb5308592e7ea7d4fbc7385ea3d529b35e346ef48bb8913f55"))
+	err(g1Isog11.yDen[10].SetString("0x04d2f259eea405bd48f010a01ad2911d9c6dd039bb61a6290e591b36e636a5c871a5c29f4f83060400f8b49cba8f6aa8"))
+	err(g1Isog11.yDen[11].SetString("0x0accbb67481d033ff5852c1e48c50c477f94ff8aefce42d28c0f9a88cea7913516f968986f7ebbea9684b529e2561092"))
+	err(g1Isog11.yDen[12].SetString("0x0ad6b9514c767fe3c3613144b45f1496543346d98adf02267d5ceef9a00d9b8693000763e3b90ac11e99b138573345cc"))
+	err(g1Isog11.yDen[13].SetString("0x02660400eb2e4f3b628bdd0d53cd76f2bf565b94e72927c1cb748df27942480e420517bd8714cc80d1fadc1326ed06f7"))
+	err(g1Isog11.yDen[14].SetString("0x0e0fa1d816ddc03e6b24255e0d7819c171c40f65e273b853324efcd6356caa205ca2f570f13497804415473a1d634b8f"))
+	g1Isog11.yDen[15].SetOne()
 }

--- a/ecc/bls12381/ec2.go
+++ b/ecc/bls12381/ec2.go
@@ -12,7 +12,7 @@ func doubleAndLine(P *G2, l *line) {
 	X, Y, Z := &P.x, &P.y, &P.z
 	X3, Y3, Z3 := &R.x, &R.y, &R.z
 	isDoubLine := l != nil
-	_3B := &g2Param3B
+	_3B := &g2Params._3b
 	var A, B, C, D, E, F, G, T ff.Fp2
 	B.Sqr(Y)       // 1. B = Y1^2
 	C.Sqr(Z)       // 2. C = Z1^2
@@ -62,7 +62,7 @@ func addAndLine(PQ, P, Q *G2, l *line) {
 	X1, Y1, Z1 := &P.x, &P.y, &P.z
 	X2, Y2, Z2 := &Q.x, &Q.y, &Q.z
 	X3, Y3, Z3 := &R.x, &R.y, &R.z
-	_3B := &g2Param3B
+	_3B := &g2Params._3b
 	isAddLine := l != nil
 	var X1X2, Y1Y2, Z1Z2, _3bZ1Z2 ff.Fp2
 	var A, B, C, D, E, F, G ff.Fp2

--- a/ecc/bls12381/ff/common.go
+++ b/ecc/bls12381/ff/common.go
@@ -26,6 +26,9 @@ func setString(out []uint64, in string, order []byte) error {
 	if !ok {
 		return errors.New("invalid string")
 	}
+	if inBig.Cmp(conv.BytesLe2BigInt(order)) >= 0 {
+		return errors.New("value out of [0,order)")
+	}
 	inBytes := make([]byte, len(order))
 	conv.BigInt2BytesLe(inBytes, inBig)
 	return setBytes(out, inBytes, order)

--- a/ecc/bls12381/ff/cyclo6.go
+++ b/ecc/bls12381/ff/cyclo6.go
@@ -8,8 +8,8 @@ type Cyclo6 Fp12
 func (z Cyclo6) String() string { return (Fp12)(z).String() }
 
 func (z *Cyclo6) Set(x *Cyclo6)                  { (*Fp12)(z).Set((*Fp12)(x)) }
-func (z Cyclo6) IsEqual(x *Cyclo6) bool          { return (Fp12)(z).IsEqual((*Fp12)(x)) }
-func (z Cyclo6) IsIdentity() bool                { i := &Fp12{}; i.SetOne(); return z.IsEqual((*Cyclo6)(i)) }
+func (z Cyclo6) IsEqual(x *Cyclo6) int           { return (Fp12)(z).IsEqual((*Fp12)(x)) }
+func (z Cyclo6) IsIdentity() int                 { i := &Fp12{}; i.SetOne(); return z.IsEqual((*Cyclo6)(i)) }
 func (z *Cyclo6) Frob(x *Cyclo6)                 { (*Fp12)(z).Frob((*Fp12)(x)) }
 func (z *Cyclo6) Mul(x, y *Cyclo6)               { (*Fp12)(z).Mul((*Fp12)(x), (*Fp12)(y)) }
 func (z *Cyclo6) Sqr(x *Cyclo6)                  { (*Fp12)(z).Sqr((*Fp12)(x)) }

--- a/ecc/bls12381/ff/cyclo6_test.go
+++ b/ecc/bls12381/ff/cyclo6_test.go
@@ -34,7 +34,7 @@ func TestCyclo6(t *testing.T) {
 		got.Sqr(&got)
 		want.Set(x)
 		want.Mul(&want, &want)
-		if !got.IsEqual(&want) {
+		if got.IsEqual(&want) == 0 {
 			test.ReportError(t, got, want, x)
 		}
 	})
@@ -50,7 +50,7 @@ func TestCyclo6(t *testing.T) {
 
 			// x^phi6primeSq = 1
 			got := z.IsIdentity()
-			want := true
+			want := 1
 			if got != want {
 				test.ReportError(t, got, want, x, z)
 			}
@@ -68,7 +68,7 @@ func TestCyclo6(t *testing.T) {
 			z.Mul(&z, x)
 			got := z
 			want := y
-			if !got.IsEqual(want) {
+			if got.IsEqual(want) == 0 {
 				test.ReportError(t, got, want, x, y)
 			}
 		}
@@ -81,7 +81,7 @@ func TestCyclo6(t *testing.T) {
 			// x*x = x^2
 			got.Mul(x, x)
 			want.Sqr(x)
-			if !got.IsEqual(&want) {
+			if got.IsEqual(&want) == 0 {
 				test.ReportError(t, got, want, x)
 			}
 		}
@@ -97,7 +97,7 @@ func TestCyclo6(t *testing.T) {
 			got = (Fp12)(y)
 			want.Inv((*Fp12)(x))
 
-			if !got.IsEqual(&want) {
+			if got.IsEqual(&want) == 0 {
 				test.ReportError(t, got, want, x)
 			}
 		}

--- a/ecc/bls12381/ff/fp12.go
+++ b/ecc/bls12381/ff/fp12.go
@@ -13,16 +13,16 @@ func (z *Fp12) Set(x *Fp12)   { z[0].Set(&x[0]); z[1].Set(&x[1]) }
 func (z *Fp12) SetBytes(b []byte) error {
 	return errFirst(z[0].SetBytes(b[:Fp6Size]), z[1].SetBytes(b[Fp6Size:2*Fp6Size]))
 }
-func (z Fp12) Bytes() []byte        { return append(z[0].Bytes(), z[1].Bytes()...) }
-func (z *Fp12) SetOne()             { z[0].SetOne(); z[1] = Fp6{} }
-func (z Fp12) IsZero() bool         { return z.IsEqual(&Fp12{}) }
-func (z Fp12) IsEqual(x *Fp12) bool { return z[0].IsEqual(&x[0]) && z[1].IsEqual(&x[1]) }
-func (z *Fp12) MulBeta()            { var t Fp6; t.Set(&z[0]); z[0].Sub(&z[0], &z[1]); z[1].Add(&t, &z[1]) }
-func (z *Fp12) Frob(x *Fp12)        { z[0].Frob(&x[0]); z[1].Frob(&x[1]); z[1].Mul(&z[1], &Fp6{frob12W1}) }
-func (z *Fp12) Cjg()                { z[1].Neg() }
-func (z *Fp12) Neg()                { z[0].Neg(); z[1].Neg() }
-func (z *Fp12) Add(x, y *Fp12)      { z[0].Add(&x[0], &y[0]); z[1].Add(&x[1], &y[1]) }
-func (z *Fp12) Sub(x, y *Fp12)      { z[0].Sub(&x[0], &y[0]); z[1].Sub(&x[1], &y[1]) }
+func (z Fp12) Bytes() []byte       { return append(z[0].Bytes(), z[1].Bytes()...) }
+func (z *Fp12) SetOne()            { z[0].SetOne(); z[1] = Fp6{} }
+func (z Fp12) IsZero() int         { return z.IsEqual(&Fp12{}) }
+func (z Fp12) IsEqual(x *Fp12) int { return z[0].IsEqual(&x[0]) & z[1].IsEqual(&x[1]) }
+func (z *Fp12) MulBeta()           { var t Fp6; t.Set(&z[0]); z[0].Sub(&z[0], &z[1]); z[1].Add(&t, &z[1]) }
+func (z *Fp12) Frob(x *Fp12)       { z[0].Frob(&x[0]); z[1].Frob(&x[1]); z[1].Mul(&z[1], &Fp6{frob12W1}) }
+func (z *Fp12) Cjg()               { z[1].Neg() }
+func (z *Fp12) Neg()               { z[0].Neg(); z[1].Neg() }
+func (z *Fp12) Add(x, y *Fp12)     { z[0].Add(&x[0], &y[0]); z[1].Add(&x[1], &y[1]) }
+func (z *Fp12) Sub(x, y *Fp12)     { z[0].Sub(&x[0], &y[0]); z[1].Sub(&x[1], &y[1]) }
 func (z *Fp12) Mul(x, y *Fp12) {
 	var x0y0, x1y1, sx, sy, k Fp6
 	x0y0.Mul(&x[0], &y[0])

--- a/ecc/bls12381/ff/fp12_test.go
+++ b/ecc/bls12381/ff/fp12_test.go
@@ -9,7 +9,7 @@ import (
 func randomFp12(t testing.TB) *Fp12 { return &Fp12{*randomFp6(t), *randomFp6(t)} }
 
 func TestFp12(t *testing.T) {
-	const testTimes = 1 << 9
+	const testTimes = 1 << 8
 	t.Run("no_alias", func(t *testing.T) {
 		var want, got Fp12
 		x := randomFp12(t)
@@ -17,7 +17,7 @@ func TestFp12(t *testing.T) {
 		got.Sqr(&got)
 		want.Set(x)
 		want.Mul(&want, &want)
-		if !got.IsEqual(&want) {
+		if got.IsEqual(&want) == 0 {
 			test.ReportError(t, got, want, x)
 		}
 	})
@@ -33,7 +33,7 @@ func TestFp12(t *testing.T) {
 			z.Mul(&z, x)
 			z.Sub(&z, y)
 			got := z.IsZero()
-			want := true
+			want := 1
 			if got != want {
 				test.ReportError(t, got, want, x, y)
 			}
@@ -54,7 +54,7 @@ func TestFp12(t *testing.T) {
 			r0.Sub(&r0, &r1)
 			got := &l0
 			want := &r0
-			if !got.IsEqual(want) {
+			if got.IsEqual(want) == 0 {
 				test.ReportError(t, got, want, x, y)
 			}
 		}
@@ -66,7 +66,7 @@ func TestFp12(t *testing.T) {
 			s := a.Bytes()
 			err := b.SetBytes(s)
 			test.CheckNoErr(t, err, "setbytes failed")
-			if !b.IsEqual(a) {
+			if b.IsEqual(a) == 0 {
 				test.ReportError(t, a, b)
 			}
 		}
@@ -81,7 +81,7 @@ func TestFp12(t *testing.T) {
 			got.Frob(x)
 			want.ExpVarTime(x, p)
 
-			if !got.IsEqual(&want) {
+			if got.IsEqual(&want) == 0 {
 				test.ReportError(t, got, want, x)
 			}
 		}

--- a/ecc/bls12381/ff/fp2.go
+++ b/ecc/bls12381/ff/fp2.go
@@ -12,16 +12,16 @@ func (z *Fp2) Set(x *Fp2)    { z[0].Set(&x[0]); z[1].Set(&x[1]) }
 func (z *Fp2) SetBytes(b []byte) error {
 	return errFirst(z[0].SetBytes(b[:FpSize]), z[1].SetBytes(b[FpSize:2*FpSize]))
 }
-func (z Fp2) Bytes() []byte       { return append(z[0].Bytes(), z[1].Bytes()...) }
-func (z *Fp2) SetOne()            { z[0].SetOne(); z[1] = Fp{} }
-func (z Fp2) IsZero() bool        { return z.IsEqual(&Fp2{}) }
-func (z Fp2) IsEqual(x *Fp2) bool { return z[0].IsEqual(&x[0]) && z[1].IsEqual(&x[1]) }
-func (z *Fp2) MulBeta()           { var t Fp; t.Set(&z[0]); z[0].Sub(&z[0], &z[1]); z[1].Add(&t, &z[1]) }
-func (z *Fp2) Frob(x *Fp2)        { z.Set(x); z.Cjg() }
-func (z *Fp2) Cjg()               { z[1].Neg() }
-func (z *Fp2) Neg()               { z[0].Neg(); z[1].Neg() }
-func (z *Fp2) Add(x, y *Fp2)      { z[0].Add(&x[0], &y[0]); z[1].Add(&x[1], &y[1]) }
-func (z *Fp2) Sub(x, y *Fp2)      { z[0].Sub(&x[0], &y[0]); z[1].Sub(&x[1], &y[1]) }
+func (z Fp2) Bytes() []byte      { return append(z[0].Bytes(), z[1].Bytes()...) }
+func (z *Fp2) SetOne()           { z[0].SetOne(); z[1] = Fp{} }
+func (z Fp2) IsZero() int        { return z.IsEqual(&Fp2{}) }
+func (z Fp2) IsEqual(x *Fp2) int { return z[0].IsEqual(&x[0]) & z[1].IsEqual(&x[1]) }
+func (z *Fp2) MulBeta()          { var t Fp; t.Set(&z[0]); z[0].Sub(&z[0], &z[1]); z[1].Add(&t, &z[1]) }
+func (z *Fp2) Frob(x *Fp2)       { z.Set(x); z.Cjg() }
+func (z *Fp2) Cjg()              { z[1].Neg() }
+func (z *Fp2) Neg()              { z[0].Neg(); z[1].Neg() }
+func (z *Fp2) Add(x, y *Fp2)     { z[0].Add(&x[0], &y[0]); z[1].Add(&x[1], &y[1]) }
+func (z *Fp2) Sub(x, y *Fp2)     { z[0].Sub(&x[0], &y[0]); z[1].Sub(&x[1], &y[1]) }
 func (z *Fp2) Mul(x, y *Fp2) {
 	var x0y0, x1y1, sx, sy, k Fp
 	x0y0.Mul(&x[0], &y[0])

--- a/ecc/bls12381/ff/fp2_test.go
+++ b/ecc/bls12381/ff/fp2_test.go
@@ -17,7 +17,7 @@ func TestFp2(t *testing.T) {
 		got.Sqr(&got)
 		want.Set(x)
 		want.Mul(&want, &want)
-		if !got.IsEqual(&want) {
+		if got.IsEqual(&want) == 0 {
 			test.ReportError(t, got, want, x)
 		}
 	})
@@ -33,7 +33,7 @@ func TestFp2(t *testing.T) {
 			z.Mul(&z, x)
 			z.Sub(&z, y)
 			got := z.IsZero()
-			want := true
+			want := 1
 			if got != want {
 				test.ReportError(t, got, want, x, y, z)
 			}
@@ -54,7 +54,7 @@ func TestFp2(t *testing.T) {
 			r0.Sub(&r0, &r1)
 			got := &l0
 			want := &r0
-			if !got.IsEqual(want) {
+			if got.IsEqual(want) == 0 {
 				test.ReportError(t, got, want, x, y)
 			}
 		}
@@ -66,7 +66,7 @@ func TestFp2(t *testing.T) {
 			s := a.Bytes()
 			err := b.SetBytes(s)
 			test.CheckNoErr(t, err, "setbytes failed")
-			if !b.IsEqual(a) {
+			if b.IsEqual(a) == 0 {
 				test.ReportError(t, a, b)
 			}
 		}

--- a/ecc/bls12381/ff/fp6.go
+++ b/ecc/bls12381/ff/fp6.go
@@ -9,6 +9,7 @@ type Fp6 [3]Fp2
 
 func (z Fp6) String() string { return fmt.Sprintf("\n0: %v\n1: %v\n2: %v", z[0], z[1], z[2]) }
 func (z *Fp6) Set(x *Fp6)    { z[0].Set(&x[0]); z[1].Set(&x[1]); z[2].Set(&x[2]) }
+func (z *Fp6) SetOne()       { z[0].SetOne(); z[1] = Fp2{}; z[2] = Fp2{} }
 func (z Fp6) Bytes() []byte  { return append(append(z[0].Bytes(), z[1].Bytes()...), z[2].Bytes()...) }
 func (z *Fp6) SetBytes(b []byte) error {
 	return errFirst(
@@ -17,10 +18,9 @@ func (z *Fp6) SetBytes(b []byte) error {
 		z[2].SetBytes(b[2*Fp2Size:3*Fp2Size]),
 	)
 }
-func (z *Fp6) SetOne()     { z[0].SetOne(); z[1] = Fp2{}; z[2] = Fp2{} }
-func (z Fp6) IsZero() bool { return z.IsEqual(&Fp6{}) }
-func (z Fp6) IsEqual(x *Fp6) bool {
-	return z[0].IsEqual(&x[0]) && z[1].IsEqual(&x[1]) && z[2].IsEqual(&x[2])
+func (z Fp6) IsZero() int { return z.IsEqual(&Fp6{}) }
+func (z Fp6) IsEqual(x *Fp6) int {
+	return z[0].IsEqual(&x[0]) & z[1].IsEqual(&x[1]) & z[2].IsEqual(&x[2])
 }
 func (z *Fp6) Neg()          { z[0].Neg(); z[1].Neg(); z[2].Neg() }
 func (z *Fp6) Add(x, y *Fp6) { z[0].Add(&x[0], &y[0]); z[1].Add(&x[1], &y[1]); z[2].Add(&x[2], &y[2]) }

--- a/ecc/bls12381/ff/fp6_test.go
+++ b/ecc/bls12381/ff/fp6_test.go
@@ -30,7 +30,7 @@ func TestFp6(t *testing.T) {
 		got.Sqr(&got)
 		want.Set(x)
 		want.Mul(&want, &want)
-		if !got.IsEqual(&want) {
+		if got.IsEqual(&want) == 0 {
 			test.ReportError(t, got, want, x)
 		}
 	})
@@ -46,7 +46,7 @@ func TestFp6(t *testing.T) {
 			z.Mul(&z, x)
 			z.Sub(&z, y)
 			got := z.IsZero()
-			want := true
+			want := 1
 			if got != want {
 				test.ReportError(t, got, want, x, y)
 			}
@@ -67,7 +67,7 @@ func TestFp6(t *testing.T) {
 			r0.Sub(&r0, &r1)
 			got := &l0
 			want := &r0
-			if !got.IsEqual(want) {
+			if got.IsEqual(want) == 0 {
 				test.ReportError(t, got, want, x, y)
 			}
 		}
@@ -82,7 +82,7 @@ func TestFp6(t *testing.T) {
 			got.Frob(x)
 			expVarTime(&want, x, p)
 
-			if !got.IsEqual(&want) {
+			if got.IsEqual(&want) == 0 {
 				test.ReportError(t, got, want, x)
 			}
 		}

--- a/ecc/bls12381/ff/fp_test.go
+++ b/ecc/bls12381/ff/fp_test.go
@@ -26,7 +26,7 @@ func TestFp(t *testing.T) {
 		got.Sqr(&got)
 		want.Set(x)
 		want.Mul(&want, &want)
-		if !got.IsEqual(&want) {
+		if got.IsEqual(&want) == 0 {
 			test.ReportError(t, got, want, x)
 		}
 	})
@@ -42,7 +42,7 @@ func TestFp(t *testing.T) {
 			z.Mul(&z, x)
 			z.Sub(&z, y)
 			got := z.IsZero()
-			want := true
+			want := 1
 			if got != want {
 				test.ReportError(t, got, want, x, y)
 			}
@@ -63,7 +63,7 @@ func TestFp(t *testing.T) {
 			r0.Sub(&r0, &r1)
 			got := &l0
 			want := &r0
-			if !got.IsEqual(want) {
+			if got.IsEqual(want) == 0 {
 				test.ReportError(t, got, want, x, y)
 			}
 		}
@@ -75,7 +75,7 @@ func TestFp(t *testing.T) {
 			s := a.Bytes()
 			err := b.SetBytes(s)
 			test.CheckNoErr(t, err, "setbytes failed")
-			if !b.IsEqual(a) {
+			if b.IsEqual(a) == 0 {
 				test.ReportError(t, a, b)
 			}
 		}

--- a/ecc/bls12381/ff/scalar.go
+++ b/ecc/bls12381/ff/scalar.go
@@ -25,8 +25,8 @@ func (z *Scalar) SetUint64(n uint64)       { z.toMont(&scRaw{n}) }
 func (z *Scalar) SetInt64(n int64)         { z.SetUint64(uint64(-n)); z.Neg() }
 func (z *Scalar) SetOne()                  { z.SetUint64(1) }
 func (z *Scalar) Random(r io.Reader) error { return randomInt(z.i[:], r, scOrder[:]) }
-func (z Scalar) IsZero() bool              { return z.IsEqual(&Scalar{}) }
-func (z Scalar) IsEqual(x *Scalar) bool    { return ctUint64Eq(z.i[:], x.i[:]) == 1 }
+func (z Scalar) IsZero() int               { return z.IsEqual(&Scalar{}) }
+func (z Scalar) IsEqual(x *Scalar) int     { return ctUint64Eq(z.i[:], x.i[:]) }
 func (z *Scalar) Neg()                     { fiatScMontSub(&z.i, &scMont{}, &z.i) }
 func (z *Scalar) Add(x, y *Scalar)         { fiatScMontAdd(&z.i, &x.i, &y.i) }
 func (z *Scalar) Sub(x, y *Scalar)         { fiatScMontSub(&z.i, &x.i, &y.i) }
@@ -59,7 +59,7 @@ func (z *Scalar) expVarTime(x *Scalar, n []byte) {
 // to ScalarOrder-1.
 func (z *Scalar) SetBytes(data []byte) error {
 	in64 := &scRaw{}
-	err := setBytes(in64[:], data[:ScalarSize], scOrder[:])
+	err := setBytes(in64[:], data, scOrder[:])
 	if err == nil {
 		z.toMont(in64)
 	}

--- a/ecc/bls12381/ff/scalar_test.go
+++ b/ecc/bls12381/ff/scalar_test.go
@@ -29,7 +29,7 @@ func TestScalar(t *testing.T) {
 			if err != nil {
 				test.ReportError(t, x, y, x)
 			}
-			if !x.IsEqual(&y) {
+			if x.IsEqual(&y) == 0 {
 				test.ReportError(t, x, y, x)
 			}
 		}
@@ -42,7 +42,7 @@ func TestScalar(t *testing.T) {
 		got.Sqr(&got)
 		want.Set(x)
 		want.Mul(&want, &want)
-		if !got.IsEqual(&want) {
+		if got.IsEqual(&want) == 0 {
 			test.ReportError(t, got, want, x)
 		}
 	})
@@ -57,7 +57,7 @@ func TestScalar(t *testing.T) {
 			z.Mul(&z, x)
 			z.Sub(&z, y)
 			got := z.IsZero()
-			want := true
+			want := 1
 			if got != want {
 				test.ReportError(t, got, want, x, y)
 			}
@@ -78,7 +78,7 @@ func TestScalar(t *testing.T) {
 			r0.Sub(&r0, &r1)
 			got := &l0
 			want := &r0
-			if !got.IsEqual(want) {
+			if got.IsEqual(want) == 0 {
 				test.ReportError(t, got, want, x, y)
 			}
 		}

--- a/ecc/bls12381/ff/uroot.go
+++ b/ecc/bls12381/ff/uroot.go
@@ -12,8 +12,8 @@ func (z *URoot) Set(x *URoot)                  { (*Cyclo6)(z).Set((*Cyclo6)(x)) 
 func (z *URoot) SetBytes(b []byte) error       { return (*Fp12)(z).SetBytes(b) }
 func (z URoot) Bytes() []byte                  { return (Fp12)(z).Bytes() }
 func (z *URoot) SetIdentity()                  { (*Fp12)(z).SetOne() }
-func (z URoot) IsEqual(x *URoot) bool          { return (Cyclo6)(z).IsEqual((*Cyclo6)(x)) }
-func (z URoot) IsIdentity() bool               { i := &URoot{}; i.SetIdentity(); return z.IsEqual(i) }
+func (z URoot) IsEqual(x *URoot) int           { return (Cyclo6)(z).IsEqual((*Cyclo6)(x)) }
+func (z URoot) IsIdentity() int                { i := &URoot{}; i.SetIdentity(); return z.IsEqual(i) }
 func (z *URoot) ExpVarTime(x *URoot, n []byte) { (*Cyclo6)(z).expVarTime((*Cyclo6)(x), n) }
 func (z *URoot) Mul(x, y *URoot)               { (*Cyclo6)(z).Mul((*Cyclo6)(x), (*Cyclo6)(y)) }
 func (z *URoot) Sqr(x *URoot)                  { (*Cyclo6)(z).Sqr((*Cyclo6)(x)) }

--- a/ecc/bls12381/ff/uroot_test.go
+++ b/ecc/bls12381/ff/uroot_test.go
@@ -21,7 +21,7 @@ func TestURoot(t *testing.T) {
 		got.Sqr(&got)
 		want.Set(x)
 		want.Mul(&want, &want)
-		if !got.IsEqual(&want) {
+		if got.IsEqual(&want) == 0 {
 			test.ReportError(t, got, want, x)
 		}
 	})
@@ -35,7 +35,7 @@ func TestURoot(t *testing.T) {
 
 			// x^order = 1
 			got := z.IsIdentity()
-			want := true
+			want := 1
 			if got != want {
 				test.ReportError(t, got, want, x, z)
 			}
@@ -53,7 +53,7 @@ func TestURoot(t *testing.T) {
 			z.Mul(&z, x)
 			got := z
 			want := y
-			if !got.IsEqual(want) {
+			if got.IsEqual(want) == 0 {
 				test.ReportError(t, got, want, x, y)
 			}
 		}
@@ -66,7 +66,7 @@ func TestURoot(t *testing.T) {
 			// x*x = x^2
 			got.Mul(x, x)
 			want.Sqr(x)
-			if !got.IsEqual(&want) {
+			if got.IsEqual(&want) == 0 {
 				test.ReportError(t, got, want, x)
 			}
 		}

--- a/ecc/bls12381/g1.go
+++ b/ecc/bls12381/g1.go
@@ -1,11 +1,13 @@
 package bls12381
 
 import (
-	"crypto/sha256"
+	"crypto"
 	"fmt"
 	"math/big"
 
 	"github.com/cloudflare/circl/ecc/bls12381/ff"
+	"github.com/cloudflare/circl/group"
+	"github.com/cloudflare/circl/internal/conv"
 )
 
 // G1Size is the length in bytes of an element in G1.
@@ -17,11 +19,11 @@ type G1 struct{ x, y, z ff.Fp }
 func (g G1) String() string { return fmt.Sprintf("x: %v\ny: %v\nz: %v", g.x, g.y, g.z) }
 
 // Bytes serializes a G1 element.
-func (g *G1) Bytes() []byte { g.Normalize(); return append(g.x.Bytes(), g.y.Bytes()...) }
+func (g *G1) Bytes() []byte { g.toAffine(); return append(g.x.Bytes(), g.y.Bytes()...) }
 
 // SetBytes sets g to the value in bytes, and returns a non-nil error if not in G1
 func (g *G1) SetBytes(b []byte) error {
-	if len(b) != G1Size {
+	if len(b) < G1Size {
 		return fmt.Errorf("incorrect length")
 	}
 	err := g.x.SetBytes(b[:ff.FpSize])
@@ -52,14 +54,17 @@ func (g *G1) Neg() { g.y.Neg() }
 // SetIdentity assigns g to the identity element.
 func (g *G1) SetIdentity() { g.x = ff.Fp{}; g.y.SetOne(); g.z = ff.Fp{} }
 
+// isValidProjective returns true if the point is not a projective point.
+func (g *G1) isValidProjective() bool { return (g.x.IsZero() & g.y.IsZero() & g.z.IsZero()) != 1 }
+
 // IsOnG1 returns true if the point is in the group G1.
-func (g *G1) IsOnG1() bool { return g.IsOnCurve() && g.IsRTorsion() }
+func (g *G1) IsOnG1() bool { return g.isValidProjective() && g.IsOnCurve() && g.isRTorsion() }
 
 // IsIdentity return true if the point is the identity of G1.
-func (g *G1) IsIdentity() bool { return g.z.IsZero() }
+func (g *G1) IsIdentity() bool { return g.isValidProjective() && (g.z.IsZero() == 1) }
 
 // IsRTorsion returns true if point is r-torsion.
-func (g *G1) IsRTorsion() bool { var P G1; P.scalarMult(ff.ScalarOrder(), g); return P.IsIdentity() }
+func (g *G1) isRTorsion() bool { var P G1; P.scalarMult(ff.ScalarOrder(), g); return P.IsIdentity() }
 
 // Double updates g = 2g.
 func (g *G1) Double() {
@@ -71,24 +76,25 @@ func (g *G1) Double() {
 	X3, Y3, Z3 := &R.x, &R.y, &R.z
 	var f0, f1, f2 ff.Fp
 	t0, t1, t2 := &f0, &f1, &f2
-	t0.Sqr(Y)              // 1.  t0 =  Y * Y
-	Z3.Add(t0, t0)         // 2.  Z3 = t0 + t0
-	Z3.Add(Z3, Z3)         // 3.  Z3 = Z3 + Z3
-	Z3.Add(Z3, Z3)         // 4.  Z3 = Z3 + Z3
-	t1.Mul(Y, Z)           // 5.  t1 =  Y * Z
-	t2.Sqr(Z)              // 6.  t2 =  Z * Z
-	t2.Mul(&g1Param3B, t2) // 7.  t2 = b3 * t2
-	X3.Mul(t2, Z3)         // 8.  X3 = t2 * Z3
-	Y3.Add(t0, t2)         // 9.  Y3 = t0 + t2
-	Z3.Mul(t1, Z3)         // 10. Z3 = t1 * Z3
-	t1.Add(t2, t2)         // 11. t1 = t2 + t2
-	t2.Add(t1, t2)         // 12. t2 = t1 + t2
-	t0.Sub(t0, t2)         // 13. t0 = t0 - t2
-	Y3.Mul(t0, Y3)         // 14. Y3 = t0 * Y3
-	Y3.Add(X3, Y3)         // 15. Y3 = X3 + Y3
-	t1.Mul(X, Y)           // 16. t1 =  X * Y
-	X3.Mul(t0, t1)         // 17. X3 = t0 * t1
-	X3.Add(X3, X3)         // 18. X3 = X3 + X3
+	_3B := &g1Params._3b
+	t0.Sqr(Y)       // 1.  t0 =  Y * Y
+	Z3.Add(t0, t0)  // 2.  Z3 = t0 + t0
+	Z3.Add(Z3, Z3)  // 3.  Z3 = Z3 + Z3
+	Z3.Add(Z3, Z3)  // 4.  Z3 = Z3 + Z3
+	t1.Mul(Y, Z)    // 5.  t1 =  Y * Z
+	t2.Sqr(Z)       // 6.  t2 =  Z * Z
+	t2.Mul(_3B, t2) // 7.  t2 = b3 * t2
+	X3.Mul(t2, Z3)  // 8.  X3 = t2 * Z3
+	Y3.Add(t0, t2)  // 9.  Y3 = t0 + t2
+	Z3.Mul(t1, Z3)  // 10. Z3 = t1 * Z3
+	t1.Add(t2, t2)  // 11. t1 = t2 + t2
+	t2.Add(t1, t2)  // 12. t2 = t1 + t2
+	t0.Sub(t0, t2)  // 13. t0 = t0 - t2
+	Y3.Mul(t0, Y3)  // 14. Y3 = t0 * Y3
+	Y3.Add(X3, Y3)  // 15. Y3 = X3 + Y3
+	t1.Mul(X, Y)    // 16. t1 =  X * Y
+	X3.Mul(t0, t1)  // 17. X3 = t0 * t1
+	X3.Add(X3, X3)  // 18. X3 = X3 + X3
 	g.Set(&R)
 }
 
@@ -101,41 +107,42 @@ func (g *G1) Add(P, Q *G1) {
 	X1, Y1, Z1 := &P.x, &P.y, &P.z
 	X2, Y2, Z2 := &Q.x, &Q.y, &Q.z
 	X3, Y3, Z3 := &R.x, &R.y, &R.z
+	_3B := &g1Params._3b
 	var f0, f1, f2, f3, f4 ff.Fp
 	t0, t1, t2, t3, t4 := &f0, &f1, &f2, &f3, &f4
-	t0.Mul(X1, X2)         // 1.  t0 = X1 * X2
-	t1.Mul(Y1, Y2)         // 2.  t1 = Y1 * Y2
-	t2.Mul(Z1, Z2)         // 3.  t2 = Z1 * Z2
-	t3.Add(X1, Y1)         // 4.  t3 = X1 + Y1
-	t4.Add(X2, Y2)         // 5.  t4 = X2 + Y2
-	t3.Mul(t3, t4)         // 6.  t3 = t3 * t4
-	t4.Add(t0, t1)         // 7.  t4 = t0 + t1
-	t3.Sub(t3, t4)         // 8.  t3 = t3 - t4
-	t4.Add(Y1, Z1)         // 9.  t4 = Y1 + Z1
-	X3.Add(Y2, Z2)         // 10. X3 = Y2 + Z2
-	t4.Mul(t4, X3)         // 11. t4 = t4 * X3
-	X3.Add(t1, t2)         // 12. X3 = t1 + t2
-	t4.Sub(t4, X3)         // 13. t4 = t4 - X3
-	X3.Add(X1, Z1)         // 14. X3 = X1 + Z1
-	Y3.Add(X2, Z2)         // 15. Y3 = X2 + Z2
-	X3.Mul(X3, Y3)         // 16. X3 = X3 * Y3
-	Y3.Add(t0, t2)         // 17. Y3 = t0 + t2
-	Y3.Sub(X3, Y3)         // 18. Y3 = X3 - Y3
-	X3.Add(t0, t0)         // 19. X3 = t0 + t0
-	t0.Add(X3, t0)         // 20. t0 = X3 + t0
-	t2.Mul(&g1Param3B, t2) // 21. t2 = b3 * t2
-	Z3.Add(t1, t2)         // 22. Z3 = t1 + t2
-	t1.Sub(t1, t2)         // 23. t1 = t1 - t2
-	Y3.Mul(&g1Param3B, Y3) // 24. Y3 = b3 * Y3
-	X3.Mul(t4, Y3)         // 25. X3 = t4 * Y3
-	t2.Mul(t3, t1)         // 26. t2 = t3 * t1
-	X3.Sub(t2, X3)         // 27. X3 = t2 - X3
-	Y3.Mul(Y3, t0)         // 28. Y3 = Y3 * t0
-	t1.Mul(t1, Z3)         // 29. t1 = t1 * Z3
-	Y3.Add(t1, Y3)         // 30. Y3 = t1 + Y3
-	t0.Mul(t0, t3)         // 31. t0 = t0 * t3
-	Z3.Mul(Z3, t4)         // 32. Z3 = Z3 * t4
-	Z3.Add(Z3, t0)         // 33. Z3 = Z3 + t0
+	t0.Mul(X1, X2)  // 1.  t0 = X1 * X2
+	t1.Mul(Y1, Y2)  // 2.  t1 = Y1 * Y2
+	t2.Mul(Z1, Z2)  // 3.  t2 = Z1 * Z2
+	t3.Add(X1, Y1)  // 4.  t3 = X1 + Y1
+	t4.Add(X2, Y2)  // 5.  t4 = X2 + Y2
+	t3.Mul(t3, t4)  // 6.  t3 = t3 * t4
+	t4.Add(t0, t1)  // 7.  t4 = t0 + t1
+	t3.Sub(t3, t4)  // 8.  t3 = t3 - t4
+	t4.Add(Y1, Z1)  // 9.  t4 = Y1 + Z1
+	X3.Add(Y2, Z2)  // 10. X3 = Y2 + Z2
+	t4.Mul(t4, X3)  // 11. t4 = t4 * X3
+	X3.Add(t1, t2)  // 12. X3 = t1 + t2
+	t4.Sub(t4, X3)  // 13. t4 = t4 - X3
+	X3.Add(X1, Z1)  // 14. X3 = X1 + Z1
+	Y3.Add(X2, Z2)  // 15. Y3 = X2 + Z2
+	X3.Mul(X3, Y3)  // 16. X3 = X3 * Y3
+	Y3.Add(t0, t2)  // 17. Y3 = t0 + t2
+	Y3.Sub(X3, Y3)  // 18. Y3 = X3 - Y3
+	X3.Add(t0, t0)  // 19. X3 = t0 + t0
+	t0.Add(X3, t0)  // 20. t0 = X3 + t0
+	t2.Mul(_3B, t2) // 21. t2 = b3 * t2
+	Z3.Add(t1, t2)  // 22. Z3 = t1 + t2
+	t1.Sub(t1, t2)  // 23. t1 = t1 - t2
+	Y3.Mul(_3B, Y3) // 24. Y3 = b3 * Y3
+	X3.Mul(t4, Y3)  // 25. X3 = t4 * Y3
+	t2.Mul(t3, t1)  // 26. t2 = t3 * t1
+	X3.Sub(t2, X3)  // 27. X3 = t2 - X3
+	Y3.Mul(Y3, t0)  // 28. Y3 = Y3 * t0
+	t1.Mul(t1, Z3)  // 29. t1 = t1 * Z3
+	Y3.Add(t1, Y3)  // 30. Y3 = t1 + Y3
+	t0.Mul(t0, t3)  // 31. t0 = t0 * t3
+	Z3.Mul(Z3, t4)  // 32. Z3 = Z3 * t4
+	Z3.Add(Z3, t0)  // 33. Z3 = Z3 + t0
 	g.Set(&R)
 }
 
@@ -164,27 +171,27 @@ func (g *G1) IsEqual(p *G1) bool {
 	ly.Mul(&g.y, &p.z) // ly = y1*z2
 	ry.Mul(&p.y, &g.z) // ry = y2*z1
 	ly.Sub(&ly, &ry)   // ly = ly-ry
-	return lx.IsZero() && ly.IsZero()
+	return g.isValidProjective() && p.isValidProjective() && lx.IsZero() == 1 && ly.IsZero() == 1
 }
 
 // IsOnCurve returns true if g is a valid point on the curve.
 func (g *G1) IsOnCurve() bool {
 	var x3, z3, y2 ff.Fp
-	y2.Sqr(&g.y)           // y2 = y^2
-	y2.Mul(&y2, &g.z)      // y2 = y^2*z
-	x3.Sqr(&g.x)           // x3 = x^2
-	x3.Mul(&x3, &g.x)      // x3 = x^3
-	z3.Sqr(&g.z)           // z3 = z^2
-	z3.Mul(&z3, &g.z)      // z3 = z^3
-	z3.Mul(&z3, &g1ParamB) // z3 = 4*z^3
-	x3.Add(&x3, &z3)       // x3 = x^3 + 4*z^3
-	y2.Sub(&y2, &x3)       // y2 = y^2*z - (x^3 + 4*z^3)
-	return y2.IsZero()
+	y2.Sqr(&g.y)             // y2 = y^2
+	y2.Mul(&y2, &g.z)        // y2 = y^2*z
+	x3.Sqr(&g.x)             // x3 = x^2
+	x3.Mul(&x3, &g.x)        // x3 = x^3
+	z3.Sqr(&g.z)             // z3 = z^2
+	z3.Mul(&z3, &g.z)        // z3 = z^3
+	z3.Mul(&z3, &g1Params.b) // z3 = 4*z^3
+	x3.Add(&x3, &z3)         // x3 = x^3 + 4*z^3
+	y2.Sub(&y2, &x3)         // y2 = y^2*z - (x^3 + 4*z^3)
+	return g.isValidProjective() && (y2.IsZero() == 1)
 }
 
-// Normalize updates g with its affine representation.
-func (g *G1) Normalize() {
-	if !g.z.IsZero() {
+// toAffine updates g with its affine representation.
+func (g *G1) toAffine() {
+	if g.z.IsZero() != 1 {
 		var invZ ff.Fp
 		invZ.Inv(&g.z)
 		g.x.Mul(&g.x, &invZ)
@@ -193,45 +200,71 @@ func (g *G1) Normalize() {
 	}
 }
 
-// Hash produces an element of G1 from the hash of a message and an optional
-// domain separation tag.
-func (g *G1) Hash(msg, dst []byte) {
-	h := sha256.New()
-	for cnt := 0; cnt < 16; cnt++ {
-		h.Reset()
-		_, _ = h.Write([]byte{byte(cnt)})
-		_, _ = h.Write(msg)
-		_, _ = h.Write(dst)
-		sum := h.Sum(nil)
-		xi := new(big.Int).SetBytes(sum)
+// EncodeToCurve is a non-uniform encoding from an input byte string (and
+// an optional domain separation tag) to elements in G1. This function must not
+// be used as a hash function, otherwise use G1.Hash instead.
+func (g *G1) Encode(input, dst []byte) {
+	const L = 64
+	pseudo := group.NewExpanderMD(crypto.SHA256, dst).Expand(input, L)
 
-		var x, gx, y, four ff.Fp
-		four.SetUint64(4)
-		err := x.SetString(xi.Text(10))
-		if err != nil {
-			panic("bad string")
-		}
-		gx.Mul(&x, &x)
-		gx.Mul(&gx, &x)
-		gx.Add(&gx, &four)
-		if y.Sqrt(&gx) {
-			g.x.Set(&x)
-			g.y.Set(&y)
-			g.z.SetOne()
-			if !g.IsOnCurve() {
-				panic("bad point")
-			}
-			return
-		}
+	bu := new(big.Int)
+	bu.SetBytes(pseudo)
+	bu.Mod(bu, conv.BytesLe2BigInt(ff.FpOrder()))
+	var u8 [ff.FpSize]byte
+	conv.BigInt2BytesLe(u8[:], bu)
+	var u ff.Fp
+	err := u.SetBytes(u8[:])
+	if err != nil {
+		panic(err)
 	}
-	panic("point not found")
+	var q isogG1Point
+	q.sswu(&u)
+	var p G1
+	p.evalIsogG1(&q)
+	g.ScalarMult(&g1Isog11.cofactor, &p)
+}
+
+// Hash produces an element of G1 from the hash of an input byte string and
+// an optional domain separation tag. This function is safe to use when a
+// random oracle returning points in G1 be required.
+func (g *G1) Hash(input, dst []byte) {
+	const L = 64
+	pseudo := group.NewExpanderMD(crypto.SHA256, dst).Expand(input, 2*L)
+	bu := new(big.Int)
+	var u8 [ff.FpSize]byte
+	var u0, u1 ff.Fp
+
+	bu.SetBytes(pseudo[0*L : 1*L])
+	bu.Mod(bu, conv.BytesLe2BigInt(ff.FpOrder()))
+	conv.BigInt2BytesLe(u8[:], bu)
+	err := u0.SetBytes(u8[:])
+	if err != nil {
+		panic(err)
+	}
+
+	bu.SetBytes(pseudo[1*L : 2*L])
+	bu.Mod(bu, conv.BytesLe2BigInt(ff.FpOrder()))
+	conv.BigInt2BytesLe(u8[:], bu)
+	err = u1.SetBytes(u8[:])
+	if err != nil {
+		panic(err)
+	}
+
+	var q0, q1 isogG1Point
+	q0.sswu(&u0)
+	q1.sswu(&u1)
+	var p, p0, p1 G1
+	p0.evalIsogG1(&q0)
+	p1.evalIsogG1(&q1)
+	p.Add(&p0, &p1)
+	g.ScalarMult(&g1Isog11.cofactor, &p)
 }
 
 // G1Generator returns the generator point of G1.
 func G1Generator() *G1 {
 	var G G1
-	G.x.Set(&g1GenX)
-	G.y.Set(&g1GenY)
+	G.x.Set(&g1Params.genX)
+	G.y.Set(&g1Params.genY)
 	G.z.SetOne()
 	return &G
 }

--- a/ecc/bls12381/g1Isog.go
+++ b/ecc/bls12381/g1Isog.go
@@ -1,0 +1,150 @@
+package bls12381
+
+import (
+	"fmt"
+
+	"github.com/cloudflare/circl/ecc/bls12381/ff"
+)
+
+type isogG1Point struct{ x, y, z ff.Fp }
+
+func (p isogG1Point) String() string { return fmt.Sprintf("x: %v\ny: %v\nz: %v", p.x, p.y, p.z) }
+
+// IsOnCurve returns true if g is a valid point on the curve.
+func (p *isogG1Point) IsOnCurve() bool {
+	var x2, x3, z2, z3, y2 ff.Fp
+	y2.Sqr(&p.y)             // y2 = y^2
+	y2.Mul(&y2, &p.z)        // y2 = y^2*z
+	z2.Sqr(&p.z)             // z2 = z^2
+	z3.Mul(&z2, &p.z)        // z3 = z^3
+	z3.Mul(&z3, &g1Isog11.b) // z3 = B*z^3
+	x2.Sqr(&p.x)             // x2 = x^2
+	x3.Mul(&z2, &g1Isog11.a) // x3 = A*z^2
+	x3.Add(&x3, &x2)         // x3 = x^2 + A*z^2
+	x3.Mul(&x3, &p.x)        // x3 = x^3 + A*x*z^2
+	x3.Add(&x3, &z3)         // x3 = x^3 + A*x*z^2 + Bz^3
+
+	return y2.IsEqual(&x3) == 1 && *p != isogG1Point{}
+}
+
+// sswu implements the Simplified Shallue-van de Woestijne-Ulas method for
+// maping a field element to a point on the isogenous curve.
+func (p *isogG1Point) sswu(u *ff.Fp) {
+	one, tv1, tv2, tv3, tv4 := &ff.Fp{}, &ff.Fp{}, &ff.Fp{}, &ff.Fp{}, &ff.Fp{}
+	za, Z, xd, x1n, gxd, gx1 := &ff.Fp{}, &ff.Fp{}, &ff.Fp{}, &ff.Fp{}, &ff.Fp{}, &ff.Fp{}
+	y, y1, x2n, y2, xn := &ff.Fp{}, &ff.Fp{}, &ff.Fp{}, &ff.Fp{}, &ff.Fp{}
+
+	A := &g1Isog11.a
+	B := &g1Isog11.b
+	Z.SetUint64(11)
+	c2 := &g1Isog11.c2
+	c1 := g1Isog11.c1[:]
+	one.SetOne()
+	negA := g1Isog11.a
+	negA.Neg()
+
+	tv1.Sqr(u)                // 1.  tv1 = u^2
+	tv3.Mul(Z, tv1)           // 2.  tv3 = Z * tv1
+	tv2.Sqr(tv3)              // 3.  tv2 = tv3^2
+	xd.Add(tv2, tv3)          // 4.   xd = tv2 + tv3
+	x1n.Add(xd, one)          // 5.  x1n = xd + 1
+	x1n.Mul(x1n, B)           // 6.  x1n = x1n * B
+	xd.Mul(&negA, xd)         // 7.   xd = -A * xd
+	e1 := xd.IsZero()         // 8.   e1 = xd == 0
+	za.Mul(Z, A)              // 9.   za = Z * A
+	xd.CMov(xd, za, e1)       //      xd = CMOV(xd, za, e1)
+	tv2.Sqr(xd)               // 10. tv2 = xd^2
+	gxd.Mul(tv2, xd)          // 11. gxd = tv2 * xd
+	tv2.Mul(A, tv2)           // 12. tv2 = A * tv2
+	gx1.Sqr(x1n)              // 13. gx1 = x1n^2
+	gx1.Add(gx1, tv2)         // 14. gx1 = gx1 + tv2
+	gx1.Mul(gx1, x1n)         // 15. gx1 = gx1 * x1n
+	tv2.Mul(B, gxd)           // 16. tv2 = B * gxd
+	gx1.Add(gx1, tv2)         // 17. gx1 = gx1 + tv2
+	tv4.Sqr(gxd)              // 18. tv4 = gxd^2
+	tv2.Mul(gx1, gxd)         // 19. tv2 = gx1 * gxd
+	tv4.Mul(tv4, tv2)         // 20. tv4 = tv4 * tv2
+	y1.ExpVarTime(tv4, c1)    // 21.  y1 = tv4^c1
+	y1.Mul(y1, tv2)           // 22.  y1 = y1 * tv2
+	x2n.Mul(tv3, x1n)         // 23. x2n = tv3 * x1n
+	y2.Mul(y1, c2)            // 24.  y2 = y1 * c2
+	y2.Mul(y2, tv1)           // 25.  y2 = y2 * tv1
+	y2.Mul(y2, u)             // 26.  y2 = y2 * u
+	tv2.Sqr(y1)               // 27. tv2 = y1^2
+	tv2.Mul(tv2, gxd)         // 28. tv2 = tv2 * gxd
+	e2 := tv2.IsEqual(gx1)    // 29.  e2 = tv2 == gx1
+	xn.CMov(x2n, x1n, e2)     // 30.  xn = CMOV(x2n, x1n, e2)
+	y.CMov(y2, y1, e2)        // 31.   y = CMOV(y2, y1, e2)
+	e3 := u.Sgn0() ^ y.Sgn0() // 32.  e3 = sgn0(u) == sgn0(y)
+	tv1.Set(y)                // 33. tv1 = y
+	tv1.Neg()                 //     tv1 = -y
+	y.CMov(tv1, y, ^e3)       //       y = CMOV(tv1, y, e3)
+	p.x.Set(xn)               // 34. return
+	p.y.Mul(y, xd)            //       (x,y) = (xn/xd, y/1)
+	p.z.Set(xd)               //       (X,Y,Z) = (xn, y*xd, xd)
+}
+
+// evalIsogG1 calculates g = g1Isog11(p), where g1Isog11 is an isogeny of
+// degree 11 to the curve used in G1.
+//
+// The isogeny is given by rational maps.
+//   g1Iso  -->   G1
+//  (x,y,z) |-> (x,y,1)
+//              (xNum/xDen, y * yNum/yDen, 1)
+//              (xNum*yDen, y * yNum*xDen, z*xDen*yDen)
+// such that:
+//  xNum = \sum ai * x^i * z^(n-1-i), for 0 <= i < n, and n=12.
+//  xDen = \sum bi * x^i * z^(n-1-i), for 0 <= i < n, and n=11.
+//  yNum = \sum ci * x^i * z^(n-1-i), for 0 <= i < n, and n=16.
+//  yDen = \sum di * x^i * z^(n-1-i), for 0 <= i < n, and n=16.
+func (g *G1) evalIsogG1(p *isogG1Point) {
+	x, y, z := &p.x, &p.y, &p.z
+	t, zi := &ff.Fp{}, &ff.Fp{}
+	xNum, xDen, yNum, yDen := &ff.Fp{}, &ff.Fp{}, &ff.Fp{}, &ff.Fp{}
+
+	ixn := len(g1Isog11.xNum) - 1
+	ixd := len(g1Isog11.xDen) - 1
+	iyn := len(g1Isog11.yNum) - 1
+	iyd := len(g1Isog11.yDen) - 1
+
+	*xNum = g1Isog11.xNum[ixn]
+	*xDen = g1Isog11.xDen[ixd]
+	*yNum = g1Isog11.yNum[iyn]
+	*yDen = g1Isog11.yDen[iyd]
+	*zi = *z
+
+	for (ixn | ixd | iyn | iyd) != 0 {
+		if ixn > 0 {
+			ixn--
+			t.Mul(zi, &g1Isog11.xNum[ixn])
+			xNum.Mul(xNum, x)
+			xNum.Add(xNum, t)
+		}
+		if ixd > 0 {
+			ixd--
+			t.Mul(zi, &g1Isog11.xDen[ixd])
+			xDen.Mul(xDen, x)
+			xDen.Add(xDen, t)
+		}
+		if iyn > 0 {
+			iyn--
+			t.Mul(zi, &g1Isog11.yNum[iyn])
+			yNum.Mul(yNum, x)
+			yNum.Add(yNum, t)
+		}
+		if iyd > 0 {
+			iyd--
+			t.Mul(zi, &g1Isog11.yDen[iyd])
+			yDen.Mul(yDen, x)
+			yDen.Add(yDen, t)
+		}
+
+		zi.Mul(zi, z)
+	}
+
+	g.x.Mul(xNum, yDen)
+	g.y.Mul(yNum, xDen)
+	g.y.Mul(&g.y, y)
+	g.z.Mul(xDen, yDen)
+	g.z.Mul(&g.z, z)
+}

--- a/ecc/bls12381/gt.go
+++ b/ecc/bls12381/gt.go
@@ -13,7 +13,7 @@ func (z *Gt) Set(x *Gt)                   { z.i.Set(&x.i) }
 func (z *Gt) SetBytes(b []byte) error     { return z.i.SetBytes(b) }
 func (z Gt) Bytes() []byte                { return z.i.Bytes() }
 func (z *Gt) SetIdentity()                { z.i.SetIdentity() }
-func (z Gt) IsEqual(x *Gt) bool           { return z.i.IsEqual(&x.i) }
+func (z Gt) IsEqual(x *Gt) bool           { return z.i.IsEqual(&x.i) == 1 }
 func (z Gt) IsIdentity() bool             { i := &Gt{}; i.SetIdentity(); return z.IsEqual(i) }
 func (z *Gt) Mul(x, y *Gt)                { z.i.Mul(&x.i, &y.i) }
 func (z *Gt) Sqr(x *Gt)                   { z.i.Sqr(&x.i) }

--- a/ecc/bls12381/hash_test.go
+++ b/ecc/bls12381/hash_test.go
@@ -1,0 +1,110 @@
+package bls12381
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cloudflare/circl/ecc/bls12381/ff"
+	"github.com/cloudflare/circl/internal/test"
+)
+
+type vectorHash struct {
+	SuiteID        string `json:"ciphersuite"`
+	CurveName      string `json:"curve"`
+	DST            string `json:"dst"`
+	IsRandomOracle bool   `json:"randomOracle"`
+	Vectors        []struct {
+		P   point  `json:"P"`
+		Msg string `json:"msg"`
+	} `json:"vectors"`
+}
+
+type point struct {
+	X string `json:"x"`
+	Y string `json:"y"`
+}
+
+func (p point) toBytes() []byte {
+	out := make([]byte, G1Size)
+	x, err := hex.DecodeString(p.X[2:])
+	if err != nil {
+		panic(err)
+	}
+	lx := len(x)
+	for i := range x {
+		out[i] = x[lx-1-i]
+	}
+
+	y, err := hex.DecodeString(p.Y[2:])
+	if err != nil {
+		panic(err)
+	}
+	ly := len(y)
+	for i := range y {
+		out[ff.FpSize+i] = y[ly-1-i]
+	}
+	return out
+}
+
+func (v *vectorHash) test(t *testing.T) {
+	got := new(G1)
+	want := new(G1)
+	dst := []byte(v.DST)
+
+	doHash := got.Encode
+	if v.IsRandomOracle {
+		doHash = got.Hash
+	}
+
+	for i, vi := range v.Vectors {
+		input := []byte(vi.Msg)
+		doHash(input, dst)
+
+		err := want.SetBytes(vi.P.toBytes())
+		test.CheckNoErr(t, err, "bad deserialization")
+
+		if !got.IsEqual(want) {
+			test.ReportError(t, got, want, v.SuiteID, i)
+		}
+	}
+}
+
+func readFile(t *testing.T, fileName string) *vectorHash {
+	jsonFile, err := os.Open(fileName)
+	if err != nil {
+		t.Fatalf("File %v can not be opened. Error: %v", fileName, err)
+	}
+	defer jsonFile.Close()
+	input, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		t.Fatalf("File %v can not be loaded. Error: %v", fileName, err)
+	}
+	v := new(vectorHash)
+	err = json.Unmarshal(input, v)
+	if err != nil {
+		t.Fatalf("File %v can not be parsed. Error: %v", fileName, err)
+	}
+	return v
+}
+
+func TestHashVectors(t *testing.T) {
+	// Test vectors from draft-irtf-cfrg-hash-to-curve:
+	// https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11
+	//
+	// JSON files can be found at:
+	// https://github.com/cfrg/draft-irtf-cfrg-hash-to-curve/tree/draft-irtf-cfrg-hash-to-curve-10/poc/vectors
+
+	fileNames, err := filepath.Glob("./testdata/BLS12381*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, fileName := range fileNames {
+		v := readFile(t, fileName)
+		t.Run(v.SuiteID, v.test)
+	}
+}

--- a/ecc/bls12381/pair.go
+++ b/ecc/bls12381/pair.go
@@ -8,10 +8,17 @@ package bls12381
 import "github.com/cloudflare/circl/ecc/bls12381/ff"
 
 // Pair calculates the ate-pairing of P and Q.
-func Pair(P *G1, Q *G2) *Gt { g := &Gt{}; P.Normalize(); finalExp(g, miller(P, Q)); return g }
+func Pair(P *G1, Q *G2) *Gt {
+	P.toAffine()
+	mi := &ff.Fp12{}
+	miller(mi, P, Q)
+	e := &Gt{}
+	finalExp(e, mi)
+	return e
+}
 
-func miller(P *G1, Q *G2) *ff.Fp12 {
-	f := &ff.Fp12{}
+func miller(f *ff.Fp12, P *G1, Q *G2) {
+	g := &ff.Fp12{}
 	f.SetOne()
 	T := &G2{}
 	T.Set(Q)
@@ -20,30 +27,31 @@ func miller(P *G1, Q *G2) *ff.Fp12 {
 	for i := lenX - 2; i >= 0; i-- {
 		f.Sqr(f)
 		doubleAndLine(T, l)
-		f.Mul(f, l.eval(P))
+		evalLine(g, l, P)
+		f.Mul(f, g)
 		// paramX is -2 ^ 63 - 2 ^ 62 - 2 ^ 60 - 2 ^ 57 - 2 ^ 48 - 2 ^ 16
 		if (i == 62) || (i == 60) || (i == 57) || (i == 48) || (i == 16) {
 			addAndLine(T, T, Q, l)
-			f.Mul(f, l.eval(P))
+			evalLine(g, l, P)
+			f.Mul(f, g)
 		}
 	}
 	f.Cjg() // inverts f as paramX is negative.
-	return f
 }
 
 // line contains the coefficients of a sparse element of Fp12.
 // Evaluating the line on P' = (xP',yP') results in
-//   g = line(P') = l[0]*xP' + l[1]*yP' + l[2] \in Fp12.
+//   f = evalLine(P') = l[0]*xP' + l[1]*yP' + l[2] \in Fp12.
 type line [3]ff.Fp2
 
-// eval updates f = f * line(P'), where f lives in Fp12 = Fp6[w]/(w^2-v) and P'
-// is the image of P on the twist curve.
-func (l *line) eval(P *G1) *ff.Fp12 {
+// evalLine updates f = f * line(P'), where f lives in Fp12 = Fp6[w]/(w^2-v)
+// and P' is the image of P on the twist curve.
+func evalLine(f *ff.Fp12, l *line, P *G1) {
 	// Send P \in E to the twist
 	//     E    -->        E'
 	//  (xP,yP) |-> (xP*w^2,yP*w^3) = (xP',yP')
 	//
-	// g = line(P') = l[0]*xP' + l[1]*yP' + l[2] \in Fp12.
+	// f = line(P') = l[0]*xP' + l[1]*yP' + l[2] \in Fp12.
 	//              = l[0]*xP*w^2 + l[1]*yP*w^3 + l[2] \in Fp12.
 
 	// First perform the products: l[0]*xP and l[1]*yP \in Fp2.
@@ -58,17 +66,15 @@ func (l *line) eval(P *G1) *ff.Fp12 {
 	// Note that w^2=v and w^6=v^3=ξ, so a generic element
 	//   a0*w^0 + a1*w^1 + a2*w^2 + a3*w^3 + a4*w^4 + a5*w^5 \in Fp12 = Fp2[w]/(w^6-ξ).
 	// is converted to
-	//   (a0+a2*v+a4*v^2) + (a1+a3*v+a5*v^2)w \in  Fp12 = Fp6[w]/(w^2-v).
+	//   (a0+a2*v+a4*v^2) + (a1+a3*v+a5*v^2)w \in Fp12 = Fp6[w]/(w^2-v).
 	//
-	// Apply such transformation to construct g \in Fp12 = Fp6[w]/(w^2-v).
-	var g ff.Fp12
-	g[0][0].Set(&l[2])
-	g[0][1].Set(&l[0])
-	g[1][1].Set(&l[1])
-	if g.IsZero() {
-		return &one
+	// Apply such transformation to construct f \in Fp12 = Fp6[w]/(w^2-v).
+	f[0][0].Set(&l[2])
+	f[0][1].Set(&l[0])
+	f[1][1].Set(&l[1])
+	if f.IsZero() == 1 {
+		f.SetOne()
 	}
-	return &g
 }
 
 func finalExp(g *Gt, f *ff.Fp12) {
@@ -84,17 +90,18 @@ func ProdPair(P []*G1, Q []*G2, n []*Scalar) *Gt {
 	}
 
 	ei := new(ff.Fp12)
+	mi := new(ff.Fp12)
 	out := new(ff.Fp12)
 	out.SetOne()
 
 	for i := range P {
-		P[i].Normalize()
-		mi := miller(P[i], Q[i])
+		P[i].toAffine()
+		miller(mi, P[i], Q[i])
 		ei.ExpVarTime(mi, n[i].Bytes())
 		out.Mul(out, ei)
 	}
 
-	g := &Gt{}
-	finalExp(g, out)
-	return g
+	e := &Gt{}
+	finalExp(e, out)
+	return e
 }

--- a/ecc/bls12381/pair_test.go
+++ b/ecc/bls12381/pair_test.go
@@ -83,25 +83,27 @@ func TestPairIdentity(t *testing.T) {
 func BenchmarkMiller(b *testing.B) {
 	g1 := G1Generator()
 	g2 := G2Generator()
+	mi := new(ff.Fp12)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = miller(g1, g2)
+		miller(mi, g1, g2)
 	}
 }
 
 func BenchmarkFinalExpo(b *testing.B) {
 	g1 := G1Generator()
 	g2 := G2Generator()
-	f := miller(g1, g2)
+	mi := new(ff.Fp12)
+	miller(mi, g1, g2)
 	c := &ff.Cyclo6{}
 	u := &ff.URoot{}
 	g := &Gt{}
 
-	ff.EasyExponentiation(c, f)
+	ff.EasyExponentiation(c, mi)
 
 	b.Run("EasyExp", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			ff.EasyExponentiation(c, f)
+			ff.EasyExponentiation(c, mi)
 		}
 	})
 	b.Run("HardExp", func(b *testing.B) {
@@ -111,7 +113,7 @@ func BenchmarkFinalExpo(b *testing.B) {
 	})
 	b.Run("FinalExp", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			finalExp(g, f)
+			finalExp(g, mi)
 		}
 	})
 }

--- a/ecc/bls12381/testdata/BLS12381G1_XMD-SHA-256_SSWU_NU_.json
+++ b/ecc/bls12381/testdata/BLS12381G1_XMD-SHA-256_SSWU_NU_.json
@@ -1,0 +1,90 @@
+{
+  "L": "0x40",
+  "Z": "0xb",
+  "ciphersuite": "BLS12381G1_XMD:SHA-256_SSWU_NU_",
+  "curve": "BLS12-381 G1",
+  "dst": "QUUX-V01-CS02-with-BLS12381G1_XMD:SHA-256_SSWU_NU_",
+  "expand": "XMD",
+  "field": {
+    "m": "0x1",
+    "p": "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab"
+  },
+  "hash": "sha256",
+  "k": "0x80",
+  "map": {
+    "name": "SSWU"
+  },
+  "randomOracle": false,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x184bb665c37ff561a89ec2122dd343f20e0f4cbcaec84e3c3052ea81d1834e192c426074b02ed3dca4e7676ce4ce48ba",
+        "y": "0x04407b8d35af4dacc809927071fc0405218f1401a6d15af775810e4e460064bcc9468beeba82fdc751be70476c888bf3"
+      },
+      "Q": {
+        "x": "0x11398d3b324810a1b093f8e35aa8571cced95858207e7f49c4fd74656096d61d8a2f9a23cdb18a4dd11cd1d66f41f709",
+        "y": "0x19316b6fb2ba7717355d5d66a361899057e1e84a6823039efc7beccefe09d023fb2713b1c415fcf278eb0c39a89b4f72"
+      },
+      "msg": "",
+      "u": [
+        "0x156c8a6a2c184569d69a76be144b5cdc5141d2d2ca4fe341f011e25e3969c55ad9e9b9ce2eb833c81a908e5fa4ac5f03"
+      ]
+    },
+    {
+      "P": {
+        "x": "0x009769f3ab59bfd551d53a5f846b9984c59b97d6842b20a2c565baa167945e3d026a3755b6345df8ec7e6acb6868ae6d",
+        "y": "0x1532c00cf61aa3d0ce3e5aa20c3b531a2abd2c770a790a2613818303c6b830ffc0ecf6c357af3317b9575c567f11cd2c"
+      },
+      "Q": {
+        "x": "0x1998321bc27ff6d71df3051b5aec12ff47363d81a5e9d2dff55f444f6ca7e7d6af45c56fd029c58237c266ef5cda5254",
+        "y": "0x034d274476c6307ae584f951c82e7ea85b84f72d28f4d6471732356121af8d62a49bc263e8eb913a6cf6f125995514ee"
+      },
+      "msg": "abc",
+      "u": [
+        "0x147e1ed29f06e4c5079b9d14fc89d2820d32419b990c1c7bb7dbea2a36a045124b31ffbde7c99329c05c559af1c6cc82"
+      ]
+    },
+    {
+      "P": {
+        "x": "0x1974dbb8e6b5d20b84df7e625e2fbfecb2cdb5f77d5eae5fb2955e5ce7313cae8364bc2fff520a6c25619739c6bdcb6a",
+        "y": "0x15f9897e11c6441eaa676de141c8d83c37aab8667173cbe1dfd6de74d11861b961dccebcd9d289ac633455dfcc7013a3"
+      },
+      "Q": {
+        "x": "0x17d502fa43bd6a4cad2859049a0c3ecefd60240d129be65da271a4c03a9c38fa78163b9d2a919d2beb57df7d609b4919",
+        "y": "0x109019902ae93a8732abecf2ff7fecd2e4e305eb91f41c9c3267f16b6c19de138c7272947f25512745da6c466cdfd1ac"
+      },
+      "msg": "abcdef0123456789",
+      "u": [
+        "0x04090815ad598a06897dd89bcda860f25837d54e897298ce31e6947378134d3761dc59a572154963e8c954919ecfa82d"
+      ]
+    },
+    {
+      "P": {
+        "x": "0x0a7a047c4a8397b3446450642c2ac64d7239b61872c9ae7a59707a8f4f950f101e766afe58223b3bff3a19a7f754027c",
+        "y": "0x1383aebba1e4327ccff7cf9912bda0dbc77de048b71ef8c8a81111d71dc33c5e3aa6edee9cf6f5fe525d50cc50b77cc9"
+      },
+      "Q": {
+        "x": "0x112eb92dd2b3aa9cd38b08de4bef603f2f9fb0ca226030626a9a2e47ad1e9847fe0a5ed13766c339e38f514bba143b21",
+        "y": "0x17542ce2f8d0a54f2c5ba8c4b14e10b22d5bcd7bae2af3c965c8c872b571058c720eac448276c99967ded2bf124490e1"
+      },
+      "msg": "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+      "u": [
+        "0x08dccd088ca55b8bfbc96fb50bb25c592faa867a8bb78d4e94a8cc2c92306190244532e91feba2b7fed977e3c3bb5a1f"
+      ]
+    },
+    {
+      "P": {
+        "x": "0x0e7a16a975904f131682edbb03d9560d3e48214c9986bd50417a77108d13dc957500edf96462a3d01e62dc6cd468ef11",
+        "y": "0x0ae89e677711d05c30a48d6d75e76ca9fb70fe06c6dd6ff988683d89ccde29ac7d46c53bb97a59b1901abf1db66052db"
+      },
+      "Q": {
+        "x": "0x1775d400a1bacc1c39c355da7e96d2d1c97baa9430c4a3476881f8521c09a01f921f592607961efc99c4cd46bd78ca19",
+        "y": "0x1109b5d59f65964315de65a7a143e86eabc053104ed289cf480949317a5685fad7254ff8e7fe6d24d3104e5d55ad6370"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "u": [
+        "0x0dd824886d2123a96447f6c56e3a3fa992fbfefdba17b6673f9f630ff19e4d326529db37e1c1be43f905bf9202e0278d"
+      ]
+    }
+  ]
+}

--- a/ecc/bls12381/testdata/BLS12381G1_XMD-SHA-256_SSWU_RO_.json
+++ b/ecc/bls12381/testdata/BLS12381G1_XMD-SHA-256_SSWU_RO_.json
@@ -1,0 +1,115 @@
+{
+  "L": "0x40",
+  "Z": "0xb",
+  "ciphersuite": "BLS12381G1_XMD:SHA-256_SSWU_RO_",
+  "curve": "BLS12-381 G1",
+  "dst": "QUUX-V01-CS02-with-BLS12381G1_XMD:SHA-256_SSWU_RO_",
+  "expand": "XMD",
+  "field": {
+    "m": "0x1",
+    "p": "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab"
+  },
+  "hash": "sha256",
+  "k": "0x80",
+  "map": {
+    "name": "SSWU"
+  },
+  "randomOracle": true,
+  "vectors": [
+    {
+      "P": {
+        "x": "0x052926add2207b76ca4fa57a8734416c8dc95e24501772c814278700eed6d1e4e8cf62d9c09db0fac349612b759e79a1",
+        "y": "0x08ba738453bfed09cb546dbb0783dbb3a5f1f566ed67bb6be0e8c67e2e81a4cc68ee29813bb7994998f3eae0c9c6a265"
+      },
+      "Q0": {
+        "x": "0x11a3cce7e1d90975990066b2f2643b9540fa40d6137780df4e753a8054d07580db3b7f1f03396333d4a359d1fe3766fe",
+        "y": "0x0eeaf6d794e479e270da10fdaf768db4c96b650a74518fc67b04b03927754bac66f3ac720404f339ecdcc028afa091b7"
+      },
+      "Q1": {
+        "x": "0x160003aaf1632b13396dbad518effa00fff532f604de1a7fc2082ff4cb0afa2d63b2c32da1bef2bf6c5ca62dc6b72f9c",
+        "y": "0x0d8bb2d14e20cf9f6036152ed386d79189415b6d015a20133acb4e019139b94e9c146aaad5817f866c95d609a361735e"
+      },
+      "msg": "",
+      "u": [
+        "0x0ba14bd907ad64a016293ee7c2d276b8eae71f25a4b941eece7b0d89f17f75cb3ae5438a614fb61d6835ad59f29c564f",
+        "0x019b9bd7979f12657976de2884c7cce192b82c177c80e0ec604436a7f538d231552f0d96d9f7babe5fa3b19b3ff25ac9"
+      ]
+    },
+    {
+      "P": {
+        "x": "0x03567bc5ef9c690c2ab2ecdf6a96ef1c139cc0b2f284dca0a9a7943388a49a3aee664ba5379a7655d3c68900be2f6903",
+        "y": "0x0b9c15f3fe6e5cf4211f346271d7b01c8f3b28be689c8429c85b67af215533311f0b8dfaaa154fa6b88176c229f2885d"
+      },
+      "Q0": {
+        "x": "0x125435adce8e1cbd1c803e7123f45392dc6e326d292499c2c45c5865985fd74fe8f042ecdeeec5ecac80680d04317d80",
+        "y": "0x0e8828948c989126595ee30e4f7c931cbd6f4570735624fd25aef2fa41d3f79cfb4b4ee7b7e55a8ce013af2a5ba20bf2"
+      },
+      "Q1": {
+        "x": "0x11def93719829ecda3b46aa8c31fc3ac9c34b428982b898369608e4f042babee6c77ab9218aad5c87ba785481eff8ae4",
+        "y": "0x0007c9cef122ccf2efd233d6eb9bfc680aa276652b0661f4f820a653cec1db7ff69899f8e52b8e92b025a12c822a6ce6"
+      },
+      "msg": "abc",
+      "u": [
+        "0x0d921c33f2bad966478a03ca35d05719bdf92d347557ea166e5bba579eea9b83e9afa5c088573c2281410369fbd32951",
+        "0x003574a00b109ada2f26a37a91f9d1e740dffd8d69ec0c35e1e9f4652c7dba61123e9dd2e76c655d956e2b3462611139"
+      ]
+    },
+    {
+      "P": {
+        "x": "0x11e0b079dea29a68f0383ee94fed1b940995272407e3bb916bbf268c263ddd57a6a27200a784cbc248e84f357ce82d98",
+        "y": "0x03a87ae2caf14e8ee52e51fa2ed8eefe80f02457004ba4d486d6aa1f517c0889501dc7413753f9599b099ebcbbd2d709"
+      },
+      "Q0": {
+        "x": "0x08834484878c217682f6d09a4b51444802fdba3d7f2df9903a0ddadb92130ebbfa807fffa0eabf257d7b48272410afff",
+        "y": "0x0b318f7ecf77f45a0f038e62d7098221d2dbbca2a394164e2e3fe953dc714ac2cde412d8f2d7f0c03b259e6795a2508e"
+      },
+      "Q1": {
+        "x": "0x158418ed6b27e2549f05531a8281b5822b31c3bf3144277fbb977f8d6e2694fedceb7011b3c2b192f23e2a44b2bd106e",
+        "y": "0x1879074f344471fac5f839e2b4920789643c075792bec5af4282c73f7941cda5aa77b00085eb10e206171b9787c4169f"
+      },
+      "msg": "abcdef0123456789",
+      "u": [
+        "0x062d1865eb80ebfa73dcfc45db1ad4266b9f3a93219976a3790ab8d52d3e5f1e62f3b01795e36834b17b70e7b76246d4",
+        "0x0cdc3e2f271f29c4ff75020857ce6c5d36008c9b48385ea2f2bf6f96f428a3deb798aa033cd482d1cdc8b30178b08e3a"
+      ]
+    },
+    {
+      "P": {
+        "x": "0x15f68eaa693b95ccb85215dc65fa81038d69629f70aeee0d0f677cf22285e7bf58d7cb86eefe8f2e9bc3f8cb84fac488",
+        "y": "0x1807a1d50c29f430b8cafc4f8638dfeeadf51211e1602a5f184443076715f91bb90a48ba1e370edce6ae1062f5e6dd38"
+      },
+      "Q0": {
+        "x": "0x0cbd7f84ad2c99643fea7a7ac8f52d63d66cefa06d9a56148e58b984b3dd25e1f41ff47154543343949c64f88d48a710",
+        "y": "0x052c00e4ed52d000d94881a5638ae9274d3efc8bc77bc0e5c650de04a000b2c334a9e80b85282a00f3148dfdface0865"
+      },
+      "Q1": {
+        "x": "0x06493fb68f0d513af08be0372f849436a787e7b701ae31cb964d968021d6ba6bd7d26a38aaa5a68e8c21a6b17dc8b579",
+        "y": "0x02e98f2ccf5802b05ffaac7c20018bc0c0b2fd580216c4aa2275d2909dc0c92d0d0bdc979226adeb57a29933536b6bb4"
+      },
+      "msg": "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+      "u": [
+        "0x010476f6a060453c0b1ad0b628f3e57c23039ee16eea5e71bb87c3b5419b1255dc0e5883322e563b84a29543823c0e86",
+        "0x0b1a912064fb0554b180e07af7e787f1f883a0470759c03c1b6509eb8ce980d1670305ae7b928226bb58fdc0a419f46e"
+      ]
+    },
+    {
+      "P": {
+        "x": "0x082aabae8b7dedb0e78aeb619ad3bfd9277a2f77ba7fad20ef6aabdc6c31d19ba5a6d12283553294c1825c4b3ca2dcfe",
+        "y": "0x05b84ae5a942248eea39e1d91030458c40153f3b654ab7872d779ad1e942856a20c438e8d99bc8abfbf74729ce1f7ac8"
+      },
+      "Q0": {
+        "x": "0x0cf97e6dbd0947857f3e578231d07b309c622ade08f2c08b32ff372bd90db19467b2563cc997d4407968d4ac80e154f8",
+        "y": "0x127f0cddf2613058101a5701f4cb9d0861fd6c2a1b8e0afe194fccf586a3201a53874a2761a9ab6d7220c68661a35ab3"
+      },
+      "Q1": {
+        "x": "0x092f1acfa62b05f95884c6791fba989bbe58044ee6355d100973bf9553ade52b47929264e6ae770fb264582d8dce512a",
+        "y": "0x028e6d0169a72cfedb737be45db6c401d3adfb12c58c619c82b93a5dfcccef12290de530b0480575ddc8397cda0bbebf"
+      },
+      "msg": "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "u": [
+        "0x0a8ffa7447f6be1c5a2ea4b959c9454b431e29ccc0802bc052413a9c5b4f9aac67a93431bd480d15be1e057c8a08e8c6",
+        "0x05d487032f602c90fa7625dbafe0f4a49ef4a6b0b33d7bb349ff4cf5410d297fd6241876e3e77b651cfc8191e40a68b7"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Implements encode and hash to curve as recommended in IETF draft. See https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11

Removes insecure try-and-increment method for hashing.

Changes:
 - Implements encode and hash to curve as recommended in IETF draft.
 - G1 ciphersuites for BLS12-381.
 - Removes certain memory allocations.
 - Adding test vectors for hash to G1.
 - Return int rather than bool in ff predicates.