### PR TITLE
bls12: implements Marshaler interfaces and SetBytes for Scalar

### DIFF
--- a/ecc/bls12381/constants.go
+++ b/ecc/bls12381/constants.go
@@ -1,6 +1,7 @@
 package bls12381
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/cloudflare/circl/ecc/bls12381/ff"
@@ -41,11 +42,10 @@ var (
 	}
 )
 
-func err(e error) {
-	if e != nil {
-		panic(e)
-	}
-}
+var (
+	errInputLength = errors.New("incorrect input length")
+	errEncoding    = errors.New("incorrect encoding")
+)
 
 func headerEncoding(isCompressed, isInfinity, isBigYCoord byte) byte {
 	return (isBigYCoord&0x1)<<5 | (isInfinity&0x1)<<6 | (isCompressed&0x1)<<7
@@ -64,6 +64,12 @@ func ratioKummer(z *ff.Fp2, t *ff.Fp12) {
 }
 
 func init() {
+	err := func(e error) {
+		if e != nil {
+			panic(e)
+		}
+	}
+
 	g1Params.b.SetUint64(4)
 	g1Params._3b.SetUint64(12)
 	err(g1Params.genX.SetString("0x17f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb"))

--- a/ecc/bls12381/ff/common.go
+++ b/ecc/bls12381/ff/common.go
@@ -35,14 +35,21 @@ func setString(in string, order []byte) ([]uint64, error) {
 		return nil, errInputRange
 	}
 	inBytes := inBig.FillBytes(make([]byte, len(order)))
-	return setBytes(inBytes, order)
+	return setBytesBounded(inBytes, order)
 }
 
-func setBytes(in []byte, order []byte) ([]uint64, error) {
+func setBytesBounded(in []byte, order []byte) ([]uint64, error) {
 	if isLessThan(in, order) == 0 {
 		return nil, errInputRange
 	}
 	return conv.BytesBe2Uint64Le(in), nil
+}
+
+func setBytesUnbounded(in []byte, order []byte) []uint64 {
+	inBig := new(big.Int).SetBytes(in)
+	inBig.Mod(inBig, new(big.Int).SetBytes(order))
+	inBytes := inBig.FillBytes(make([]byte, len(order)))
+	return conv.BytesBe2Uint64Le(inBytes)
 }
 
 // isLessThan returns 1 if 0 <= x < y, otherwise 0. Assumes that slices have the same length.

--- a/ecc/bls12381/ff/cyclo6_test.go
+++ b/ecc/bls12381/ff/cyclo6_test.go
@@ -14,14 +14,14 @@ func randomCyclo6(t testing.TB) *Cyclo6 {
 }
 
 // phi6primeSq evaluates the 6-th cyclotomic polynomial, \phi_6(x) = x^2-x+1, at p^2.
-func phi6primeSq() *big.Int {
+func phi6primeSq() []byte {
 	one := big.NewInt(1)
 	p := new(big.Int).SetBytes(fpOrder[:]) // p
 	p2 := new(big.Int).Mul(p, p)           // p^2
 	p4 := new(big.Int).Sub(p2, one)        // p^2 - 1
 	p4.Mul(p4, p2)                         // p^4 - p^2
 	p4.Add(p4, one)                        // p^4 - p^2 + 1
-	return p4
+	return p4.Bytes()
 }
 
 func TestCyclo6(t *testing.T) {
@@ -38,7 +38,7 @@ func TestCyclo6(t *testing.T) {
 		}
 	})
 	t.Run("order", func(t *testing.T) {
-		cyclo6Order := phi6primeSq().Bytes()
+		cyclo6Order := phi6primeSq()
 		var z Cyclo6
 		for i := 0; i < 16; i++ {
 			x := randomCyclo6(t)

--- a/ecc/bls12381/ff/fp12_test.go
+++ b/ecc/bls12381/ff/fp12_test.go
@@ -59,13 +59,14 @@ func TestFp12(t *testing.T) {
 			}
 		}
 	})
-	t.Run("serdes", func(t *testing.T) {
+	t.Run("marshal", func(t *testing.T) {
 		var b Fp12
 		for i := 0; i < testTimes; i++ {
 			a := randomFp12(t)
-			s := a.Bytes()
-			err := b.SetBytes(s)
-			test.CheckNoErr(t, err, "setbytes failed")
+			s, err := a.MarshalBinary()
+			test.CheckNoErr(t, err, "MarshalBinary failed")
+			err = b.UnmarshalBinary(s)
+			test.CheckNoErr(t, err, "UnmarshalBinary failed")
 			if b.IsEqual(a) == 0 {
 				test.ReportError(t, a, b)
 			}

--- a/ecc/bls12381/ff/fp2_test.go
+++ b/ecc/bls12381/ff/fp2_test.go
@@ -101,13 +101,14 @@ func TestFp2(t *testing.T) {
 			}
 		}
 	})
-	t.Run("serdes", func(t *testing.T) {
+	t.Run("marshal", func(t *testing.T) {
 		var b Fp2
 		for i := 0; i < testTimes; i++ {
 			a := randomFp2(t)
-			s := a.Bytes()
-			err := b.SetBytes(s)
-			test.CheckNoErr(t, err, "setbytes failed")
+			s, err := a.MarshalBinary()
+			test.CheckNoErr(t, err, "MarshalBinary failed")
+			err = b.UnmarshalBinary(s)
+			test.CheckNoErr(t, err, "UnmarshalBinary failed")
 			if b.IsEqual(a) == 0 {
 				test.ReportError(t, a, b)
 			}

--- a/ecc/bls12381/ff/fp_test.go
+++ b/ecc/bls12381/ff/fp_test.go
@@ -107,13 +107,14 @@ func TestFp(t *testing.T) {
 			}
 		}
 	})
-	t.Run("serdes", func(t *testing.T) {
+	t.Run("marshal", func(t *testing.T) {
 		var b Fp
 		for i := 0; i < testTimes; i++ {
 			a := randomFp(t)
-			s := a.Bytes()
-			err := b.SetBytes(s)
-			test.CheckNoErr(t, err, "setbytes failed")
+			s, err := a.MarshalBinary()
+			test.CheckNoErr(t, err, "MarshalBinary failed")
+			err = b.UnmarshalBinary(s)
+			test.CheckNoErr(t, err, "UnmarshalBinary failed")
 			if b.IsEqual(a) == 0 {
 				test.ReportError(t, a, b)
 			}

--- a/ecc/bls12381/ff/uroot.go
+++ b/ecc/bls12381/ff/uroot.go
@@ -7,13 +7,13 @@ const URootSize = Fp12Size
 // that x^n=1, where n = ScalarOrder().
 type URoot Cyclo6
 
-func (z URoot) String() string                 { return (Cyclo6)(z).String() }
-func (z *URoot) SetBytes(b []byte) error       { return (*Fp12)(z).SetBytes(b) }
-func (z URoot) Bytes() []byte                  { return (Fp12)(z).Bytes() }
-func (z *URoot) SetIdentity()                  { (*Fp12)(z).SetOne() }
-func (z URoot) IsEqual(x *URoot) int           { return (Cyclo6)(z).IsEqual((*Cyclo6)(x)) }
-func (z URoot) IsIdentity() int                { i := &URoot{}; i.SetIdentity(); return z.IsEqual(i) }
-func (z *URoot) ExpVarTime(x *URoot, n []byte) { (*Cyclo6)(z).expVarTime((*Cyclo6)(x), n) }
-func (z *URoot) Mul(x, y *URoot)               { (*Cyclo6)(z).Mul((*Cyclo6)(x), (*Cyclo6)(y)) }
-func (z *URoot) Sqr(x *URoot)                  { (*Cyclo6)(z).Sqr((*Cyclo6)(x)) }
-func (z *URoot) Inv(x *URoot)                  { (*Cyclo6)(z).Inv((*Cyclo6)(x)) }
+func (z URoot) String() string                  { return (Cyclo6)(z).String() }
+func (z *URoot) UnmarshalBinary(b []byte) error { return (*Fp12)(z).UnmarshalBinary(b) }
+func (z URoot) MarshalBinary() ([]byte, error)  { return (Fp12)(z).MarshalBinary() }
+func (z *URoot) SetIdentity()                   { (*Fp12)(z).SetOne() }
+func (z URoot) IsEqual(x *URoot) int            { return (Cyclo6)(z).IsEqual((*Cyclo6)(x)) }
+func (z URoot) IsIdentity() int                 { i := &URoot{}; i.SetIdentity(); return z.IsEqual(i) }
+func (z *URoot) ExpVarTime(x *URoot, n []byte)  { (*Cyclo6)(z).expVarTime((*Cyclo6)(x), n) }
+func (z *URoot) Mul(x, y *URoot)                { (*Cyclo6)(z).Mul((*Cyclo6)(x), (*Cyclo6)(y)) }
+func (z *URoot) Sqr(x *URoot)                   { (*Cyclo6)(z).Sqr((*Cyclo6)(x)) }
+func (z *URoot) Inv(x *URoot)                   { (*Cyclo6)(z).Inv((*Cyclo6)(x)) }

--- a/ecc/bls12381/g1_test.go
+++ b/ecc/bls12381/g1_test.go
@@ -125,6 +125,7 @@ func BenchmarkG1(b *testing.B) {
 }
 
 func TestG1Serial(t *testing.T) {
+	mustOk := "must be ok"
 	mustErr := "must be an error"
 	t.Run("valid", func(t *testing.T) {
 		testTimes := 1 << 6
@@ -150,14 +151,14 @@ func TestG1Serial(t *testing.T) {
 		test.CheckIsErr(t, q.SetBytes(b[:1]), mustErr)
 		test.CheckIsErr(t, q.SetBytes(b[:G1Size-1]), mustErr)
 		test.CheckIsErr(t, q.SetBytes(b[:G1SizeCompressed]), mustErr)
-		test.CheckNoErr(t, q.SetBytes(b), "must be ok")
-		test.CheckNoErr(t, q.SetBytes(append(b, 0)), "must be ok")
+		test.CheckNoErr(t, q.SetBytes(b), mustOk)
+		test.CheckNoErr(t, q.SetBytes(append(b, 0)), mustOk)
 		b = p.BytesCompressed()
 		test.CheckIsErr(t, q.SetBytes(b[:0]), mustErr)
 		test.CheckIsErr(t, q.SetBytes(b[:1]), mustErr)
 		test.CheckIsErr(t, q.SetBytes(b[:G1SizeCompressed-1]), mustErr)
-		test.CheckNoErr(t, q.SetBytes(b), "must be ok")
-		test.CheckNoErr(t, q.SetBytes(append(b, 0)), "must be ok")
+		test.CheckNoErr(t, q.SetBytes(b), mustOk)
+		test.CheckNoErr(t, q.SetBytes(append(b, 0)), mustOk)
 	})
 	t.Run("badInfinity", func(t *testing.T) {
 		var badInf, p G1
@@ -178,7 +179,8 @@ func TestG1Serial(t *testing.T) {
 		}
 		var e ff.Fp
 		_ = e.Random(rand.Reader)
-		good := e.Bytes()
+		good, err := e.MarshalBinary()
+		test.CheckNoErr(t, err, mustOk)
 
 		// bad x, good y
 		b := append(bad, good...)
@@ -193,7 +195,8 @@ func TestG1Serial(t *testing.T) {
 	t.Run("noQR", func(t *testing.T) {
 		var x ff.Fp
 		x.SetUint64(1) // Let x=1, so x^3+4 = 5, which is not QR.
-		b := x.Bytes()
+		b, err := x.MarshalBinary()
+		test.CheckNoErr(t, err, mustOk)
 		b[0] = b[0]&0x1F | headerEncoding(1, 0, 0)
 		test.CheckIsErr(t, new(G1).SetBytes(b), mustErr)
 	})
@@ -201,7 +204,11 @@ func TestG1Serial(t *testing.T) {
 		// p=(0,1) is not on curve.
 		var x, y ff.Fp
 		y.SetUint64(1)
-		b := append(x.Bytes(), y.Bytes()...)
+		bx, err := x.MarshalBinary()
+		test.CheckNoErr(t, err, mustOk)
+		by, err := y.MarshalBinary()
+		test.CheckNoErr(t, err, mustOk)
+		b := append(bx, by...)
 		b[0] = b[0]&0x1F | headerEncoding(0, 0, 0)
 		test.CheckIsErr(t, new(G1).SetBytes(b), mustErr)
 	})

--- a/ecc/bls12381/gt.go
+++ b/ecc/bls12381/gt.go
@@ -8,15 +8,15 @@ const GtSize = ff.URootSize
 // Gt represents an element of the output (multiplicative) group of a pairing.
 type Gt struct{ i ff.URoot }
 
-func (z Gt) String() string           { return z.i.String() }
-func (z *Gt) SetBytes(b []byte) error { return z.i.SetBytes(b) }
-func (z Gt) Bytes() []byte            { return z.i.Bytes() }
-func (z *Gt) SetIdentity()            { z.i.SetIdentity() }
-func (z Gt) IsEqual(x *Gt) bool       { return z.i.IsEqual(&x.i) == 1 }
-func (z Gt) IsIdentity() bool         { i := &Gt{}; i.SetIdentity(); return z.IsEqual(i) }
-func (z *Gt) Mul(x, y *Gt)            { z.i.Mul(&x.i, &y.i) }
-func (z *Gt) Sqr(x *Gt)               { z.i.Sqr(&x.i) }
-func (z *Gt) Inv(x *Gt)               { z.i.Inv(&x.i) }
+func (z Gt) String() string                  { return z.i.String() }
+func (z *Gt) UnmarshalBinary(b []byte) error { return z.i.UnmarshalBinary(b) }
+func (z Gt) MarshalBinary() ([]byte, error)  { return z.i.MarshalBinary() }
+func (z *Gt) SetIdentity()                   { z.i.SetIdentity() }
+func (z Gt) IsEqual(x *Gt) bool              { return z.i.IsEqual(&x.i) == 1 }
+func (z Gt) IsIdentity() bool                { i := &Gt{}; i.SetIdentity(); return z.IsEqual(i) }
+func (z *Gt) Mul(x, y *Gt)                   { z.i.Mul(&x.i, &y.i) }
+func (z *Gt) Sqr(x *Gt)                      { z.i.Sqr(&x.i) }
+func (z *Gt) Inv(x *Gt)                      { z.i.Inv(&x.i) }
 
 // ExpVarTime calculates z=x^n, where n is the exponent in big-endian order.
-func (z *Gt) ExpVarTime(x *Gt, n *Scalar) { z.i.ExpVarTime(&x.i, n.Bytes()) }
+func (z *Gt) ExpVarTime(x *Gt, n *Scalar) { b, _ := n.MarshalBinary(); z.i.ExpVarTime(&x.i, b) }

--- a/ecc/bls12381/pair.go
+++ b/ecc/bls12381/pair.go
@@ -90,7 +90,8 @@ func ProdPair(P []*G1, Q []*G2, n []*Scalar) *Gt {
 	affinize(P)
 	for i := range P {
 		miller(mi, P[i], Q[i])
-		ei.ExpVarTime(mi, n[i].Bytes())
+		nb, _ := n[i].MarshalBinary()
+		ei.ExpVarTime(mi, nb)
 		out.Mul(out, ei)
 	}
 


### PR DESCRIPTION
Implements the Marshaler interfaces from go stdlib for serialization and deserialization.
Also, Scalar exposes `SetBytes([]byte)` to set scalars using variable-length data.