### PR TITLE
sha3: prevent state from escaping to heap

### DIFF
--- a/internal/sha3/xor.go
+++ b/internal/sha3/xor.go
@@ -13,12 +13,3 @@ type storageBuf [maxRate]byte
 func (b *storageBuf) asBytes() *[maxRate]byte {
 	return (*[maxRate]byte)(b)
 }
-
-var (
-	xorIn            = xorInGeneric
-	copyOut          = copyOutGeneric
-	xorInUnaligned   = xorInGeneric
-	copyOutUnaligned = copyOutGeneric
-)
-
-const xorImplementationUnaligned = "generic"

--- a/internal/sha3/xor_generic.go
+++ b/internal/sha3/xor_generic.go
@@ -2,14 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (!amd64 || appengine) && (!386 || appengine) && (!ppc64le || appengine)
+// +build !amd64 appengine
+// +build !386 appengine
+// +build !ppc64le appengine
+
 package sha3
 
 import "encoding/binary"
 
-// xorInGeneric xors the bytes in buf into the state; it
+// xorIn xors the bytes in buf into the state; it
 // makes no non-portable assumptions about memory layout
 // or alignment.
-func xorInGeneric(d *State, buf []byte) {
+func xorIn(d *State, buf []byte) {
 	n := len(buf) / 8
 
 	for i := 0; i < n; i++ {
@@ -19,8 +24,8 @@ func xorInGeneric(d *State, buf []byte) {
 	}
 }
 
-// copyOutGeneric copies ulint64s to a byte buffer.
-func copyOutGeneric(d *State, b []byte) {
+// copyOut copies ulint64s to a byte buffer.
+func copyOut(d *State, b []byte) {
 	for i := 0; len(b) >= 8; i++ {
 		binary.LittleEndian.PutUint64(b, d.a[i])
 		b = b[8:]

--- a/internal/sha3/xor_unaligned.go
+++ b/internal/sha3/xor_unaligned.go
@@ -17,9 +17,9 @@ func (b *storageBuf) asBytes() *[maxRate]byte {
 	return (*[maxRate]byte)(unsafe.Pointer(b))
 }
 
-// xorInUnaligned uses unaligned reads and writes to update d.a to contain d.a
+// xorInuses unaligned reads and writes to update d.a to contain d.a
 // XOR buf.
-func xorInUnaligned(d *State, buf []byte) {
+func xorIn(d *State, buf []byte) {
 	n := len(buf)
 	bw := (*[maxRate / 8]uint64)(unsafe.Pointer(&buf[0]))[: n/8 : n/8]
 	if n >= 72 {
@@ -55,14 +55,7 @@ func xorInUnaligned(d *State, buf []byte) {
 	}
 }
 
-func copyOutUnaligned(d *State, buf []byte) {
+func copyOut(d *State, buf []byte) {
 	ab := (*[maxRate]uint8)(unsafe.Pointer(&d.a[0]))
 	copy(buf, ab[:])
 }
-
-var (
-	xorIn   = xorInUnaligned
-	copyOut = copyOutUnaligned
-)
-
-const xorImplementationUnaligned = "unaligned"


### PR DESCRIPTION
Two issues prevented the sha3/shake state from staying on the heap:

    1. xorIn and copyOut were virtuals (variables)
    2. State contains a pointer (buf) into itself

The solution is simple.

For (1) we set xorIn and copyOut at compile-time, which it already was,
but the compiler didn't notice.

For (2) we store the bounds of the original slice buf into storage
instead of the slice itself.

Actual performance benefit doesn't show up properly in this microbenchmark
as it is seen when there is a lot of pressure on the GC:

```
name                   old time/op   new time/op   delta
PermutationFunction-8    375ns ± 7%    375ns ± 9%    ~     (p=0.730 n=5+5)
Sha3_512_MTU-8          8.68µs ± 0%   8.10µs ± 3%  -6.74%  (p=0.008 n=5+5)
Sha3_384_MTU-8          6.27µs ± 1%   6.04µs ± 2%  -3.51%  (p=0.008 n=5+5)
Sha3_256_MTU-8          4.99µs ± 0%   4.72µs ± 4%  -5.56%  (p=0.008 n=5+5)
Sha3_224_MTU-8          4.78µs ± 0%   4.36µs ± 2%  -8.73%  (p=0.016 n=4+5)
Shake128_MTU-8          3.62µs ± 4%   3.59µs ± 3%    ~     (p=0.690 n=5+5)
Shake256_MTU-8          3.86µs ± 2%   3.86µs ± 3%    ~     (p=0.690 n=5+5)
Shake256_16x-8          53.9µs ± 2%   56.3µs ± 5%  +4.51%  (p=0.032 n=5+5)
Shake256_1MiB-8         2.96ms ± 2%   2.94ms ± 1%    ~     (p=0.421 n=5+5)
Sha3_512_1MiB-8         5.57ms ± 3%   5.45ms ± 1%    ~     (p=0.056 n=5+5)

name                   old speed     new speed     delta
PermutationFunction-8  533MB/s ± 7%  534MB/s ± 9%    ~     (p=0.841 n=5+5)
Sha3_512_MTU-8         155MB/s ± 0%  167MB/s ± 3%  +7.27%  (p=0.008 n=5+5)
Sha3_384_MTU-8         215MB/s ± 1%  223MB/s ± 2%  +3.66%  (p=0.008 n=5+5)
Sha3_256_MTU-8         270MB/s ± 0%  286MB/s ± 4%  +5.95%  (p=0.008 n=5+5)
Sha3_224_MTU-8         283MB/s ± 0%  310MB/s ± 2%  +9.59%  (p=0.016 n=4+5)
Shake128_MTU-8         373MB/s ± 4%  376MB/s ± 3%    ~     (p=0.690 n=5+5)
Shake256_MTU-8         350MB/s ± 2%  350MB/s ± 3%    ~     (p=0.690 n=5+5)
Shake256_16x-8         304MB/s ± 2%  291MB/s ± 5%  -4.25%  (p=0.032 n=5+5)
Shake256_1MiB-8        354MB/s ± 2%  357MB/s ± 1%    ~     (p=0.421 n=5+5)
Sha3_512_1MiB-8        188MB/s ± 3%  192MB/s ± 1%    ~     (p=0.056 n=5+5)
```

Closes #281