### PR TITLE
[oprf] Publicize oprf.Server.PrivateKey

### DIFF
--- a/oprf/server.go
+++ b/oprf/server.go
@@ -12,7 +12,7 @@ import (
 // Server is a representation of a OPRF server during protocol execution.
 type Server struct {
 	suite
-	privateKey PrivateKey
+	PrivateKey PrivateKey
 }
 
 // NewServer creates a Server in base mode, and generates a key if no skS is
@@ -45,7 +45,7 @@ func newServer(id SuiteID, m Mode, skS *PrivateKey) (*Server, error) {
 }
 
 // GetPublicKey returns the public key corresponding to the server.
-func (s *Server) GetPublicKey() *PublicKey { return s.privateKey.Public() }
+func (s *Server) GetPublicKey() *PublicKey { return s.PrivateKey.Public() }
 
 // Evaluate evaluates a set of blinded inputs from the client.
 func (s *Server) Evaluate(blindedElements []Blinded, info []byte) (*Evaluation, error) {
@@ -69,7 +69,7 @@ func (s *Server) evaluateWithProofScalar(blindedElements []Blinded, info []byte,
 
 	context := s.evaluationContext(info)
 	m := s.Group.HashToScalar(context, s.getDST(hashToScalarDST))
-	t := s.Group.NewScalar().Add(s.privateKey.k, m)
+	t := s.Group.NewScalar().Add(s.PrivateKey.k, m)
 	tInv := s.Group.NewScalar().Inv(t)
 
 	var err error
@@ -110,7 +110,7 @@ func (s *Server) FullEvaluate(input, info []byte) ([]byte, error) {
 	p := s.Group.HashToElement(input, s.getDST(hashToGroupDST))
 	context := s.evaluationContext(info)
 	m := s.Group.HashToScalar(context, s.getDST(hashToScalarDST))
-	t := s.Group.NewScalar().Add(s.privateKey.k, m)
+	t := s.Group.NewScalar().Add(s.PrivateKey.k, m)
 	tInv := s.Group.NewScalar().Inv(t)
 	p.Mul(p, tInv)
 	ser, err := p.MarshalBinaryCompress()


### PR DESCRIPTION
Hey. Thanks for the fantastic repo!

This change is minimal and there might be an API I missed that does exactly this, so please let me know if I missed it.

This change allows protocols like [OPAQUE](https://datatracker.ietf.org/doc/html/draft-krawczyk-cfrg-opaque-06) to serialize and save the private key of a server, so an `oprf.Server` instance can be recreated easily at a later step.

More concretely in OPAQUE, the password registration step requires a new `kU` parameter - which is the `oprf.Server`'s private key, created [here in oprf.NewServer()](https://github.com/afjoseph/circl/blob/c9f04ddc2908c0995f6122f2b4c3ff7a0298bc33/oprf/server.go#L36) - to be saved in [the last step](https://datatracker.ietf.org/doc/html/draft-krawczyk-cfrg-opaque-06#section-3.1) of the password registration procedure, and later retrieved during password authentication. This can be done after this PR by using the same saved private key inside `oprf.NewServer`.

Cheers and many thanks. Lemme know if a more graceful solution is required (i.e., exposing an `oprf.Server.[De]SerializeKey` function)