### PR TITLE
group: removes order method from group interface

### DIFF
--- a/group/group.go
+++ b/group/group.go
@@ -26,8 +26,6 @@ type Group interface {
 	Identity() Element
 	// Creates an element of the group set to the generator of the group.
 	Generator() Element
-	// Returns a scalar set to the group order.
-	Order() Scalar
 	// RandomElement creates an element chosen at random (using randomness
 	// from rnd) from the set of group elements. Use crypto/rand.Reader as
 	// a cryptographically secure random number generator

--- a/group/group_test.go
+++ b/group/group_test.go
@@ -164,15 +164,17 @@ func testCSelect(t *testing.T, testTimes int, g group.Group) {
 }
 
 func testOrder(t *testing.T, testTimes int, g group.Group) {
+	I := g.Identity()
 	Q := g.NewElement()
-	order := g.Order()
+	minusOne := g.NewScalar().SetUint64(1)
+	minusOne.Neg(minusOne)
 	for i := 0; i < testTimes; i++ {
 		P := g.RandomElement(rand.Reader)
 
-		Q.Mul(P, order)
-		got := Q.IsIdentity()
-		want := true
-		if got != want {
+		Q.Mul(P, minusOne)
+		got := Q.Add(Q, P)
+		want := I
+		if !got.IsEqual(want) {
 			test.ReportError(t, got, want, P)
 		}
 	}

--- a/group/ristretto255.go
+++ b/group/ristretto255.go
@@ -59,16 +59,6 @@ func (g ristrettoGroup) Generator() Element {
 	}
 }
 
-func (g ristrettoGroup) Order() Scalar {
-	q := r255.Scalar{
-		0x5cf5d3ed, 0x5812631a, 0xa2f79cd6, 0x14def9de,
-		0x00000000, 0x00000000, 0x00000000, 0x10000000,
-	}
-	return &ristrettoScalar{
-		s: q,
-	}
-}
-
 func (g ristrettoGroup) RandomElement(r io.Reader) Element {
 	var x r255.Point
 	x.Rand()

--- a/group/short.go
+++ b/group/short.go
@@ -34,7 +34,6 @@ func (g wG) Identity() Element   { return g.zeroElement() }
 func (g wG) zeroScalar() *wScl   { return &wScl{g, make([]byte, (g.c.Params().BitSize+7)/8)} }
 func (g wG) zeroElement() *wElt  { return &wElt{g, new(big.Int), new(big.Int)} }
 func (g wG) Generator() Element  { return &wElt{g, g.c.Params().Gx, g.c.Params().Gy} }
-func (g wG) Order() Scalar       { s := &wScl{g, nil}; s.fromBig(g.c.Params().N); return s }
 func (g wG) RandomElement(rd io.Reader) Element {
 	b := make([]byte, (g.c.Params().BitSize+7)/8)
 	if n, err := io.ReadFull(rd, b); err != nil || n != len(b) {


### PR DESCRIPTION
There is no point in returning a `Scalar` for Order method.
Also, returning a big.Int is not desirable.
Since the group order is public and well-know for the groups supported, then it's better to remove the method.

Based on top of: #355  (merge that first)
Fixes #214 