### PR TITLE
Export Group and Hash for each OPRF suite

### DIFF
--- a/oprf/keys.go
+++ b/oprf/keys.go
@@ -27,7 +27,7 @@ func (k *PrivateKey) UnmarshalBinary(s Suite, data []byte) error {
 		return ErrInvalidSuite
 	}
 	k.p = p
-	k.k = k.p.g.NewScalar()
+	k.k = k.p.Group.NewScalar()
 
 	return k.k.UnmarshalBinary(data)
 }
@@ -38,14 +38,14 @@ func (k *PublicKey) UnmarshalBinary(s Suite, data []byte) error {
 		return ErrInvalidSuite
 	}
 	k.p = p
-	k.e = k.p.g.NewElement()
+	k.e = k.p.Group.NewElement()
 
 	return k.e.UnmarshalBinary(data)
 }
 
 func (k *PrivateKey) Public() *PublicKey {
 	if k.pub == nil {
-		k.pub = &PublicKey{k.p, k.p.g.NewElement().MulGen(k.k)}
+		k.pub = &PublicKey{k.p, k.p.Group.NewElement().MulGen(k.k)}
 	}
 
 	return k.pub
@@ -61,7 +61,7 @@ func GenerateKey(s Suite, rnd io.Reader) (*PrivateKey, error) {
 	if !ok {
 		return nil, ErrInvalidSuite
 	}
-	privateKey := p.g.RandomScalar(rnd)
+	privateKey := p.Group.RandomScalar(rnd)
 
 	return &PrivateKey{p, privateKey, nil}, nil
 }
@@ -83,13 +83,13 @@ func DeriveKey(s Suite, mode Mode, seed, info []byte) (*PrivateKey, error) {
 	deriveInput := append(append(append([]byte{}, seed...), lenInfo...), info...)
 
 	dst := p.getDST(deriveKeyPairDST)
-	zero := p.g.NewScalar()
-	privateKey := p.g.NewScalar()
+	zero := p.Group.NewScalar()
+	privateKey := p.Group.NewScalar()
 	for counter := byte(0); privateKey.IsEqual(zero); counter++ {
 		if counter > maxTries {
 			return nil, ErrDeriveKeyPairError
 		}
-		privateKey = p.g.HashToScalar(append(deriveInput, counter), dst)
+		privateKey = p.Group.HashToScalar(append(deriveInput, counter), dst)
 	}
 
 	return &PrivateKey{p, privateKey, nil}, nil

--- a/oprf/oprf.go
+++ b/oprf/oprf.go
@@ -86,11 +86,11 @@ type Suite interface{ cannotBeImplementedExternally() }
 
 var (
 	// SuiteP256 represents the OPRF with P-256 and SHA-256.
-	SuiteP256 Suite = params{ID: 3, g: group.P256, h: crypto.SHA256}
+	SuiteP256 Suite = params{ID: 3, Group: group.P256, Hash: crypto.SHA256}
 	// SuiteP384 represents the OPRF with P-384 and SHA-384.
-	SuiteP384 Suite = params{ID: 4, g: group.P384, h: crypto.SHA384}
+	SuiteP384 Suite = params{ID: 4, Group: group.P384, Hash: crypto.SHA384}
 	// SuiteP521 represents the OPRF with P-521 and SHA-512.
-	SuiteP521 Suite = params{ID: 5, g: group.P521, h: crypto.SHA512}
+	SuiteP521 Suite = params{ID: 5, Group: group.P521, Hash: crypto.SHA512}
 )
 
 func GetSuite(id int) (Suite, error) {
@@ -164,15 +164,15 @@ func NewPartialObliviousServer(s Suite, key *PrivateKey) PartialObliviousServer 
 }
 
 type params struct {
-	ID uint16
-	m  Mode
-	g  group.Group
-	h  crypto.Hash
+	ID    uint16
+	m     Mode
+	Group group.Group
+	Hash  crypto.Hash
 }
 
 func (p params) cannotBeImplementedExternally() {}
 
-func (p params) String() string { return fmt.Sprintf("Suite%v", p.g) }
+func (p params) String() string { return fmt.Sprintf("Suite%v", p.Group) }
 
 func (p params) getDST(name string) []byte {
 	return append(append(append([]byte{},
@@ -192,7 +192,7 @@ func (p params) scalarFromInfo(info []byte) (group.Scalar, error) {
 		lenInfo...),
 		info...)
 
-	return p.g.HashToScalar(framedInfo, p.getDST(hashToScalarDST)), nil
+	return p.Group.HashToScalar(framedInfo, p.getDST(hashToScalarDST)), nil
 }
 
 func (p params) finalizeHash(h hash.Hash, input, info, element []byte) []byte {
@@ -219,8 +219,8 @@ func (p params) finalizeHash(h hash.Hash, input, info, element []byte) []byte {
 }
 
 func (p params) getDLEQParams() (out dleq.Params) {
-	out.G = p.g
-	out.H = p.h
+	out.G = p.Group
+	out.H = p.Hash
 	out.DST = p.getDST("")
 
 	return

--- a/oprf/server.go
+++ b/oprf/server.go
@@ -24,7 +24,7 @@ func (s server) PublicKey() *PublicKey { return s.privateKey.Public() }
 func (s server) evaluate(elements []Blinded, secret blind) []Evaluated {
 	evaluations := make([]Evaluated, len(elements))
 	for i := range elements {
-		evaluations[i] = s.params.g.NewElement().Mul(elements[i], secret)
+		evaluations[i] = s.params.Group.NewElement().Mul(elements[i], secret)
 	}
 
 	return evaluations
@@ -41,7 +41,7 @@ func (s VerifiableServer) Evaluate(req *EvaluationRequest) (*Evaluation, error) 
 
 	proof, err := dleq.Prover{Params: s.getDLEQParams()}.ProveBatch(
 		s.privateKey.k,
-		s.params.g.Generator(),
+		s.params.Group.Generator(),
 		s.PublicKey().e,
 		req.Elements,
 		evaluations,
@@ -64,8 +64,8 @@ func (s PartialObliviousServer) Evaluate(req *EvaluationRequest, info []byte) (*
 
 	proof, err := dleq.Prover{Params: s.getDLEQParams()}.ProveBatch(
 		keyProof,
-		s.params.g.Generator(),
-		s.params.g.NewElement().MulGen(keyProof),
+		s.params.Group.Generator(),
+		s.params.Group.NewElement().MulGen(keyProof),
 		evaluations,
 		req.Elements,
 		rand.Reader,
@@ -82,12 +82,12 @@ func (s server) secretFromInfo(info []byte) (t, tInv group.Scalar, err error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	t = s.params.g.NewScalar().Add(m, s.privateKey.k)
+	t = s.params.Group.NewScalar().Add(m, s.privateKey.k)
 
-	if zero := s.params.g.NewScalar(); t.IsEqual(zero) {
+	if zero := s.params.Group.NewScalar(); t.IsEqual(zero) {
 		return nil, nil, ErrInverseZero
 	}
-	tInv = s.params.g.NewScalar().Inv(t)
+	tInv = s.params.Group.NewScalar().Inv(t)
 
 	return t, tInv, nil
 }
@@ -102,14 +102,14 @@ func (s server) fullEvaluate(input, info []byte) ([]byte, error) {
 		}
 	}
 
-	element := s.params.g.HashToElement(input, s.params.getDST(hashToGroupDST))
-	evaluation := s.params.g.NewElement().Mul(element, evalSecret)
+	element := s.params.Group.HashToElement(input, s.params.getDST(hashToGroupDST))
+	evaluation := s.params.Group.NewElement().Mul(element, evalSecret)
 	serEval, err := evaluation.MarshalBinaryCompress()
 	if err != nil {
 		return nil, err
 	}
 
-	return s.finalizeHash(s.params.h.New(), input, info, serEval), nil
+	return s.finalizeHash(s.params.Hash.New(), input, info, serEval), nil
 }
 
 func (s Server) FullEvaluate(input []byte) (output []byte, err error) {

--- a/oprf/vectors_test.go
+++ b/oprf/vectors_test.go
@@ -164,25 +164,25 @@ func (v *vector) test(t *testing.T) {
 
 		blinds := make([]blind, len(blindsBytes))
 		for j := range blindsBytes {
-			blinds[j] = params.g.NewScalar()
+			blinds[j] = params.Group.NewScalar()
 			err := blinds[j].UnmarshalBinary(blindsBytes[j])
 			test.CheckNoErr(t, err, "invalid blind")
 		}
 
 		finData, evalReq, err := client.blind(inputs, blinds)
 		test.CheckNoErr(t, err, "invalid client request")
-		evalReqBytes, err := elementsMarshalBinary(params.g, evalReq.Elements)
+		evalReqBytes, err := elementsMarshalBinary(params.Group, evalReq.Elements)
 		test.CheckNoErr(t, err, "bad serialization")
 		v.compareBytes(t, evalReqBytes, flattenList(t, vi.BlindedElement, "blindedElement"))
 
 		eval, err := server.Evaluate(evalReq)
 		test.CheckNoErr(t, err, "invalid evaluation")
-		elemBytes, err := elementsMarshalBinary(params.g, eval.Elements)
+		elemBytes, err := elementsMarshalBinary(params.Group, eval.Elements)
 		test.CheckNoErr(t, err, "invalid evaluations marshaling")
 		v.compareBytes(t, elemBytes, flattenList(t, vi.EvaluationElement, "evaluation"))
 
 		if v.Mode == VerifiableMode || v.Mode == PartialObliviousMode {
-			randomness := toScalar(t, params.g, vi.Proof.R, "invalid proof random scalar")
+			randomness := toScalar(t, params.Group, vi.Proof.R, "invalid proof random scalar")
 			var proof encoding.BinaryMarshaler
 			switch v.Mode {
 			case VerifiableMode:
@@ -190,7 +190,7 @@ func (v *vector) test(t *testing.T) {
 				prover := dleq.Prover{Params: ss.getDLEQParams()}
 				proof, err = prover.ProveBatchWithRandomness(
 					ss.privateKey.k,
-					ss.params.g.Generator(),
+					ss.params.Group.Generator(),
 					server.PublicKey().e,
 					evalReq.Elements,
 					eval.Elements,
@@ -201,8 +201,8 @@ func (v *vector) test(t *testing.T) {
 				prover := dleq.Prover{Params: ss.getDLEQParams()}
 				proof, err = prover.ProveBatchWithRandomness(
 					keyProof,
-					ss.params.g.Generator(),
-					ss.params.g.NewElement().MulGen(keyProof),
+					ss.params.Group.Generator(),
+					ss.params.Group.NewElement().MulGen(keyProof),
 					eval.Elements,
 					evalReq.Elements,
 					randomness)


### PR DESCRIPTION
This is needed so clients can go from `suite` to `group` for serialization functions. Otherwise, clients have to know that, e.g., `oprf.SuiteP384` corresponds to `group.P384`. Now, clients can access the group by `oprf.SuiteP384.Group`.