### PR TITLE
Formatting auto-generated code.

### DIFF
--- a/kem/kyber/gen.go
+++ b/kem/kyber/gen.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"bytes"
+	"go/format"
 	"io/ioutil"
 	"strings"
 	"text/template"
@@ -47,7 +48,13 @@ func generatePackageFiles() {
 			panic(err)
 		}
 
-		res := string(buf.Bytes())
+		// Formating output code
+		code, err := format.Source(buf.Bytes())
+		if err != nil {
+			panic("error formating code")
+		}
+
+		res := string(code)
 		offset := strings.Index(res, TemplateWarning)
 		if offset == -1 {
 			panic("Missing template warning in pkg.templ.go")

--- a/kem/kyber/kyber1024/kyber.go
+++ b/kem/kyber/kyber1024/kyber.go
@@ -12,10 +12,10 @@ import (
 	"crypto/subtle"
 	"io"
 
+	cryptoRand "crypto/rand"
 	"github.com/cloudflare/circl/internal/sha3"
 	"github.com/cloudflare/circl/kem"
 	cpapke "github.com/cloudflare/circl/pke/kyber/kyber1024"
-	cryptoRand "crypto/rand"
 )
 
 const (

--- a/kem/kyber/kyber512/kyber.go
+++ b/kem/kyber/kyber512/kyber.go
@@ -12,10 +12,10 @@ import (
 	"crypto/subtle"
 	"io"
 
+	cryptoRand "crypto/rand"
 	"github.com/cloudflare/circl/internal/sha3"
 	"github.com/cloudflare/circl/kem"
 	cpapke "github.com/cloudflare/circl/pke/kyber/kyber512"
-	cryptoRand "crypto/rand"
 )
 
 const (

--- a/kem/kyber/kyber768/kyber.go
+++ b/kem/kyber/kyber768/kyber.go
@@ -12,10 +12,10 @@ import (
 	"crypto/subtle"
 	"io"
 
+	cryptoRand "crypto/rand"
 	"github.com/cloudflare/circl/internal/sha3"
 	"github.com/cloudflare/circl/kem"
 	cpapke "github.com/cloudflare/circl/pke/kyber/kyber768"
-	cryptoRand "crypto/rand"
 )
 
 const (

--- a/kem/sike/gen.go
+++ b/kem/sike/gen.go
@@ -8,6 +8,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"go/format"
 	"io/ioutil"
 	"strings"
 	"text/template"
@@ -56,7 +57,13 @@ func generatePackageFiles() {
 			panic(err)
 		}
 
-		res := string(buf.Bytes())
+		// Formating output code
+		code, err := format.Source(buf.Bytes())
+		if err != nil {
+			panic("error formating code")
+		}
+
+		res := string(code)
 		offset := strings.Index(res, TemplateWarning)
 		if offset == -1 {
 			panic("Missing template warning in pkg.templ.go")

--- a/pke/kyber/gen.go
+++ b/pke/kyber/gen.go
@@ -8,6 +8,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"go/format"
 	"io/ioutil"
 	"os"
 	"path"
@@ -82,7 +83,13 @@ func generateParamsFiles() {
 			panic(err)
 		}
 
-		res := string(buf.Bytes())
+		// Formating output code
+		code, err := format.Source(buf.Bytes())
+		if err != nil {
+			panic("error formating code")
+		}
+
+		res := string(code)
 		offset := strings.Index(res, TemplateWarning)
 		if offset == -1 {
 			panic("Missing template warning in params.templ.go")

--- a/sign/dilithium/gen.go
+++ b/sign/dilithium/gen.go
@@ -8,6 +8,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"go/format"
 	"io/ioutil"
 	"os"
 	"path"
@@ -142,7 +143,13 @@ func generateParamsFiles() {
 			panic(err)
 		}
 
-		res := string(buf.Bytes())
+		// Formating output code
+		code, err := format.Source(buf.Bytes())
+		if err != nil {
+			panic("error formating code")
+		}
+
+		res := string(code)
 		offset := strings.Index(res, TemplateWarning)
 		if offset == -1 {
 			panic("Missing template warning in params.templ.go")


### PR DESCRIPTION
explicit format files because golangci-lint skips auto-generated files. See also https://github.com/golangci/golangci-lint/issues/2864.