### PR TITLE
Alternative tower for fast pairings

### DIFF
--- a/ecc/bls12381/ff/doc.go
+++ b/ecc/bls12381/ff/doc.go
@@ -13,6 +13,11 @@
 // The binary representation takes Fp2Size = 96 bytes encoded as a[1] || a[0]
 // all in big-endian form.
 //
+// Fp4
+//
+// Fp4 is GF(p^4)=Fp2[t]/(t^2-(u+1)). We use the repesentation  a[1]v+a[0].
+// There is no fixed external form.
+//
 // Fp6
 //
 // Fp6 are elements of the finite field GF(p^6) = Fp2[v]/(v^3-u-1) represented as
@@ -26,6 +31,9 @@
 //  (a[1]w + a[0]) in Fp12, where a[0],a[1] in Fp6
 // The binary representation takes Fp12Size = 576 bytes encoded as a[1] || a[0]
 // all in big-endian form.
+//
+// We can also represent this field via Fp4[w]/(w^3-t). This is the struct Fp12alt,
+// used to accelerate the pairing calculation.
 //
 // Scalar
 //

--- a/ecc/bls12381/ff/fp12cubic.go
+++ b/ecc/bls12381/ff/fp12cubic.go
@@ -1,0 +1,166 @@
+package ff
+
+import "fmt"
+
+// Fp12Cubic represents elements of Fp4[w]/w^3-t
+type Fp12Cubic [3]Fp4
+
+// LineValue a represents a[0]+a[1]*w^2+a[2]*w^3, with all values in Fp2.
+// This lets us shave off a number of Fp2 multiplications.
+type LineValue [3]Fp2
+
+func (z Fp12Cubic) String() string {
+	return fmt.Sprintf("%s + ( %s )*w + ( %s )*w^2", z[0], z[1], z[2])
+}
+func (z Fp12Cubic) IsEqual(x *Fp12Cubic) int {
+	return z[0].IsEqual(&x[0]) & z[1].IsEqual(&x[1]) & z[2].IsEqual(&x[2])
+}
+func (z *Fp12Cubic) FromFp12(x *Fp12) {
+	// To understand this function, write everything in Fp2[w]/(w^6-(u+1)).
+	// v = w^2
+	// t = w^3
+	z[0][0] = x[0][0] // w^0
+	z[1][0] = x[1][0] // w^1
+	z[2][0] = x[0][1] // w^2
+	z[0][1] = x[1][1] // w^3
+	z[1][1] = x[0][2] // w^4
+	z[2][1] = x[1][2] // w^5
+}
+
+func (z *Fp12) FromFp12Alt(x *Fp12Cubic) {
+	z[0][0] = x[0][0] // w^0
+	z[1][0] = x[1][0] // w^1
+	z[0][1] = x[2][0] // w^2
+	z[1][1] = x[0][1] // w^3
+	z[0][2] = x[1][1] // w^4
+	z[1][2] = x[2][1] // w^5
+}
+
+func (z *Fp12Cubic) Add(x *Fp12Cubic, y *Fp12Cubic) {
+	z[0].Add(&x[0], &y[0])
+	z[1].Add(&x[1], &y[1])
+	z[2].Add(&x[2], &y[2])
+}
+
+func (z *Fp12Cubic) SetOne() {
+	z[0].SetOne()
+	z[1] = Fp4{}
+	z[2] = Fp4{}
+}
+
+func (z *Fp12Cubic) Mul(x *Fp12Cubic, y *Fp12Cubic) {
+	// This is a Karatsuba like technique: compute x_iy_i, then
+	// subtract the terms from expressions like (x0+x1)(y0+y1).
+	// See Multiplication and Squaring in Pairing Friendly Fields
+	// for more.
+	var v0, v1, v2, p0, p1, p2, tx, ty Fp4
+	v0.Mul(&x[0], &y[0])
+	v1.Mul(&x[1], &y[1])
+	v2.Mul(&x[2], &y[2])
+
+	tx.Add(&x[1], &x[2])
+	ty.Add(&y[1], &y[2])
+	p0.Mul(&tx, &ty)
+
+	tx.Add(&x[0], &x[1])
+	ty.Add(&y[0], &y[1])
+	p1.Mul(&tx, &ty)
+
+	tx.Add(&x[0], &x[2])
+	ty.Add(&y[0], &y[2])
+	p2.Mul(&tx, &ty)
+
+	z[0].Sub(&p0, &v1)
+	z[0].Sub(&z[0], &v2)
+	z[0].mulT(&z[0])
+	z[0].Add(&z[0], &v0)
+
+	z[1].Sub(&p1, &v0)
+	z[1].Sub(&z[1], &v1)
+	tx.mulT(&v2)
+	z[1].Add(&z[1], &tx)
+
+	z[2].Sub(&p2, &v0)
+	z[2].Add(&z[2], &v1)
+	z[2].Sub(&z[2], &v2)
+}
+
+func (z *Fp12Cubic) Sqr(x *Fp12Cubic) {
+	// The Chung-Hasan asymmetric squaring formula.
+	// We keep the same notation as in Multiplication
+	// and Squaring on Pairing-Friendly Fields to make
+	// it easier to compare.
+
+	var s0, s1, s2, s3, s4, t Fp4
+	s0.Sqr(&x[0]) // x0^2
+	s1.Mul(&x[0], &x[1])
+	s1.Add(&s1, &s1) // 2x0x1
+	t.Add(&x[0], &x[2])
+	t.Sub(&t, &x[1])
+	s2.Sqr(&t) // (x0-x1+x2)^2
+	s3.Mul(&x[1], &x[2])
+	s3.Add(&s3, &s3) // 2x1x2
+	s4.Sqr(&x[2])    // x2^2
+
+	z[0].mulT(&s3)
+	z[0].Add(&z[0], &s0)
+
+	z[1].mulT(&s4)
+	z[1].Add(&z[1], &s1)
+
+	z[2].Add(&s1, &s2)
+	z[2].Add(&z[2], &s3)
+	z[2].Sub(&z[2], &s0)
+	z[2].Sub(&z[2], &s4)
+}
+
+func (z *Fp12Cubic) MulLine(x *Fp12Cubic, y *LineValue) {
+	// Values produced by evaluating a line function
+	// do not have a linear term, and the quadratic term is
+	// in Fp2.
+
+	// We copy the Mul method, but remove any multiplies by y1,
+	// and strength reduce multiplies by y2.
+	var y0 Fp4
+	var y2 Fp2
+	var v0, v2, p0, p1, p2, tx, ty Fp4
+
+	y0[0] = y[0]
+	y0[1] = y[2]
+	y2 = y[1]
+
+	v0.Mul(&x[0], &y0)
+	v2.mulSubfield(&x[2], &y2)
+
+	tx.Add(&x[1], &x[2])
+	p0.mulSubfield(&tx, &y2)
+
+	tx.Add(&x[0], &x[1])
+	p1.Mul(&tx, &y0)
+
+	tx.Add(&x[0], &x[2])
+	ty = y0
+	ty[0].Add(&ty[0], &y2)
+	p2.Mul(&tx, &ty)
+
+	z[0].Sub(&p0, &v2)
+	z[0].mulT(&z[0])
+	z[0].Add(&z[0], &v0)
+
+	z[1].Sub(&p1, &v0)
+	tx.mulT(&v2)
+	z[1].Add(&z[1], &tx)
+
+	z[2].Sub(&p2, &v0)
+	z[2].Sub(&z[2], &v2)
+}
+
+func (z *LineValue) IsZero() int {
+	return z[0].IsZero() & z[1].IsZero() & z[2].IsZero()
+}
+
+func (z *LineValue) SetOne() {
+	z[0].SetOne()
+	z[1] = Fp2{}
+	z[2] = Fp2{}
+}

