### PR TITLE
Remove test that is no longer supported with Go 1.18

### DIFF
--- a/ecc/p384/p384_test.go
+++ b/ecc/p384/p384_test.go
@@ -169,21 +169,6 @@ func TestScalarMult(t *testing.T) {
 			}
 		}
 	})
-
-	t.Run("wrong P", func(t *testing.T) {
-		for i := 0; i < testTimes; i++ {
-			k, _ := rand.Int(rand.Reader, params.N)
-			x, _ := rand.Int(rand.Reader, params.P)
-			y, _ := rand.Int(rand.Reader, params.P)
-
-			got := CirclCurve.IsOnCurve(CirclCurve.ScalarMult(x, y, k.Bytes()))
-			want := StdCurve.IsOnCurve(StdCurve.ScalarMult(x, y, k.Bytes()))
-
-			if got != want {
-				test.ReportError(t, got, want, k, x, y)
-			}
-		}
-	})
 }
 
 func TestCombinedMult(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/cloudflare/circl/issues/329

Removing this test will resolve the failing test and allow this package to build successfully again in Ubuntu.

If you would prefer to use build tags to have this test still run with Go 1.17 but not with Go 1.18 I can make that change, just let me know.