### PR TITLE
sidh: deprecates sidh and sike packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ go get -u github.com/cloudflare/circl
  - [VOPRF](https://datatracker.ietf.org/doc/draft-irtf-cfrg-voprf/): Verifiable Oblivious Pseudorandom function.
 
 #### Post-Quantum Key Encapsulation Methods
- - [SIDH/SIKE](https://sike.org/): Supersingular Key Encapsulation with primes p434, p503, p751
  - [CSIDH](https://csidh.isogeny.org/): Post-Quantum Commutative Group Action
  - [Kyber](https://pq-crystals.org/kyber/) KEM: modes 512, 768, 1024
  - [FrodoKEM](https://frodokem.org/) KEM: modes 640-SHAKE
+ - (**insecure, deprecated**) [SIDH/SIKE](https://sike.org/): Supersingular Key Encapsulation with primes p434, p503, p751
 
 #### Post-Quantum Public-Key Encryption
  - [Kyber](https://pq-crystals.org/kyber/) PKE: modes 512, 768, 1024

--- a/dh/sidh/doc.go
+++ b/dh/sidh/doc.go
@@ -1,30 +1,44 @@
-// Package sidh provides implementation of experimental post-quantum
+// Package sidh is deprecated, it provides SIDH and SIKE key encapsulation
+// mechanisms.
+//
+// DEPRECATION NOTICE
+//
+// SIDH and SIKE are deprecated as were shown vulnerable to a key recovery
+// attack by Castryck-Decru's paper (https://eprint.iacr.org/2022/975). New
+// systems should not rely on this package. This package is frozen.
+//
+// SIDH and SIKE
+//
+// This package provides implementation of experimental post-quantum
 // Supersingular Isogeny Diffie-Hellman (SIDH) as well as Supersingular
 // Isogeny Key Encapsulation (SIKE).
 //
-// It comes with implementations of 2 different field arithmetic
-// implementations sidh.Fp503 and sidh.Fp751.
+// It comes with implementations of three different field arithmetic
+// implementations sidh.Fp434, sidh.Fp503, and sidh.Fp751.
 //
 //	| Algorithm | Public Key Size | Shared Secret Size | Ciphertext Size |
 //	|-----------|-----------------|--------------------|-----------------|
-//	| SIDH/p503 |          376    |        126         | N/A             |
-//	| SIDH/p751 |          564    |        188         | N/A             |
-//	| SIKE/p503 |          376    |         16         | 402             |
-//	| SIKE/p751 |          564    |         24         | 596             |
+//	| SIDH/p434 |          330    |        110         |       N/A       |
+//	| SIDH/p503 |          378    |        126         |       N/A       |
+//	| SIDH/p751 |          564    |        188         |       N/A       |
+//	| SIKE/p434 |          330    |         16         |       346       |
+//	| SIKE/p503 |          378    |         24         |       402       |
+//	| SIKE/p751 |          564    |         32         |       596       |
 //
 // In order to instantiate SIKE/p751 KEM one needs to create a KEM object
 // and allocate internal structures. This can be done with NewSike751 helper.
-// After that kem can be used multiple times.
+// After that, the kem variable can be used multiple times.
 //
 //	var kem = sike.NewSike751(rand.Reader)
 //	kem.Encapsulate(ciphertext, sharedSecret, publicBob)
-//	kem.Decapsulate(sharedSecret, privateBob, PublicBob, ciphertext)
+//	kem.Decapsulate(sharedSecret, privateBob, publicBob, ciphertext)
 //
 // Code is optimized for AMD64 and aarch64. Generic implementation
 // is provided for other architectures.
 //
 // References:
-// - [SIDH] https://eprint.iacr.org/2011/506
-// - [SIKE] http://www.sike.org/files/SIDH-spec.pdf
+//
+//  - [SIDH] https://eprint.iacr.org/2011/506
+//  - [SIKE] http://www.sike.org/files/SIDH-spec.pdf
 //
 package sidh

--- a/dh/sidh/sidh.go
+++ b/dh/sidh/sidh.go
@@ -11,6 +11,8 @@ import (
 )
 
 // I keep it bool in order to be able to apply logical NOT.
+//
+// Deprecated: not cryptographically secure.
 type KeyVariant uint
 
 // Base type for public and private key. Used mainly to carry domain
@@ -23,6 +25,8 @@ type key struct {
 }
 
 // Defines operations on public key
+//
+// Deprecated: not cryptographically secure.
 type PublicKey struct {
 	key
 	// x-coordinates of P,Q,P-Q in this exact order
@@ -30,6 +34,8 @@ type PublicKey struct {
 }
 
 // Defines operations on private key
+//
+// Deprecated: not cryptographically secure.
 type PrivateKey struct {
 	key
 	// Secret key
@@ -38,8 +44,7 @@ type PrivateKey struct {
 	S []byte
 }
 
-// Id's correspond to bitlength of the prime field characteristic
-// Currently Fp751 is the only one supported by this implementation
+// Identifiers correspond to the bitlength of the prime field characteristic.
 const (
 	Fp434 = common.Fp434
 	Fp503 = common.Fp503
@@ -65,6 +70,8 @@ func (key *key) Variant() KeyVariant {
 
 // NewPublicKey initializes public key.
 // Usage of this function guarantees that the object is correctly initialized.
+//
+// Deprecated: not cryptographically secure.
 func NewPublicKey(id uint8, v KeyVariant) *PublicKey {
 	return &PublicKey{key: key{params: common.Params(id), keyVariant: v}}
 }
@@ -132,6 +139,8 @@ func (pub *PublicKey) Size() int {
 
 // NewPrivateKey initializes private key.
 // Usage of this function guarantees that the object is correctly initialized.
+//
+// Deprecated: not cryptographically secure.
 func NewPrivateKey(id uint8, v KeyVariant) *PrivateKey {
 	prv := &PrivateKey{key: key{params: common.Params(id), keyVariant: v}}
 	if (v & KeyVariantSidhA) == KeyVariantSidhA {

--- a/dh/sidh/sike.go
+++ b/dh/sidh/sike.go
@@ -10,6 +10,8 @@ import (
 )
 
 // SIKE KEM interface.
+//
+// Deprecated: not cryptographically secure.
 type KEM struct {
 	allocated   bool
 	rng         io.Reader
@@ -20,6 +22,8 @@ type KEM struct {
 }
 
 // NewSike434 instantiates SIKE/p434 KEM.
+//
+// Deprecated: not cryptographically secure.
 func NewSike434(rng io.Reader) *KEM {
 	var c KEM
 	c.Allocate(Fp434, rng)
@@ -27,6 +31,8 @@ func NewSike434(rng io.Reader) *KEM {
 }
 
 // NewSike503 instantiates SIKE/p503 KEM.
+//
+// Deprecated: not cryptographically secure.
 func NewSike503(rng io.Reader) *KEM {
 	var c KEM
 	c.Allocate(Fp503, rng)
@@ -34,6 +40,8 @@ func NewSike503(rng io.Reader) *KEM {
 }
 
 // NewSike751 instantiates SIKE/p751 KEM.
+//
+// Deprecated: not cryptographically secure.
 func NewSike751(rng io.Reader) *KEM {
 	var c KEM
 	c.Allocate(Fp751, rng)

--- a/kem/schemes/schemes.go
+++ b/kem/schemes/schemes.go
@@ -9,7 +9,6 @@
 // Post-quantum kems:
 //  FrodoKEM-640-SHAKE
 //  Kyber512, Kyber768, Kyber1024
-//  SIKEp434, SIKEp503, SIKEp751
 package schemes
 
 import (
@@ -22,9 +21,6 @@ import (
 	"github.com/cloudflare/circl/kem/kyber/kyber1024"
 	"github.com/cloudflare/circl/kem/kyber/kyber512"
 	"github.com/cloudflare/circl/kem/kyber/kyber768"
-	"github.com/cloudflare/circl/kem/sike/sikep434"
-	"github.com/cloudflare/circl/kem/sike/sikep503"
-	"github.com/cloudflare/circl/kem/sike/sikep751"
 )
 
 var allSchemes = [...]kem.Scheme{
@@ -37,9 +33,6 @@ var allSchemes = [...]kem.Scheme{
 	kyber512.Scheme(),
 	kyber768.Scheme(),
 	kyber1024.Scheme(),
-	sikep434.Scheme(),
-	sikep503.Scheme(),
-	sikep751.Scheme(),
 	hybrid.Kyber512X25519(),
 	hybrid.Kyber768X25519(),
 	hybrid.Kyber768X448(),

--- a/kem/schemes/schemes_test.go
+++ b/kem/schemes/schemes_test.go
@@ -155,9 +155,6 @@ func Example_schemes() {
 	// Kyber512
 	// Kyber768
 	// Kyber1024
-	// SIKEp434
-	// SIKEp503
-	// SIKEp751
 	// Kyber512-X25519
 	// Kyber768-X25519
 	// Kyber768-X448

--- a/kem/sike/doc.go
+++ b/kem/sike/doc.go
@@ -1,4 +1,11 @@
 //go:generate go run gen.go
 
-// Package sike contains the SIKE key encapsulation mechanism.
+// Package sike is deprecated, it contains the SIKE key encapsulation mechanism.
+//
+// DEPRECATION NOTICE
+//
+// SIDH and SIKE are deprecated as were shown vulnerable to a key recovery
+// attack by Castryck-Decru's paper (https://eprint.iacr.org/2022/975). New
+// systems should not rely on this package. This package is frozen.
+//
 package sike

--- a/kem/sike/sikep434/sike.go
+++ b/kem/sike/sikep434/sike.go
@@ -1,6 +1,13 @@
 // Code generated from pkg.templ.go. DO NOT EDIT.
 
-// Package sikep434 implements the key encapsulation mechanism SIKEp434.
+// Package sikep434 is deprecated, it implements the key encapsulation mechanism SIKEp434.
+//
+// DEPRECATION NOTICE
+//
+// SIDH and SIKE are deprecated as were shown vulnerable to a key recovery
+// attack by Castryck-Decru's paper (https://eprint.iacr.org/2022/975). New
+// systems should not rely on this package. This package is frozen.
+//
 package sikep434
 
 import (
@@ -14,11 +21,13 @@ import (
 	"github.com/cloudflare/circl/kem"
 )
 
+// Deprecated: not cryptographically secure.
 type PrivateKey struct {
 	sk *sidh.PrivateKey
 	pk *sidh.PublicKey
 }
 
+// Deprecated: not cryptographically secure.
 type PublicKey sidh.PublicKey
 
 const (
@@ -31,6 +40,8 @@ type scheme struct{}
 var sch kem.Scheme = &scheme{}
 
 // Scheme returns a KEM interface.
+//
+// Deprecated: not cryptographically secure.
 func Scheme() kem.Scheme { return sch }
 
 var params *sidh.KEM
@@ -87,6 +98,7 @@ func (pk *PublicKey) MarshalBinary() ([]byte, error) {
 	return ret, nil
 }
 
+// Deprecated: not cryptographically secure.
 func GenerateKeyPair(rand io.Reader) (kem.PublicKey, kem.PrivateKey, error) {
 	sk := sidh.NewPrivateKey(sidh.Fp434, sidh.KeyVariantSike)
 

--- a/kem/sike/sikep503/sike.go
+++ b/kem/sike/sikep503/sike.go
@@ -1,6 +1,13 @@
 // Code generated from pkg.templ.go. DO NOT EDIT.
 
-// Package sikep503 implements the key encapsulation mechanism SIKEp503.
+// Package sikep503 is deprecated, it implements the key encapsulation mechanism SIKEp503.
+//
+// DEPRECATION NOTICE
+//
+// SIDH and SIKE are deprecated as were shown vulnerable to a key recovery
+// attack by Castryck-Decru's paper (https://eprint.iacr.org/2022/975). New
+// systems should not rely on this package. This package is frozen.
+//
 package sikep503
 
 import (
@@ -14,11 +21,13 @@ import (
 	"github.com/cloudflare/circl/kem"
 )
 
+// Deprecated: not cryptographically secure.
 type PrivateKey struct {
 	sk *sidh.PrivateKey
 	pk *sidh.PublicKey
 }
 
+// Deprecated: not cryptographically secure.
 type PublicKey sidh.PublicKey
 
 const (
@@ -31,6 +40,8 @@ type scheme struct{}
 var sch kem.Scheme = &scheme{}
 
 // Scheme returns a KEM interface.
+//
+// Deprecated: not cryptographically secure.
 func Scheme() kem.Scheme { return sch }
 
 var params *sidh.KEM
@@ -87,6 +98,7 @@ func (pk *PublicKey) MarshalBinary() ([]byte, error) {
 	return ret, nil
 }
 
+// Deprecated: not cryptographically secure.
 func GenerateKeyPair(rand io.Reader) (kem.PublicKey, kem.PrivateKey, error) {
 	sk := sidh.NewPrivateKey(sidh.Fp503, sidh.KeyVariantSike)
 

--- a/kem/sike/sikep751/sike.go
+++ b/kem/sike/sikep751/sike.go
@@ -1,6 +1,13 @@
 // Code generated from pkg.templ.go. DO NOT EDIT.
 
-// Package sikep751 implements the key encapsulation mechanism SIKEp751.
+// Package sikep751 is deprecated, it implements the key encapsulation mechanism SIKEp751.
+//
+// DEPRECATION NOTICE
+//
+// SIDH and SIKE are deprecated as were shown vulnerable to a key recovery
+// attack by Castryck-Decru's paper (https://eprint.iacr.org/2022/975). New
+// systems should not rely on this package. This package is frozen.
+//
 package sikep751
 
 import (
@@ -14,11 +21,13 @@ import (
 	"github.com/cloudflare/circl/kem"
 )
 
+// Deprecated: not cryptographically secure.
 type PrivateKey struct {
 	sk *sidh.PrivateKey
 	pk *sidh.PublicKey
 }
 
+// Deprecated: not cryptographically secure.
 type PublicKey sidh.PublicKey
 
 const (
@@ -31,6 +40,8 @@ type scheme struct{}
 var sch kem.Scheme = &scheme{}
 
 // Scheme returns a KEM interface.
+//
+// Deprecated: not cryptographically secure.
 func Scheme() kem.Scheme { return sch }
 
 var params *sidh.KEM
@@ -87,6 +98,7 @@ func (pk *PublicKey) MarshalBinary() ([]byte, error) {
 	return ret, nil
 }
 
+// Deprecated: not cryptographically secure.
 func GenerateKeyPair(rand io.Reader) (kem.PublicKey, kem.PrivateKey, error) {
 	sk := sidh.NewPrivateKey(sidh.Fp751, sidh.KeyVariantSike)
 

--- a/kem/sike/templates/pkg.templ.go
+++ b/kem/sike/templates/pkg.templ.go
@@ -4,7 +4,14 @@
 
 // Code generated from pkg.templ.go. DO NOT EDIT.
 
-// Package {{.Pkg}} implements the key encapsulation mechanism {{.Name}}.
+// Package {{.Pkg}} is deprecated, it implements the key encapsulation mechanism {{.Name}}.
+//
+// DEPRECATION NOTICE
+//
+// SIDH and SIKE are deprecated as were shown vulnerable to a key recovery
+// attack by Castryck-Decru's paper (https://eprint.iacr.org/2022/975). New
+// systems should not rely on this package. This package is frozen.
+//
 package {{.Pkg}}
 
 import (
@@ -18,11 +25,14 @@ import (
 	"github.com/cloudflare/circl/kem"
 )
 
+
+// Deprecated: not cryptographically secure.
 type PrivateKey struct {
 	sk *sidh.PrivateKey
 	pk *sidh.PublicKey
 }
 
+// Deprecated: not cryptographically secure.
 type PublicKey sidh.PublicKey
 
 const (
@@ -35,6 +45,8 @@ type scheme struct{}
 var sch kem.Scheme = &scheme{}
 
 // Scheme returns a KEM interface.
+//
+// Deprecated: not cryptographically secure.
 func Scheme() kem.Scheme { return sch }
 
 var params *sidh.KEM
@@ -91,6 +103,7 @@ func (pk *PublicKey) MarshalBinary() ([]byte, error) {
 	return ret, nil
 }
 
+// Deprecated: not cryptographically secure.
 func GenerateKeyPair(rand io.Reader) (kem.PublicKey, kem.PrivateKey, error) {
 	sk := sidh.NewPrivateKey(sidh.{{.Field}}, sidh.KeyVariantSike)
 


### PR DESCRIPTION
## DEPRECATION NOTICE

SIDH and SIKE are deprecated as were shown vulnerable to a key recovery attack by Castryck-Decru's paper (https://eprint.iacr.org/2022/975). New systems should not rely on this package. This package is frozen.

Changes:
 - package /circl/dh/sidh is deprecated and frozen.
 - package /circl/kem/sike is deprecated and frozen.
 - package /circl/kem/schemes removes sike from the registry.
 
 