### PR TITLE
sike: blinds the difference point to prevent invalid case in xDblAdd

### DIFF
--- a/dh/sidh/internal/p434/arith_amd64.s
+++ b/dh/sidh/internal/p434/arith_amd64.s
@@ -395,6 +395,34 @@ TEXT ·cswapP434(SB),NOSPLIT,$0-17
 #endif
     RET
 
+TEXT ·cmovP434(SB),NOSPLIT,$0-17
+
+    MOVQ    x+0(FP), DI
+    MOVQ    y+8(FP), SI
+    MOVB    choice+16(FP), AL   // AL = 0 or 1
+    MOVBLZX AL, AX  // AX = 0 or 1
+    NEGQ    AX          // AX = 0x00..00 or 0xff..ff
+#ifndef CMOV_BLOCK
+#define CMOV_BLOCK(idx)    \
+    MOVQ    (idx*8)(DI), BX \ // BX = x[idx]
+    MOVQ    (idx*8)(SI), DX \ // DX = y[idx]
+    XORQ    BX, DX          \ // DX = y[idx] ^ x[idx]
+    ANDQ    AX, DX          \ // DX = (y[idx] ^ x[idx]) & mask
+    XORQ    DX, BX          \ // BX = (y[idx] ^ x[idx]) & mask) ^ x[idx] = x[idx] or y[idx]
+    MOVQ    BX, (idx*8)(DI)
+#endif
+    CMOV_BLOCK(0)
+    CMOV_BLOCK(1)
+    CMOV_BLOCK(2)
+    CMOV_BLOCK(3)
+    CMOV_BLOCK(4)
+    CMOV_BLOCK(5)
+    CMOV_BLOCK(6)
+#ifdef CMOV_BLOCK
+#undef CMOV_BLOCK
+#endif
+    RET
+
 TEXT ·addP434(SB),NOSPLIT,$0-24
     MOVQ    z+0(FP), DX
     MOVQ    x+8(FP), DI

--- a/dh/sidh/internal/p434/arith_decl.go
+++ b/dh/sidh/internal/p434/arith_decl.go
@@ -10,6 +10,12 @@ import (
 	. "github.com/cloudflare/circl/dh/sidh/internal/common"
 )
 
+// If choice = 0, leave x unchanged. If choice = 1, sets x to y.
+// If choice is neither 0 nor 1 then behaviour is undefined.
+// This function executes in constant time.
+//go:noescape
+func cmovP434(x, y *Fp, choice uint8)
+
 // If choice = 0, leave x,y unchanged. If choice = 1, set x,y = y,x.
 // If choice is neither 0 nor 1 then behaviour is undefined.
 // This function executes in constant time.

--- a/dh/sidh/internal/p434/arith_generic.go
+++ b/dh/sidh/internal/p434/arith_generic.go
@@ -51,6 +51,16 @@ func subP434(z, x, y *common.Fp) {
 	}
 }
 
+// If choice = 0, leave x unchanged. If choice = 1, sets x to y.
+// If choice is neither 0 nor 1 then behaviour is undefined.
+// This function executes in constant time.
+func cmovP434(x, y *common.Fp, choice uint8) {
+	mask := 0 - uint64(choice)
+	for i := 0; i < FpWords; i++ {
+		x[i] ^= mask & (x[i] ^ y[i])
+	}
+}
+
 // Conditionally swaps bits in x and y in constant time.
 // mask indicates bits to be swapped (set bits are swapped)
 // For details see "Hackers Delight, 2.20"

