### PR TITLE
group: adds a method to retrieve the group.

### DIFF
--- a/group/group.go
+++ b/group/group.go
@@ -31,6 +31,7 @@ type Group interface {
 
 // Element represents an abstract element of a prime-order group.
 type Element interface {
+	Group() Group
 	Set(Element) Element
 	Copy() Element
 	IsIdentity() bool
@@ -47,6 +48,7 @@ type Element interface {
 
 // Scalar represents an integer scalar.
 type Scalar interface {
+	Group() Group
 	Set(Scalar) Scalar
 	Copy() Scalar
 	IsEqual(Scalar) bool

--- a/group/ristretto255.go
+++ b/group/ristretto255.go
@@ -126,6 +126,8 @@ func (g ristrettoGroup) HashToScalar(msg, dst []byte) Scalar {
 	return s
 }
 
+func (e *ristrettoElement) Group() Group { return Ristretto255 }
+
 func (e *ristrettoElement) IsIdentity() bool {
 	var zero r255.Point
 	zero.SetZero()
@@ -181,6 +183,7 @@ func (e *ristrettoElement) UnmarshalBinary(data []byte) error {
 	return e.p.UnmarshalBinary(data)
 }
 
+func (s *ristrettoScalar) Group() Group       { return Ristretto255 }
 func (s *ristrettoScalar) String() string     { return fmt.Sprintf("0x%x", s.s.Bytes()) }
 func (s *ristrettoScalar) SetUint64(n uint64) { s.s.SetUint64(n) }
 

--- a/group/short.go
+++ b/group/short.go
@@ -125,6 +125,7 @@ type wElt struct {
 	x, y *big.Int
 }
 
+func (e *wElt) Group() Group     { return e.wG }
 func (e *wElt) String() string   { return fmt.Sprintf("x: 0x%v\ny: 0x%v", e.x.Text(16), e.y.Text(16)) }
 func (e *wElt) IsIdentity() bool { return e.x.Sign() == 0 && e.y.Sign() == 0 }
 func (e *wElt) IsEqual(o Element) bool {
@@ -219,6 +220,7 @@ type wScl struct {
 	k []byte
 }
 
+func (s *wScl) Group() Group       { return s.wG }
 func (s *wScl) String() string     { return fmt.Sprintf("0x%x", s.k) }
 func (s *wScl) SetUint64(n uint64) { s.fromBig(new(big.Int).SetUint64(n)) }
 func (s *wScl) IsEqual(a Scalar) bool {


### PR DESCRIPTION
Adds a method to retrieve the group for elements and scalars. This becomes handy in code and avoids storing the group elsewhere.