### PR TITLE
Add benchmarks for all OPRF suites (including a new Ristretto255 suite)

### DIFF
--- a/oprf/oprf.go
+++ b/oprf/oprf.go
@@ -86,18 +86,19 @@ type Suite interface {
 	ID() int
 	Group() group.Group
 	Hash() crypto.Hash
+	Name() string
 	cannotBeImplementedExternally()
 }
 
 var (
-	// SuiteRistretto255 represents the OPRF with Ristretto255 and SHA-512.
-	SuiteRistretto255 Suite = params{id: 1, group: group.Ristretto255, hash: crypto.SHA512}
+	// SuiteRistretto255 represents the OPRF with Ristretto255 and SHA-512
+	SuiteRistretto255 Suite = params{id: 1, group: group.Ristretto255, hash: crypto.SHA512, name: "OPRF(ristretto255, SHA-512)"}
 	// SuiteP256 represents the OPRF with P-256 and SHA-256.
-	SuiteP256 Suite = params{id: 3, group: group.P256, hash: crypto.SHA256}
+	SuiteP256 Suite = params{id: 3, group: group.P256, hash: crypto.SHA256, name: "OPRF(P-256, SHA-256)"}
 	// SuiteP384 represents the OPRF with P-384 and SHA-384.
-	SuiteP384 Suite = params{id: 4, group: group.P384, hash: crypto.SHA384}
+	SuiteP384 Suite = params{id: 4, group: group.P384, hash: crypto.SHA384, name: "OPRF(P-384, SHA-384)"}
 	// SuiteP521 represents the OPRF with P-521 and SHA-512.
-	SuiteP521 Suite = params{id: 5, group: group.P521, hash: crypto.SHA512}
+	SuiteP521 Suite = params{id: 5, group: group.P521, hash: crypto.SHA512, name: "OPRF(P-521, SHA-512)"}
 )
 
 func GetSuite(id int) (Suite, error) {
@@ -177,6 +178,7 @@ type params struct {
 	m     Mode
 	group group.Group
 	hash  crypto.Hash
+	name  string
 }
 
 func (p params) cannotBeImplementedExternally() {}
@@ -185,6 +187,7 @@ func (p params) String() string     { return fmt.Sprintf("Suite%v", p.group) }
 func (p params) ID() int            { return int(p.id) }
 func (p params) Group() group.Group { return p.group }
 func (p params) Hash() crypto.Hash  { return p.hash }
+func (p params) Name() string       { return p.name }
 
 func (p params) getDST(name string) []byte {
 	return append(append(append([]byte{},


### PR DESCRIPTION
We were previously only testing P-256, but it's probably useful to have benchmarks for all suites (to compare and contrast for applications like Privacy Pass).

Benchmarks from my machine are below.

```
✗ go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/cloudflare/circl/oprf
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkAPI/OPRF_OPRF(ristretto255,_SHA-512)/Client/Request-12         	    8329	    134348 ns/op
BenchmarkAPI/OPRF_OPRF(ristretto255,_SHA-512)/Server/Evaluate-12        	   10000	    117887 ns/op
BenchmarkAPI/OPRF_OPRF(ristretto255,_SHA-512)/Client/Finalize-12        	    6694	    185566 ns/op
BenchmarkAPI/OPRF_OPRF(ristretto255,_SHA-512)/Server/VerifyFinalize-12  	    8535	    137740 ns/op
BenchmarkAPI/OPRF_OPRF(ristretto255,_SHA-512)/Server/FullEvaluate-12    	    8502	    137558 ns/op
BenchmarkAPI/VOPRFOPRF(ristretto255,_SHA-512)/Client/Request-12         	    9141	    132059 ns/op
BenchmarkAPI/VOPRFOPRF(ristretto255,_SHA-512)/Server/Evaluate-12        	    2575	    448148 ns/op
BenchmarkAPI/VOPRFOPRF(ristretto255,_SHA-512)/Client/Finalize-12        	    1663	    690075 ns/op
BenchmarkAPI/VOPRFOPRF(ristretto255,_SHA-512)/Server/VerifyFinalize-12  	    8941	    138982 ns/op
BenchmarkAPI/VOPRFOPRF(ristretto255,_SHA-512)/Server/FullEvaluate-12    	    8721	    138919 ns/op
BenchmarkAPI/POPRFOPRF(ristretto255,_SHA-512)/Client/Request-12         	    9058	    132935 ns/op
BenchmarkAPI/POPRFOPRF(ristretto255,_SHA-512)/Server/Evaluate-12        	    2313	    499251 ns/op
BenchmarkAPI/POPRFOPRF(ristretto255,_SHA-512)/Client/Finalize-12        	    1651	    709824 ns/op
BenchmarkAPI/POPRFOPRF(ristretto255,_SHA-512)/Server/VerifyFinalize-12  	    5809	    204057 ns/op
BenchmarkAPI/POPRFOPRF(ristretto255,_SHA-512)/Server/FullEvaluate-12    	    5820	    201851 ns/op
BenchmarkAPI/OPRF_OPRF(P-256,_SHA-256)/Client/Request-12                	    3994	    302609 ns/op
BenchmarkAPI/OPRF_OPRF(P-256,_SHA-256)/Server/Evaluate-12               	   10000	    104789 ns/op
BenchmarkAPI/OPRF_OPRF(P-256,_SHA-256)/Client/Finalize-12               	   10000	    114940 ns/op
BenchmarkAPI/OPRF_OPRF(P-256,_SHA-256)/Server/VerifyFinalize-12         	    4144	    293959 ns/op
BenchmarkAPI/OPRF_OPRF(P-256,_SHA-256)/Server/FullEvaluate-12           	    4052	    293190 ns/op
BenchmarkAPI/VOPRFOPRF(P-256,_SHA-256)/Client/Request-12                	    4026	    314748 ns/op
BenchmarkAPI/VOPRFOPRF(P-256,_SHA-256)/Server/Evaluate-12               	    2956	    410958 ns/op
BenchmarkAPI/VOPRFOPRF(P-256,_SHA-256)/Client/Finalize-12               	    2037	    589849 ns/op
BenchmarkAPI/VOPRFOPRF(P-256,_SHA-256)/Server/VerifyFinalize-12         	    4155	    291355 ns/op
BenchmarkAPI/VOPRFOPRF(P-256,_SHA-256)/Server/FullEvaluate-12           	    4185	    291373 ns/op
BenchmarkAPI/POPRFOPRF(P-256,_SHA-256)/Client/Request-12                	    4021	    300035 ns/op
BenchmarkAPI/POPRFOPRF(P-256,_SHA-256)/Server/Evaluate-12               	    2788	    423762 ns/op
BenchmarkAPI/POPRFOPRF(P-256,_SHA-256)/Client/Finalize-12               	    1928	    615774 ns/op
BenchmarkAPI/POPRFOPRF(P-256,_SHA-256)/Server/VerifyFinalize-12         	    3862	    310359 ns/op
BenchmarkAPI/POPRFOPRF(P-256,_SHA-256)/Server/FullEvaluate-12           	    3822	    310828 ns/op
BenchmarkAPI/OPRF_OPRF(P-384,_SHA-384)/Client/Request-12                	    1178	   1006420 ns/op
BenchmarkAPI/OPRF_OPRF(P-384,_SHA-384)/Server/Evaluate-12               	    1963	    596119 ns/op
BenchmarkAPI/OPRF_OPRF(P-384,_SHA-384)/Client/Finalize-12               	    1882	    618329 ns/op
BenchmarkAPI/OPRF_OPRF(P-384,_SHA-384)/Server/VerifyFinalize-12         	    1179	   1010536 ns/op
BenchmarkAPI/OPRF_OPRF(P-384,_SHA-384)/Server/FullEvaluate-12           	    1171	   1038197 ns/op
BenchmarkAPI/VOPRFOPRF(P-384,_SHA-384)/Client/Request-12                	    1166	   1013154 ns/op
BenchmarkAPI/VOPRFOPRF(P-384,_SHA-384)/Server/Evaluate-12               	     500	   2712349 ns/op
BenchmarkAPI/VOPRFOPRF(P-384,_SHA-384)/Client/Finalize-12               	     301	   3485267 ns/op
BenchmarkAPI/VOPRFOPRF(P-384,_SHA-384)/Server/VerifyFinalize-12         	    1191	   1007107 ns/op
BenchmarkAPI/VOPRFOPRF(P-384,_SHA-384)/Server/FullEvaluate-12           	    1191	   1076705 ns/op
BenchmarkAPI/POPRFOPRF(P-384,_SHA-384)/Client/Request-12                	    1171	   1084027 ns/op
BenchmarkAPI/POPRFOPRF(P-384,_SHA-384)/Server/Evaluate-12               	     393	   2896576 ns/op
BenchmarkAPI/POPRFOPRF(P-384,_SHA-384)/Client/Finalize-12               	     253	   4010709 ns/op
BenchmarkAPI/POPRFOPRF(P-384,_SHA-384)/Server/VerifyFinalize-12         	    1070	   1028873 ns/op
BenchmarkAPI/POPRFOPRF(P-384,_SHA-384)/Server/FullEvaluate-12           	    1172	   1049010 ns/op
BenchmarkAPI/OPRF_OPRF(P-521,_SHA-512)/Client/Request-12                	     303	   4258508 ns/op
BenchmarkAPI/OPRF_OPRF(P-521,_SHA-512)/Server/Evaluate-12               	     378	   2999543 ns/op
BenchmarkAPI/OPRF_OPRF(P-521,_SHA-512)/Client/Finalize-12               	     386	   3152643 ns/op
BenchmarkAPI/OPRF_OPRF(P-521,_SHA-512)/Server/VerifyFinalize-12         	     295	   4283408 ns/op
BenchmarkAPI/OPRF_OPRF(P-521,_SHA-512)/Server/FullEvaluate-12           	     321	   3645406 ns/op
BenchmarkAPI/VOPRFOPRF(P-521,_SHA-512)/Client/Request-12                	     319	   3712189 ns/op
BenchmarkAPI/VOPRFOPRF(P-521,_SHA-512)/Server/Evaluate-12               	     100	  10300027 ns/op
BenchmarkAPI/VOPRFOPRF(P-521,_SHA-512)/Client/Finalize-12               	      78	  14856760 ns/op
BenchmarkAPI/VOPRFOPRF(P-521,_SHA-512)/Server/VerifyFinalize-12         	     322	   3744080 ns/op
BenchmarkAPI/VOPRFOPRF(P-521,_SHA-512)/Server/FullEvaluate-12           	     319	   3698312 ns/op
BenchmarkAPI/POPRFOPRF(P-521,_SHA-512)/Client/Request-12                	     319	   3693820 ns/op
BenchmarkAPI/POPRFOPRF(P-521,_SHA-512)/Server/Evaluate-12               	      97	  11619638 ns/op
BenchmarkAPI/POPRFOPRF(P-521,_SHA-512)/Client/Finalize-12               	      76	  15998667 ns/op
BenchmarkAPI/POPRFOPRF(P-521,_SHA-512)/Server/VerifyFinalize-12         	     319	   3727345 ns/op
BenchmarkAPI/POPRFOPRF(P-521,_SHA-512)/Server/FullEvaluate-12           	     314	   3772882 ns/op
```