--- a/dh/sidh/internal/p434/arith_test.go
+++ b/dh/sidh/internal/p434/arith_test.go
@@ -29,7 +29,7 @@ func TestFpCswap(t *testing.T) {
 	cswapP434(&x, &y, 0)
 	for i := 0; i < FpWords; i++ {
 		if (x[i] != one[i]) || (y[i] != two[i]) {
-			t.Error("Found", x, "expected", two)
+			t.Error("Found", x, "expected", one)
 		}
 	}
 
@@ -37,6 +37,34 @@ func TestFpCswap(t *testing.T) {
 	for i := 0; i < FpWords; i++ {
 		if (x[i] != two[i]) || (y[i] != one[i]) {
 			t.Error("Found", x, "expected", two)
+		}
+	}
+}
+
+func TestFpCmov(t *testing.T) {
+	var one = common.Fp{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	var two = common.Fp{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2}
+
+	var x = one
+	var y = two
+
+	cmovP434(&x, &y, 0)
+	for i := 0; i < FpWords; i++ {
+		if x[i] != one[i] {
+			t.Error("Found", x, "expected", one)
+		}
+		if y[i] != two[i] {
+			t.Error("Found", y, "expected", two)
+		}
+	}
+
+	cmovP434(&x, &y, 1)
+	for i := 0; i < FpWords; i++ {
+		if x[i] != two[i] {
+			t.Error("Found", x, "expected", two)
+		}
+		if y[i] != two[i] {
+			t.Error("Found", y, "expected", two)
 		}
 	}
 }

--- a/dh/sidh/internal/p434/curve.go
+++ b/dh/sidh/internal/p434/curve.go
@@ -4,6 +4,8 @@
 package p434
 
 import (
+	"crypto/rand"
+
 	. "github.com/cloudflare/circl/dh/sidh/internal/common"
 )
 
@@ -239,6 +241,12 @@ func ScalarMul3Pt(cparams *ProjectiveCurveParameters, P, Q, PmQ *ProjectivePoint
 	R2 = *PmQ
 	R0 = *Q
 
+	var blind ProjectivePoint
+	b := make([]byte, 4*params.Bytelen)
+	_, _ = rand.Read(b)
+	BytesToFp2(&blind.X, b[:2*params.Bytelen], params.Bytelen)
+	BytesToFp2(&blind.Z, b[2*params.Bytelen:], params.Bytelen)
+
 	// Iterate over the bits of the scalar, bottom to top
 	prevBit := uint8(0)
 	for i := uint(0); i < nbits; i++ {
@@ -246,6 +254,7 @@ func ScalarMul3Pt(cparams *ProjectiveCurveParameters, P, Q, PmQ *ProjectivePoint
 		swap := prevBit ^ bit
 		prevBit = bit
 		cswap(&R1.X, &R1.Z, &R2.X, &R2.Z, swap)
+		cmov(&R1.X, &R1.Z, &blind.X, &blind.Z, isZero(&R1.X) | isZero(&R1.Z))
 		R0, R2 = xDbladd(&R0, &R2, &R1, &aPlus2Over4)
 	}
 	cswap(&R1.X, &R1.Z, &R2.X, &R2.Z, prevBit)

--- a/dh/sidh/internal/p434/fp2.go
+++ b/dh/sidh/internal/p434/fp2.go
@@ -157,6 +157,29 @@ func cswap(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
 	cswapP434(&xPz.B, &xQz.B, choice)
 }
 
+// In case choice == 1, performs following moves in constant time:
+//     xPx <- xQx
+//     xPz <- xQz
+// Otherwise returns xPx, xPz, xQx, xQz unchanged
+func cmov(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
+	cmovP434(&xPx.A, &xQx.A, choice)
+	cmovP434(&xPx.B, &xQx.B, choice)
+	cmovP434(&xPz.A, &xQz.A, choice)
+	cmovP434(&xPz.B, &xQz.B, choice)
+}
+
+func isZero(x *common.Fp2) uint8 {
+	r64 := uint64(0)
+	for i := 0; i < FpWords; i++ {
+		r64 |= x.A[i] | x.B[i]
+	}
+	r := uint8(0)
+	for i := uint64(0); i < 64; i++ {
+		r |= uint8((r64 >> i) & 0x1)
+	}
+	return 1 - r
+}
+
 // Converts in.A and in.B to Montgomery domain and stores
 // in 'out'
 // out.A = in.A * R mod p

--- a/dh/sidh/internal/p503/arith_arm64.s
+++ b/dh/sidh/internal/p503/arith_arm64.s
@@ -2,6 +2,42 @@
 
 #include "textflag.h"
 
+
+TEXT ·cmovP503(SB), NOSPLIT, $0-17
+	MOVD	x+0(FP), R0
+	MOVD	y+8(FP), R1
+	MOVB	choice+16(FP), R2
+
+	// Set flags
+	// If choice is not 0 or 1, this implementation will swap completely
+	CMP	$0, R2
+
+	LDP	0(R0), (R3, R4)
+	LDP	0(R1), (R5, R6)
+	CSEL	EQ, R3, R5, R7
+	CSEL	EQ, R4, R6, R8
+	STP	(R7, R8), 0(R0)
+
+	LDP	16(R0), (R3, R4)
+	LDP	16(R1), (R5, R6)
+	CSEL	EQ, R3, R5, R7
+	CSEL	EQ, R4, R6, R8
+	STP	(R7, R8), 16(R0)
+
+	LDP	32(R0), (R3, R4)
+	LDP	32(R1), (R5, R6)
+	CSEL	EQ, R3, R5, R7
+	CSEL	EQ, R4, R6, R8
+	STP	(R7, R8), 32(R0)
+
+	LDP	48(R0), (R3, R4)
+	LDP	48(R1), (R5, R6)
+	CSEL	EQ, R3, R5, R7
+	CSEL	EQ, R4, R6, R8
+	STP	(R7, R8), 48(R0)
+
+	RET
+
 TEXT ·cswapP503(SB), NOSPLIT, $0-17
 	MOVD	x+0(FP), R0
 	MOVD	y+8(FP), R1

--- a/dh/sidh/internal/p503/arith_decl.go
+++ b/dh/sidh/internal/p503/arith_decl.go
@@ -10,6 +10,12 @@ import (
 	. "github.com/cloudflare/circl/dh/sidh/internal/common"
 )
 
+// If choice = 0, leave x unchanged. If choice = 1, sets x to y.
+// If choice is neither 0 nor 1 then behaviour is undefined.
+// This function executes in constant time.
+//go:noescape
+func cmovP503(x, y *Fp, choice uint8)
+
 // If choice = 0, leave x,y unchanged. If choice = 1, set x,y = y,x.
 // If choice is neither 0 nor 1 then behaviour is undefined.
 // This function executes in constant time.

--- a/dh/sidh/internal/p503/arith_generic.go
+++ b/dh/sidh/internal/p503/arith_generic.go
@@ -51,6 +51,16 @@ func subP503(z, x, y *common.Fp) {
 	}
 }
 
+// If choice = 0, leave x unchanged. If choice = 1, sets x to y.
+// If choice is neither 0 nor 1 then behaviour is undefined.
+// This function executes in constant time.
+func cmovP503(x, y *common.Fp, choice uint8) {
+	mask := 0 - uint64(choice)
+	for i := 0; i < FpWords; i++ {
+		x[i] ^= mask & (x[i] ^ y[i])
+	}
+}
+
 // Conditionally swaps bits in x and y in constant time.
 // mask indicates bits to be swapped (set bits are swapped)
 // For details see "Hackers Delight, 2.20"

--- a/dh/sidh/internal/p503/arith_test.go
+++ b/dh/sidh/internal/p503/arith_test.go
@@ -29,7 +29,7 @@ func TestFpCswap(t *testing.T) {
 	cswapP503(&x, &y, 0)
 	for i := 0; i < FpWords; i++ {
 		if (x[i] != one[i]) || (y[i] != two[i]) {
-			t.Error("Found", x, "expected", two)
+			t.Error("Found", x, "expected", one)
 		}
 	}
 
@@ -37,6 +37,34 @@ func TestFpCswap(t *testing.T) {
 	for i := 0; i < FpWords; i++ {
 		if (x[i] != two[i]) || (y[i] != one[i]) {
 			t.Error("Found", x, "expected", two)
+		}
+	}
+}
+
+func TestFpCmov(t *testing.T) {
+	var one = common.Fp{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	var two = common.Fp{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2}
+
+	var x = one
+	var y = two
+
+	cmovP503(&x, &y, 0)
+	for i := 0; i < FpWords; i++ {
+		if x[i] != one[i] {
+			t.Error("Found", x, "expected", one)
+		}
+		if y[i] != two[i] {
+			t.Error("Found", y, "expected", two)
+		}
+	}
+
+	cmovP503(&x, &y, 1)
+	for i := 0; i < FpWords; i++ {
+		if x[i] != two[i] {
+			t.Error("Found", x, "expected", two)
+		}
+		if y[i] != two[i] {
+			t.Error("Found", y, "expected", two)
 		}
 	}
 }

--- a/dh/sidh/internal/p503/curve.go
+++ b/dh/sidh/internal/p503/curve.go
@@ -4,6 +4,8 @@
 package p503
 
 import (
+	"crypto/rand"
+
 	. "github.com/cloudflare/circl/dh/sidh/internal/common"
 )
 
@@ -239,6 +241,12 @@ func ScalarMul3Pt(cparams *ProjectiveCurveParameters, P, Q, PmQ *ProjectivePoint
 	R2 = *PmQ
 	R0 = *Q
 
+	var blind ProjectivePoint
+	b := make([]byte, 4*params.Bytelen)
+	_, _ = rand.Read(b)
+	BytesToFp2(&blind.X, b[:2*params.Bytelen], params.Bytelen)
+	BytesToFp2(&blind.Z, b[2*params.Bytelen:], params.Bytelen)
+
 	// Iterate over the bits of the scalar, bottom to top
 	prevBit := uint8(0)
 	for i := uint(0); i < nbits; i++ {
@@ -246,6 +254,7 @@ func ScalarMul3Pt(cparams *ProjectiveCurveParameters, P, Q, PmQ *ProjectivePoint
 		swap := prevBit ^ bit
 		prevBit = bit
 		cswap(&R1.X, &R1.Z, &R2.X, &R2.Z, swap)
+		cmov(&R1.X, &R1.Z, &blind.X, &blind.Z, isZero(&R1.X) | isZero(&R1.Z))
 		R0, R2 = xDbladd(&R0, &R2, &R1, &aPlus2Over4)
 	}
 	cswap(&R1.X, &R1.Z, &R2.X, &R2.Z, prevBit)

--- a/dh/sidh/internal/p503/fp2.go
+++ b/dh/sidh/internal/p503/fp2.go
@@ -157,6 +157,29 @@ func cswap(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
 	cswapP503(&xPz.B, &xQz.B, choice)
 }
 
+// In case choice == 1, performs following moves in constant time:
+//     xPx <- xQx
+//     xPz <- xQz
+// Otherwise returns xPx, xPz, xQx, xQz unchanged
+func cmov(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
+	cmovP503(&xPx.A, &xQx.A, choice)
+	cmovP503(&xPx.B, &xQx.B, choice)
+	cmovP503(&xPz.A, &xQz.A, choice)
+	cmovP503(&xPz.B, &xQz.B, choice)
+}
+
+func isZero(x *common.Fp2) uint8 {
+	r64 := uint64(0)
+	for i := 0; i < FpWords; i++ {
+		r64 |= x.A[i] | x.B[i]
+	}
+	r := uint8(0)
+	for i := uint64(0); i < 64; i++ {
+		r |= uint8((r64 >> i) & 0x1)
+	}
+	return 1 - r
+}
+
 // Converts in.A and in.B to Montgomery domain and stores
 // in 'out'
 // out.A = in.A * R mod p

--- a/dh/sidh/internal/p751/arith_amd64.s
+++ b/dh/sidh/internal/p751/arith_amd64.s
@@ -228,6 +228,39 @@ TEXT ·cswapP751(SB), NOSPLIT, $0-17
 
 	RET
 
+TEXT ·cmovP751(SB),NOSPLIT,$0-17
+
+    MOVQ    x+0(FP), DI
+    MOVQ    y+8(FP), SI
+    MOVB    choice+16(FP), AL   // AL = 0 or 1
+    MOVBLZX AL, AX  // AX = 0 or 1
+    NEGQ    AX          // AX = 0x00..00 or 0xff..ff
+#ifndef CMOV_BLOCK
+#define CMOV_BLOCK(idx)    \
+    MOVQ    (idx*8)(DI), BX \ // BX = x[idx]
+    MOVQ    (idx*8)(SI), DX \ // DX = y[idx]
+    XORQ    BX, DX          \ // DX = y[idx] ^ x[idx]
+    ANDQ    AX, DX          \ // DX = (y[idx] ^ x[idx]) & mask
+    XORQ    DX, BX          \ // BX = (y[idx] ^ x[idx]) & mask) ^ x[idx] = x[idx] or y[idx]
+    MOVQ    BX, (idx*8)(DI)
+#endif
+    CMOV_BLOCK(0)
+    CMOV_BLOCK(1)
+    CMOV_BLOCK(2)
+    CMOV_BLOCK(3)
+    CMOV_BLOCK(4)
+    CMOV_BLOCK(5)
+    CMOV_BLOCK(6)
+    CMOV_BLOCK(7)
+    CMOV_BLOCK(8)
+    CMOV_BLOCK(9)
+    CMOV_BLOCK(10)
+    CMOV_BLOCK(11)
+#ifdef CMOV_BLOCK
+#undef CMOV_BLOCK
+#endif
+    RET
+
 TEXT ·addP751(SB), NOSPLIT, $0-24
 
 	MOVQ	z+0(FP), REG_P3
@@ -2574,4 +2607,3 @@ TEXT ·sulP751(SB), NOSPLIT, $0-24
 	ADCQ    R15, (96+88)(REG_P3)
 
 	RET
-

--- a/dh/sidh/internal/p751/arith_arm64.s
+++ b/dh/sidh/internal/p751/arith_arm64.s
@@ -2,6 +2,53 @@
 
 #include "textflag.h"
 
+TEXT ·cmovP751(SB), NOSPLIT, $0-17
+	MOVD	x+0(FP), R0
+	MOVD	y+8(FP), R1
+	MOVB	choice+16(FP), R2
+
+	// Set flags
+	// If choice is not 0 or 1, this implementation will swap completely
+	CMP	$0, R2
+
+	LDP	0(R0), (R3, R4)
+	LDP	0(R1), (R5, R6)
+	CSEL	EQ, R3, R5, R7
+	CSEL	EQ, R4, R6, R8
+	STP	(R7, R8), 0(R0)
+
+	LDP	16(R0), (R3, R4)
+	LDP	16(R1), (R5, R6)
+	CSEL	EQ, R3, R5, R7
+	CSEL	EQ, R4, R6, R8
+	STP	(R7, R8), 16(R0)
+
+	LDP	32(R0), (R3, R4)
+	LDP	32(R1), (R5, R6)
+	CSEL	EQ, R3, R5, R7
+	CSEL	EQ, R4, R6, R8
+	STP	(R7, R8), 32(R0)
+
+	LDP	48(R0), (R3, R4)
+	LDP	48(R1), (R5, R6)
+	CSEL	EQ, R3, R5, R7
+	CSEL	EQ, R4, R6, R8
+	STP	(R7, R8), 48(R0)
+
+	LDP	64(R0), (R3, R4)
+	LDP	64(R1), (R5, R6)
+	CSEL	EQ, R3, R5, R7
+	CSEL	EQ, R4, R6, R8
+	STP	(R7, R8), 64(R0)
+
+	LDP	80(R0), (R3, R4)
+	LDP	80(R1), (R5, R6)
+	CSEL	EQ, R3, R5, R7
+	CSEL	EQ, R4, R6, R8
+	STP	(R7, R8), 80(R0)
+
+	RET
+
 TEXT ·cswapP751(SB), NOSPLIT, $0-17
 	MOVD	x+0(FP), R0
 	MOVD	y+8(FP), R1

--- a/dh/sidh/internal/p751/arith_decl.go
+++ b/dh/sidh/internal/p751/arith_decl.go
@@ -10,6 +10,12 @@ import (
 	. "github.com/cloudflare/circl/dh/sidh/internal/common"
 )
 
+// If choice = 0, leave x unchanged. If choice = 1, sets x to y.
+// If choice is neither 0 nor 1 then behaviour is undefined.
+// This function executes in constant time.
+//go:noescape
+func cmovP751(x, y *Fp, choice uint8)
+
 // If choice = 0, leave x,y unchanged. If choice = 1, set x,y = y,x.
 // If choice is neither 0 nor 1 then behaviour is undefined.
 // This function executes in constant time.

--- a/dh/sidh/internal/p751/arith_generic.go
+++ b/dh/sidh/internal/p751/arith_generic.go
@@ -51,6 +51,16 @@ func subP751(z, x, y *common.Fp) {
 	}
 }
 
+// If choice = 0, leave x unchanged. If choice = 1, sets x to y.
+// If choice is neither 0 nor 1 then behaviour is undefined.
+// This function executes in constant time.
+func cmovP751(x, y *common.Fp, choice uint8) {
+	mask := 0 - uint64(choice)
+	for i := 0; i < FpWords; i++ {
+		x[i] ^= mask & (x[i] ^ y[i])
+	}
+}
+
 // Conditionally swaps bits in x and y in constant time.
 // mask indicates bits to be swapped (set bits are swapped)
 // For details see "Hackers Delight, 2.20"

--- a/dh/sidh/internal/p751/arith_test.go
+++ b/dh/sidh/internal/p751/arith_test.go
@@ -29,7 +29,7 @@ func TestFpCswap(t *testing.T) {
 	cswapP751(&x, &y, 0)
 	for i := 0; i < FpWords; i++ {
 		if (x[i] != one[i]) || (y[i] != two[i]) {
-			t.Error("Found", x, "expected", two)
+			t.Error("Found", x, "expected", one)
 		}
 	}
 
@@ -37,6 +37,34 @@ func TestFpCswap(t *testing.T) {
 	for i := 0; i < FpWords; i++ {
 		if (x[i] != two[i]) || (y[i] != one[i]) {
 			t.Error("Found", x, "expected", two)
+		}
+	}
+}
+
+func TestFpCmov(t *testing.T) {
+	var one = common.Fp{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	var two = common.Fp{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2}
+
+	var x = one
+	var y = two
+
+	cmovP751(&x, &y, 0)
+	for i := 0; i < FpWords; i++ {
+		if x[i] != one[i] {
+			t.Error("Found", x, "expected", one)
+		}
+		if y[i] != two[i] {
+			t.Error("Found", y, "expected", two)
+		}
+	}
+
+	cmovP751(&x, &y, 1)
+	for i := 0; i < FpWords; i++ {
+		if x[i] != two[i] {
+			t.Error("Found", x, "expected", two)
+		}
+		if y[i] != two[i] {
+			t.Error("Found", y, "expected", two)
 		}
 	}
 }

--- a/dh/sidh/internal/p751/curve.go
+++ b/dh/sidh/internal/p751/curve.go
@@ -4,6 +4,8 @@
 package p751
 
 import (
+	"crypto/rand"
+
 	. "github.com/cloudflare/circl/dh/sidh/internal/common"
 )
 
@@ -239,6 +241,12 @@ func ScalarMul3Pt(cparams *ProjectiveCurveParameters, P, Q, PmQ *ProjectivePoint
 	R2 = *PmQ
 	R0 = *Q
 
+	var blind ProjectivePoint
+	b := make([]byte, 4*params.Bytelen)
+	_, _ = rand.Read(b)
+	BytesToFp2(&blind.X, b[:2*params.Bytelen], params.Bytelen)
+	BytesToFp2(&blind.Z, b[2*params.Bytelen:], params.Bytelen)
+
 	// Iterate over the bits of the scalar, bottom to top
 	prevBit := uint8(0)
 	for i := uint(0); i < nbits; i++ {
@@ -246,6 +254,7 @@ func ScalarMul3Pt(cparams *ProjectiveCurveParameters, P, Q, PmQ *ProjectivePoint
 		swap := prevBit ^ bit
 		prevBit = bit
 		cswap(&R1.X, &R1.Z, &R2.X, &R2.Z, swap)
+		cmov(&R1.X, &R1.Z, &blind.X, &blind.Z, isZero(&R1.X) | isZero(&R1.Z))
 		R0, R2 = xDbladd(&R0, &R2, &R1, &aPlus2Over4)
 	}
 	cswap(&R1.X, &R1.Z, &R2.X, &R2.Z, prevBit)

--- a/dh/sidh/internal/p751/fp2.go
+++ b/dh/sidh/internal/p751/fp2.go
@@ -157,6 +157,29 @@ func cswap(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
 	cswapP751(&xPz.B, &xQz.B, choice)
 }
 
+// In case choice == 1, performs following moves in constant time:
+//     xPx <- xQx
+//     xPz <- xQz
+// Otherwise returns xPx, xPz, xQx, xQz unchanged
+func cmov(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
+	cmovP751(&xPx.A, &xQx.A, choice)
+	cmovP751(&xPx.B, &xQx.B, choice)
+	cmovP751(&xPz.A, &xQz.A, choice)
+	cmovP751(&xPz.B, &xQz.B, choice)
+}
+
+func isZero(x *common.Fp2) uint8 {
+	r64 := uint64(0)
+	for i := 0; i < FpWords; i++ {
+		r64 |= x.A[i] | x.B[i]
+	}
+	r := uint8(0)
+	for i := uint64(0); i < 64; i++ {
+		r |= uint8((r64 >> i) & 0x1)
+	}
+	return 1 - r
+}
+
 // Converts in.A and in.B to Montgomery domain and stores
 // in 'out'
 // out.A = in.A * R mod p

--- a/dh/sidh/internal/templates/arith_decl.gotemp
+++ b/dh/sidh/internal/templates/arith_decl.gotemp
@@ -10,6 +10,12 @@ import (
 	. "github.com/cloudflare/circl/dh/sidh/internal/common"
 )
 
+// If choice = 0, leave x unchanged. If choice = 1, sets x to y.
+// If choice is neither 0 nor 1 then behaviour is undefined.
+// This function executes in constant time.
+//go:noescape
+func cmov{{ .FIELD}}(x, y *Fp, choice uint8)
+
 // If choice = 0, leave x,y unchanged. If choice = 1, set x,y = y,x.
 // If choice is neither 0 nor 1 then behaviour is undefined.
 // This function executes in constant time.

--- a/dh/sidh/internal/templates/arith_generic.gotemp
+++ b/dh/sidh/internal/templates/arith_generic.gotemp
@@ -51,6 +51,16 @@ func sub{{ .FIELD }}(z, x, y *common.Fp) {
 	}
 }
 
+// If choice = 0, leave x unchanged. If choice = 1, sets x to y.
+// If choice is neither 0 nor 1 then behaviour is undefined.
+// This function executes in constant time.
+func cmov{{ .FIELD }}(x, y *common.Fp, choice uint8) {
+	mask := 0 - uint64(choice)
+	for i := 0; i < FpWords; i++ {
+		x[i] ^= mask & (x[i] ^ y[i])
+	}
+}
+
 // Conditionally swaps bits in x and y in constant time.
 // mask indicates bits to be swapped (set bits are swapped)
 // For details see "Hackers Delight, 2.20"

--- a/dh/sidh/internal/templates/arith_test.gotemp
+++ b/dh/sidh/internal/templates/arith_test.gotemp
@@ -29,7 +29,7 @@ func TestFpCswap(t *testing.T) {
 	cswap{{ .FIELD}}(&x, &y, 0)
 	for i := 0; i < FpWords; i++ {
 		if (x[i] != one[i]) || (y[i] != two[i]) {
-			t.Error("Found", x, "expected", two)
+			t.Error("Found", x, "expected", one)
 		}
 	}
 
@@ -37,6 +37,34 @@ func TestFpCswap(t *testing.T) {
 	for i := 0; i < FpWords; i++ {
 		if (x[i] != two[i]) || (y[i] != one[i]) {
 			t.Error("Found", x, "expected", two)
+		}
+	}
+}
+
+func TestFpCmov(t *testing.T) {
+	var one = common.Fp{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+	var two = common.Fp{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2}
+
+	var x = one
+	var y = two
+
+	cmov{{ .FIELD}}(&x, &y, 0)
+	for i := 0; i < FpWords; i++ {
+		if x[i] != one[i] {
+			t.Error("Found", x, "expected", one)
+		}
+		if y[i] != two[i] {
+			t.Error("Found", y, "expected", two)
+		}
+	}
+
+	cmov{{ .FIELD}}(&x, &y, 1)
+	for i := 0; i < FpWords; i++ {
+		if x[i] != two[i] {
+			t.Error("Found", x, "expected", two)
+		}
+		if y[i] != two[i] {
+			t.Error("Found", y, "expected", two)
 		}
 	}
 }

--- a/dh/sidh/internal/templates/curve.gotemp
+++ b/dh/sidh/internal/templates/curve.gotemp
@@ -4,6 +4,8 @@
 package {{ .PACKAGE}}
 
 import (
+	"crypto/rand"
+
 	. "github.com/cloudflare/circl/dh/sidh/internal/common"
 )
 
@@ -239,6 +241,12 @@ func ScalarMul3Pt(cparams *ProjectiveCurveParameters, P, Q, PmQ *ProjectivePoint
 	R2 = *PmQ
 	R0 = *Q
 
+	var blind ProjectivePoint
+	b := make([]byte, 4*params.Bytelen)
+	_, _ = rand.Read(b)
+	BytesToFp2(&blind.X, b[:2*params.Bytelen], params.Bytelen)
+	BytesToFp2(&blind.Z, b[2*params.Bytelen:], params.Bytelen)
+
 	// Iterate over the bits of the scalar, bottom to top
 	prevBit := uint8(0)
 	for i := uint(0); i < nbits; i++ {
@@ -246,6 +254,7 @@ func ScalarMul3Pt(cparams *ProjectiveCurveParameters, P, Q, PmQ *ProjectivePoint
 		swap := prevBit ^ bit
 		prevBit = bit
 		cswap(&R1.X, &R1.Z, &R2.X, &R2.Z, swap)
+		cmov(&R1.X, &R1.Z, &blind.X, &blind.Z, isZero(&R1.X) | isZero(&R1.Z))
 		R0, R2 = xDbladd(&R0, &R2, &R1, &aPlus2Over4)
 	}
 	cswap(&R1.X, &R1.Z, &R2.X, &R2.Z, prevBit)

--- a/dh/sidh/internal/templates/fp2.gotemp
+++ b/dh/sidh/internal/templates/fp2.gotemp
@@ -157,6 +157,29 @@ func cswap(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
 	cswap{{ .FIELD}}(&xPz.B, &xQz.B, choice)
 }
 
+// In case choice == 1, performs following moves in constant time:
+//     xPx <- xQx
+//     xPz <- xQz
+// Otherwise returns xPx, xPz, xQx, xQz unchanged
+func cmov(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
+	cmov{{ .FIELD}}(&xPx.A, &xQx.A, choice)
+	cmov{{ .FIELD}}(&xPx.B, &xQx.B, choice)
+	cmov{{ .FIELD}}(&xPz.A, &xQz.A, choice)
+	cmov{{ .FIELD}}(&xPz.B, &xQz.B, choice)
+}
+
+func isZero(x *common.Fp2) uint8 {
+	r64 := uint64(0)
+	for i := 0; i < FpWords; i++ {
+		r64 |= x.A[i] | x.B[i]
+	}
+	r := uint8(0)
+	for i := uint64(0); i < 64; i++ {
+		r |= uint8((r64 >> i) & 0x1)
+	}
+	return 1 - r
+}
+
 // Converts in.A and in.B to Montgomery domain and stores
 // in 'out'
 // out.A = in.A * R mod p


### PR DESCRIPTION
The xDbladd(P,Q,QmP) function has an exceptional case when QmP is
a point of order two: either T=(0,1) or O=(1,0). When this happens,
the isogeny calculation continues with registers filled with all-zeros.

The fix proposed detects when QmP is exceptional, and replaces its value
with a random one. Both detection and replacement are performed in
constant-time.

Bug reported by Hovav & Wang.