--- a/ecc/bls12381/ff/fp12cubic_test.go
+++ b/ecc/bls12381/ff/fp12cubic_test.go
@@ -1,0 +1,83 @@
+package ff
+
+import (
+	"testing"
+
+	"github.com/cloudflare/circl/internal/test"
+)
+
+func TestFP12CubicAdd(t *testing.T) {
+	const testTimes = 1 << 8
+	for i := 0; i < testTimes; i++ {
+		var xalt, yalt, zalt Fp12Cubic
+		var z, zcmp Fp12
+		x := randomFp12(t)
+		y := randomFp12(t)
+		xalt.FromFp12(x)
+		yalt.FromFp12(y)
+		zalt.Add(&xalt, &yalt)
+		z.Add(x, y)
+		zcmp.FromFp12Alt(&zalt)
+		if z.IsEqual(&zcmp) == 0 {
+			test.ReportError(t, z, zcmp, x, y)
+		}
+	}
+}
+
+func TestFP12CubicMul(t *testing.T) {
+	const testTimes = 1 << 8
+	for i := 0; i < testTimes; i++ {
+		var xalt, yalt, zalt Fp12Cubic
+		var z, zcmp Fp12
+		x := randomFp12(t)
+		y := randomFp12(t)
+		xalt.FromFp12(x)
+		yalt.FromFp12(y)
+		zalt.Mul(&xalt, &yalt)
+		z.Mul(x, y)
+		zcmp.FromFp12Alt(&zalt)
+		if z.IsEqual(&zcmp) == 0 {
+			test.ReportError(t, z, zcmp, x, y)
+		}
+	}
+}
+
+func TestFP12AltSqr(t *testing.T) {
+	const testTimes = 1 << 8
+	for i := 0; i < testTimes; i++ {
+		var xalt, zalt Fp12Cubic
+		var z, zcmp Fp12
+		x := randomFp12(t)
+		xalt.FromFp12(x)
+		zalt.Sqr(&xalt)
+		z.Sqr(x)
+		zcmp.FromFp12Alt(&zalt)
+		if z.IsEqual(&zcmp) == 0 {
+			test.ReportError(t, z, zcmp, x)
+		}
+	}
+}
+
+func TestFP12CubicLine(t *testing.T) {
+	const testTimes = 1 << 8
+	for i := 0; i < testTimes; i++ {
+		var x, y, z, zcmp Fp12Cubic
+		var yline LineValue
+		xnorm := randomFp12(t)
+		x.FromFp12(xnorm)
+
+		yline[0] = *randomFp2(t)
+		yline[1] = *randomFp2(t)
+		yline[2] = *randomFp2(t)
+
+		y[0][0] = yline[0]
+		y[0][1] = yline[2]
+		y[2][0] = yline[1]
+
+		zcmp.Mul(&x, &y)
+		z.MulLine(&x, &yline)
+		if z.IsEqual(&zcmp) == 0 {
+			test.ReportError(t, z, zcmp, x)
+		}
+	}
+}

