### PR TITLE
bls12: addition chain for inversion in Fp

### DIFF
--- a/ecc/bls12381/ff/fp.go
+++ b/ecc/bls12381/ff/fp.go
@@ -41,7 +41,6 @@ func (z *Fp) Add(x, y *Fp)         { fiatFpMontAdd(&z.i, &x.i, &y.i) }
 func (z *Fp) Sub(x, y *Fp)         { fiatFpMontSub(&z.i, &x.i, &y.i) }
 func (z *Fp) Mul(x, y *Fp)         { fiatFpMontMul(&z.i, &x.i, &y.i) }
 func (z *Fp) Sqr(x *Fp)            { fiatFpMontSquare(&z.i, &x.i) }
-func (z *Fp) Inv(x *Fp)            { z.ExpVarTime(x, fpOrderMinus2[:]) }
 func (z *Fp) toMont(in *fpRaw)     { fiatFpMontMul(&z.i, in, &fpRSquare) }
 func (z Fp) fromMont() (out fpRaw) { fiatFpMontMul(&out, &z.i, &fpMont{1}); return }
 func (z Fp) Sgn0() int             { return int(z.fromMont()[0]) & 1 }
@@ -119,6 +118,69 @@ func (z *Fp) SetString(s string) error {
 
 func fiatFpMontCmovznzU64(z *uint64, b, x, y uint64) { cselectU64(z, b, x, y) }
 
+func (z *Fp) Inv(x *Fp) {
+	// Addition chain found using mmcloughlin/addchain: v0.3.0
+	// McLoughlin, Michael Ben. (2021). https://doi.org/10.5281/zenodo.4758226
+	var i2, i4, i8, i9, i11, i13, i17, i20, i25, i26, i52, i54, i55, i77, i79,
+		i86, i93, i103, i105, i119, i123, i137, i149, i151, i169, i177, i191,
+		i195, i208, i215, i225, i229, i235, i245, i255 Fp
+
+	i2.Sqr(x)
+	i4.Sqr(&i2)
+	i8.Sqr(&i4)
+	i9.Mul(&i8, x)
+	i11.Mul(&i9, &i2)
+	i13.Mul(&i11, &i2)
+	i17.Mul(&i13, &i4)
+	i20.Mul(&i11, &i9)
+	i25.Mul(&i17, &i8)
+	i26.Mul(&i25, x)
+	i52.Sqr(&i26)
+	i54.Mul(&i52, &i2)
+	i55.Mul(&i54, x)
+	i77.Mul(&i52, &i25)
+	i79.Mul(&i77, &i2)
+	i86.Mul(&i77, &i8)
+	i93.Mul(&i86, &i8)
+	i103.Mul(&i77, &i26)
+	i105.Mul(&i103, &i2)
+	i119.Mul(&i93, &i26)
+	i123.Mul(&i119, &i4)
+	i137.Mul(&i86, &i52)
+	i149.Mul(&i123, &i26)
+	i151.Mul(&i149, &i2)
+	i169.Mul(&i149, &i20)
+	i177.Mul(&i169, &i8)
+	i191.Mul(&i137, &i54)
+	i195.Mul(&i191, &i4)
+	i208.Mul(&i195, &i13)
+	i215.Mul(&i195, &i20)
+	i225.Mul(&i208, &i17)
+	i229.Mul(&i225, &i4)
+	i235.Mul(&i215, &i20)
+	i245.Mul(&i225, &i20)
+	i255.Mul(&i235, &i20)
+	z.Mul(&i225, &i191)
+
+	for _, s := range []struct {
+		l int
+		x *Fp
+	}{
+		{8, &i17}, {11, &i245}, {11, &i229}, {8, &i255}, {7, &i77}, {9, &i105},
+		{10, &i177}, {7, &i93}, {9, &i123}, {6, &i25}, {11, &i105}, {9, &i235},
+		{10, &i215}, {6, &i25}, {10, &i119}, {9, &i151}, {11, &i79}, {10, &i225},
+		{9, &i137}, {9, &i191}, {8, &i103}, {10, &i195}, {9, &i149}, {12, &i123},
+		{5, &i11}, {11, &i123}, {7, &i9}, {13, &i245}, {9, &i191}, {8, &i255},
+		{8, &i235}, {11, &i169}, {8, &i255}, {8, &i255}, {6, &i55}, {10, &i255},
+		{9, &i255}, {8, &i255}, {8, &i255}, {8, &i255}, {7, &i86}, {9, &i169},
+	} {
+		for i := 0; i < s.l; i++ {
+			z.Sqr(z)
+		}
+		z.Mul(z, s.x)
+	}
+}
+
 var (
 	// fpOrder is the order of the Fp field (big-endian).
 	fpOrder = [FpSize]byte{
@@ -128,15 +190,6 @@ var (
 		0x67, 0x30, 0xd2, 0xa0, 0xf6, 0xb0, 0xf6, 0x24,
 		0x1e, 0xab, 0xff, 0xfe, 0xb1, 0x53, 0xff, 0xff,
 		0xb9, 0xfe, 0xff, 0xff, 0xff, 0xff, 0xaa, 0xab,
-	}
-	// fpOrderMinus2 is the fpOrder minus two used for inversion (big-endian).
-	fpOrderMinus2 = [FpSize]byte{
-		0x1a, 0x01, 0x11, 0xea, 0x39, 0x7f, 0xe6, 0x9a,
-		0x4b, 0x1b, 0xa7, 0xb6, 0x43, 0x4b, 0xac, 0xd7,
-		0x64, 0x77, 0x4b, 0x84, 0xf3, 0x85, 0x12, 0xbf,
-		0x67, 0x30, 0xd2, 0xa0, 0xf6, 0xb0, 0xf6, 0x24,
-		0x1e, 0xab, 0xff, 0xfe, 0xb1, 0x53, 0xff, 0xff,
-		0xb9, 0xfe, 0xff, 0xff, 0xff, 0xff, 0xaa, 0xa9,
 	}
 	// fpOrderPlus1Div2 is the half of (fpOrder plus one) used for lexicographically order (big-endian).
 	fpOrderPlus1Div2 = [FpSize]byte{


### PR DESCRIPTION
Using special addition chain for inversion in Fp.

Chain was found using [mmcloughlin/addchain](https://github.com/mmcloughlin/addchain/tree/v0.3.0) v0.3.0 
McLoughlin, Michael Ben. (2021). https://doi.org/10.5281/zenodo.4758226

```
benchmark               old ns/op     new ns/op     delta
BenchmarkFp12/Inv-8     112649        89706         -20.37%
BenchmarkFp2/Inv-8      95025         68185         -28.25%
BenchmarkFp6/Inv-8      100276        73924         -26.28%
BenchmarkFp/Inv-8       100091        70305         -29.76%
```

cc: @mmcloughlin 