### PR TITLE
Enable Ristretto255 for OPRFs.

### DIFF
--- a/oprf/oprf.go
+++ b/oprf/oprf.go
@@ -90,6 +90,8 @@ type Suite interface {
 }
 
 var (
+	// SuiteRistretto255 represents the OPRF with Ristretto255 and SHA-512.
+	SuiteRistretto255 Suite = params{id: 1, group: group.Ristretto255, hash: crypto.SHA512}
 	// SuiteP256 represents the OPRF with P-256 and SHA-256.
 	SuiteP256 Suite = params{id: 3, group: group.P256, hash: crypto.SHA256}
 	// SuiteP384 represents the OPRF with P-384 and SHA-384.
@@ -100,6 +102,8 @@ var (
 
 func GetSuite(id int) (Suite, error) {
 	switch uint16(id) {
+	case SuiteRistretto255.(params).id:
+		return SuiteRistretto255, nil
 	case SuiteP256.(params).id:
 		return SuiteP256, nil
 	case SuiteP384.(params).id:

--- a/oprf/oprf_test.go
+++ b/oprf/oprf_test.go
@@ -129,6 +129,7 @@ func TestAPI(t *testing.T) {
 	info := []byte("shared info")
 
 	for _, suite := range []Suite{
+		SuiteRistretto255,
 		SuiteP256,
 		SuiteP384,
 		SuiteP521,

--- a/oprf/vectors_test.go
+++ b/oprf/vectors_test.go
@@ -102,7 +102,6 @@ func readFile(t *testing.T, fileName string) []vector {
 }
 
 func (v *vector) SetUpParties(t *testing.T) (id params, s commonServer, c commonClient) {
-	t.Helper()
 	suite, err := GetSuite(v.ID)
 	test.CheckNoErr(t, err, "suite id")
 	seed := toBytes(t, v.Seed, "seed for key derivation")


### PR DESCRIPTION
oprf.SuiteR255 represents the OPRF with Ristretto255 and SHA-512.