--- a/ecc/bls12381/ff/fp4.go
+++ b/ecc/bls12381/ff/fp4.go
@@ -1,0 +1,98 @@
+package ff
+
+import "fmt"
+
+// Fp4Size is the size of an Fp4 element
+const Fp4Size = 4 * FpSize
+
+// Fp4 is obtained by adjoining t, the square root of u+1 to Fp2
+type Fp4 [2]Fp2
+
+func (z Fp4) String() string { return fmt.Sprintf("%s + ( %s )*t", z[0], z[1]) }
+
+func (z *Fp4) SetOne() {
+	z[0].SetOne()
+	z[1] = Fp2{}
+}
+func (z *Fp4) IsZero() int {
+	return z.IsEqual(&Fp4{})
+}
+
+func (z *Fp4) IsEqual(x *Fp4) int {
+	return z[0].IsEqual(&x[0]) & z[1].IsEqual(&x[1])
+}
+
+func (z *Fp4) Neg() {
+	z[0].Neg()
+	z[1].Neg()
+}
+
+func (z *Fp4) Add(x *Fp4, y *Fp4) {
+	z[0].Add(&x[0], &y[0])
+	z[1].Add(&x[1], &y[1])
+}
+
+func (z *Fp4) Sub(x *Fp4, y *Fp4) {
+	z[0].Sub(&x[0], &y[0])
+	z[1].Sub(&x[1], &y[1])
+}
+
+func (z *Fp4) Mul(x *Fp4, y *Fp4) {
+	var x0y0, x1y1, sx, sy, k Fp2
+	x0y0.Mul(&x[0], &y[0])
+	x1y1.Mul(&x[1], &y[1])
+	sx.Add(&x[0], &x[1])
+	sy.Add(&y[0], &y[1])
+	k.Mul(&sx, &sy)
+	k.Sub(&k, &x0y0)
+	k.Sub(&k, &x1y1)
+	// k is x0y1+x1y0 computed as (x0+x1)(y0+y1)-x0y0-x1y1
+	z[1] = k
+	// Multiply x1y1 by u+1
+	z[0][1].Add(&x1y1[0], &x1y1[1])
+	z[0][0].Sub(&x1y1[0], &x1y1[1])
+	z[0].Add(&z[0], &x0y0)
+}
+
+func (z *Fp4) Sqr(x *Fp4) {
+	var x0s, x1s, sx, k Fp2
+	x0s.Sqr(&x[0])
+	x1s.Sqr(&x[1])
+	sx.Add(&x[0], &x[1])
+	k.Sqr(&sx)
+	k.Sub(&k, &x0s)
+	k.Sub(&k, &x1s)
+
+	z[1] = k
+	// Multiplying x1s by u+1
+	z[0][1].Add(&x1s[0], &x1s[1])
+	z[0][0].Sub(&x1s[0], &x1s[1])
+	z[0].Add(&z[0], &x0s)
+}
+
+func (z *Fp4) Inv(x *Fp4) {
+	// Compute the inverse via conjugation
+	var denom, x0sqr, x1sqr Fp2
+	x0sqr.Sqr(&x[0])
+	x1sqr.Sqr(&x[1])
+	denom[1].Add(&x1sqr[0], &x1sqr[1])
+	denom[0].Sub(&x1sqr[0], &x1sqr[1])
+	denom.Sub(&x0sqr, &denom)
+	denom.Inv(&denom)
+	z[0] = x[0]
+	z[1].Sub(&z[1], &x[1])
+	z.mulSubfield(z, &denom)
+}
+
+func (z *Fp4) mulSubfield(x *Fp4, y *Fp2) {
+	z[0].Mul(&x[0], y)
+	z[1].Mul(&x[1], y)
+}
+
+func (z *Fp4) mulT(x *Fp4) {
+	var t Fp4
+	t[1] = x[0]
+	t[0][1].Add(&x[1][0], &x[1][1])
+	t[0][0].Sub(&x[1][0], &x[1][1])
+	*z = t
+}


### PR DESCRIPTION
By constructing Fp12 as a cubic over a biquadratic, we can take
advantage of the special form of line function evaluations and save
multiplications inside of the Miller loop. Currently this produces a
6% gain, although further improvements should be possible.