### PR TITLE
Expose randomly generated values for Blind RSA (salt and blind)

### DIFF
--- a/blindsign/blindrsa/blindrsa.go
+++ b/blindsign/blindrsa/blindrsa.go
@@ -192,7 +192,9 @@ func (state RSAVerifierState) CopyBlind() []byte {
 
 // CopySalt returns an encoding of the per-message salt used in the protocol.
 func (state RSAVerifierState) CopySalt() []byte {
-	return state.salt
+	salt := make([]byte, len(state.salt))
+	copy(salt, state.salt)
+	return salt
 }
 
 // An RSASigner represents the Signer in the blind RSA protocol.

--- a/blindsign/blindsign.go
+++ b/blindsign/blindsign.go
@@ -20,6 +20,12 @@ type VerifierState interface {
 	// Finalize completes the blind signature protocol and produces a signature
 	// over the corresponding Verifier-provided message.
 	Finalize(data []byte) ([]byte, error)
+
+	// CopyBlind returns an encoding of the blind value used in the protocol.
+	CopyBlind() []byte
+
+	// CopySalt returns an encoding of the per-message salt used in the protocol.
+	CopySalt() []byte
 }
 
 // A Signer represents a specific instance of a blind signature signer.


### PR DESCRIPTION
This is useful when generating test vectors for applications using this package.