### PR TITLE
Removes dependency on io/ioutil as is deprecated.

### DIFF
--- a/blindsign/blindrsa/blindrsa_test.go
+++ b/blindsign/blindrsa/blindrsa_test.go
@@ -12,8 +12,8 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 )
 
@@ -361,7 +361,7 @@ func verifyTestVector(t *testing.T, vector testVector) {
 }
 
 func TestVectors(t *testing.T) {
-	data, err := ioutil.ReadFile("testdata/test_vectors.json")
+	data, err := os.ReadFile("testdata/test_vectors.json")
 	if err != nil {
 		t.Fatal("Failed reading test vectors:", err)
 	}

--- a/dh/x25519/key_test.go
+++ b/dh/x25519/key_test.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -40,7 +39,10 @@ func TestRFC7748Kat(t *testing.T) {
 		t.Fatalf("File %v can not be opened. Error: %v", nameFile, err)
 	}
 	defer jsonFile.Close()
-	input, _ := ioutil.ReadAll(jsonFile)
+	input, err := io.ReadAll(jsonFile)
+	if err != nil {
+		t.Fatalf("File %v can not be read. Error: %v", nameFile, err)
+	}
 
 	err = json.Unmarshal(input, &kat)
 	if err != nil {
@@ -71,7 +73,10 @@ func TestRFC7748Times(t *testing.T) {
 		t.Fatalf("File %v can not be opened. Error: %v", nameFile, err)
 	}
 	defer jsonFile.Close()
-	input, _ := ioutil.ReadAll(jsonFile)
+	input, err := io.ReadAll(jsonFile)
+	if err != nil {
+		t.Fatalf("File %v can not be read. Error: %v", nameFile, err)
+	}
 
 	var kat []katTimes
 	err = json.Unmarshal(input, &kat)
@@ -125,7 +130,11 @@ func TestWycheproof(t *testing.T) {
 	}
 	defer jsonFile.Close()
 
-	input, _ := ioutil.ReadAll(jsonFile)
+	input, err := io.ReadAll(jsonFile)
+	if err != nil {
+		t.Fatalf("File %v can not be read. Error: %v", nameFile, err)
+	}
+
 	var vecRaw []struct {
 		TcID    int      `json:"tcId"`
 		Comment string   `json:"comment"`

--- a/dh/x448/key_test.go
+++ b/dh/x448/key_test.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -40,7 +39,10 @@ func TestRFC7748Kat(t *testing.T) {
 		t.Fatalf("File %v can not be opened. Error: %v", nameFile, err)
 	}
 	defer jsonFile.Close()
-	input, _ := ioutil.ReadAll(jsonFile)
+	input, err := io.ReadAll(jsonFile)
+	if err != nil {
+		t.Fatalf("File %v can not be read. Error: %v", nameFile, err)
+	}
 
 	err = json.Unmarshal(input, &kat)
 	if err != nil {
@@ -70,7 +72,10 @@ func TestRFC7748Times(t *testing.T) {
 		t.Fatalf("File %v can not be opened. Error: %v", nameFile, err)
 	}
 	defer jsonFile.Close()
-	input, _ := ioutil.ReadAll(jsonFile)
+	input, err := io.ReadAll(jsonFile)
+	if err != nil {
+		t.Fatalf("File %v can not be read. Error: %v", nameFile, err)
+	}
 
 	var kat []katTimes
 	err = json.Unmarshal(input, &kat)

--- a/ecc/bls12381/hash_test.go
+++ b/ecc/bls12381/hash_test.go
@@ -3,7 +3,7 @@ package bls12381
 import (
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -102,7 +102,7 @@ func readFile(t *testing.T, fileName string) *vectorHash {
 		t.Fatalf("File %v can not be opened. Error: %v", fileName, err)
 	}
 	defer jsonFile.Close()
-	input, err := ioutil.ReadAll(jsonFile)
+	input, err := io.ReadAll(jsonFile)
 	if err != nil {
 		t.Fatalf("File %v can not be loaded. Error: %v", fileName, err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.16
 require (
 	github.com/bwesterb/go-ristretto v1.2.2
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa
-	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10
+	golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664 h1:v1W7bwXHsnLLloWYTVEdvGvA7BHMeBYsPcF0GLDxIRs=
+golang.org/x/sys v0.0.0-20220808155132-1c4a2a72c664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/hpke/vectors_test.go
+++ b/hpke/vectors_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -190,7 +190,10 @@ func readFile(t *testing.T, fileName string) []vector {
 		t.Fatalf("File %v can not be opened. Error: %v", fileName, err)
 	}
 	defer jsonFile.Close()
-	input, _ := ioutil.ReadAll(jsonFile)
+	input, err := io.ReadAll(jsonFile)
+	if err != nil {
+		t.Fatalf("File %v can not be read. Error: %v", fileName, err)
+	}
 	var vectors []vector
 	err = json.Unmarshal(input, &vectors)
 	if err != nil {

--- a/oprf/vectors_test.go
+++ b/oprf/vectors_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -90,7 +90,10 @@ func readFile(t *testing.T, fileName string) []vector {
 		t.Fatalf("File %v can not be opened. Error: %v", fileName, err)
 	}
 	defer jsonFile.Close()
-	input, _ := ioutil.ReadAll(jsonFile)
+	input, err := io.ReadAll(jsonFile)
+	if err != nil {
+		t.Fatalf("File %v can not be read. Error: %v", fileName, err)
+	}
 
 	var v []vector
 	err = json.Unmarshal(input, &v)

--- a/pke/kyber/gen.go
+++ b/pke/kyber/gen.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 	"go/format"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -94,7 +93,7 @@ func generateParamsFiles() {
 		if offset == -1 {
 			panic("Missing template warning in params.templ.go")
 		}
-		err = ioutil.WriteFile(mode.Pkg()+"/internal/params.go",
+		err = io.WriteFile(mode.Pkg()+"/internal/params.go",
 			[]byte(res[offset:]), 0o644)
 		if err != nil {
 			panic(err)
@@ -121,7 +120,7 @@ func generatePackageFiles() {
 		if offset == -1 {
 			panic("Missing template warning in pkg.templ.go")
 		}
-		err = ioutil.WriteFile(mode.Pkg()+"/kyber.go", []byte(res[offset:]), 0o644)
+		err = io.WriteFile(mode.Pkg()+"/kyber.go", []byte(res[offset:]), 0o644)
 		if err != nil {
 			panic(err)
 		}
@@ -137,7 +136,7 @@ func generateSourceFiles() {
 		return x == "params.go" || x == "params_test.go"
 	}
 
-	fs, err := ioutil.ReadDir("kyber512/internal")
+	fs, err := io.ReadDir("kyber512/internal")
 	if err != nil {
 		panic(err)
 	}
@@ -148,7 +147,7 @@ func generateSourceFiles() {
 		if ignored(name) {
 			continue
 		}
-		files[name], err = ioutil.ReadFile(path.Join("kyber512/internal", name))
+		files[name], err = io.ReadFile(path.Join("kyber512/internal", name))
 		if err != nil {
 			panic(err)
 		}
@@ -160,7 +159,7 @@ func generateSourceFiles() {
 			continue
 		}
 
-		fs, err = ioutil.ReadDir(path.Join(mode.Pkg(), "internal"))
+		fs, err = io.ReadDir(path.Join(mode.Pkg(), "internal"))
 		for _, f := range fs {
 			name := f.Name()
 			fn := path.Join(mode.Pkg(), "internal", name)
@@ -194,14 +193,14 @@ func generateSourceFiles() {
 				name,
 				string(expected),
 			))
-			got, err := ioutil.ReadFile(fn)
+			got, err := io.ReadFile(fn)
 			if err == nil {
 				if bytes.Equal(got, expected) {
 					continue
 				}
 			}
 			fmt.Printf("Updating %s\n", fn)
-			err = ioutil.WriteFile(fn, expected, 0o644)
+			err = io.WriteFile(fn, expected, 0o644)
 			if err != nil {
 				panic(err)
 			}

--- a/sign/dilithium/gen.go
+++ b/sign/dilithium/gen.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 	"go/format"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -154,7 +153,7 @@ func generateParamsFiles() {
 		if offset == -1 {
 			panic("Missing template warning in params.templ.go")
 		}
-		err = ioutil.WriteFile(mode.Pkg()+"/internal/params.go",
+		err = io.WriteFile(mode.Pkg()+"/internal/params.go",
 			[]byte(res[offset:]), 0o644)
 		if err != nil {
 			panic(err)
@@ -181,7 +180,7 @@ func generateModeToplevelFiles() {
 		if offset == -1 {
 			panic("Missing template warning in mode.templ.go")
 		}
-		err = ioutil.WriteFile(mode.Pkg()+".go", []byte(res[offset:]), 0o644)
+		err = io.WriteFile(mode.Pkg()+".go", []byte(res[offset:]), 0o644)
 		if err != nil {
 			panic(err)
 		}
@@ -207,7 +206,7 @@ func generateModePackageFiles() {
 		if offset == -1 {
 			panic("Missing template warning in modePkg.templ.go")
 		}
-		err = ioutil.WriteFile(mode.Pkg()+"/dilithium.go", []byte(res[offset:]), 0o644)
+		err = io.WriteFile(mode.Pkg()+"/dilithium.go", []byte(res[offset:]), 0o644)
 		if err != nil {
 			panic(err)
 		}
@@ -224,7 +223,7 @@ func generateSourceFiles() {
 			strings.HasSuffix(x, ".swp")
 	}
 
-	fs, err := ioutil.ReadDir("mode3/internal")
+	fs, err := io.ReadDir("mode3/internal")
 	if err != nil {
 		panic(err)
 	}
@@ -235,7 +234,7 @@ func generateSourceFiles() {
 		if ignored(name) {
 			continue
 		}
-		files[name], err = ioutil.ReadFile(path.Join("mode3/internal", name))
+		files[name], err = io.ReadFile(path.Join("mode3/internal", name))
 		if err != nil {
 			panic(err)
 		}
@@ -247,7 +246,7 @@ func generateSourceFiles() {
 			continue
 		}
 
-		fs, err = ioutil.ReadDir(path.Join(mode.Pkg(), "internal"))
+		fs, err = io.ReadDir(path.Join(mode.Pkg(), "internal"))
 		for _, f := range fs {
 			name := f.Name()
 			fn := path.Join(mode.Pkg(), "internal", name)
@@ -281,14 +280,14 @@ func generateSourceFiles() {
 				name,
 				string(expected),
 			))
-			got, err := ioutil.ReadFile(fn)
+			got, err := io.ReadFile(fn)
 			if err == nil {
 				if bytes.Equal(got, expected) {
 					continue
 				}
 			}
 			fmt.Printf("Updating %s\n", fn)
-			err = ioutil.WriteFile(fn, expected, 0o644)
+			err = io.WriteFile(fn, expected, 0o644)
 			if err != nil {
 				panic(err)
 			}

--- a/sign/ed25519/wycheproof_test.go
+++ b/sign/ed25519/wycheproof_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -44,7 +44,10 @@ func (kat *Wycheproof) readFile(t *testing.T, fileName string) {
 		t.Fatalf("File %v can not be opened. Error: %v", fileName, err)
 	}
 	defer jsonFile.Close()
-	input, _ := ioutil.ReadAll(jsonFile)
+	input, err := io.ReadAll(jsonFile)
+	if err != nil {
+		t.Fatalf("File %v can not be read. Error: %v", fileName, err)
+	}
 
 	err = json.Unmarshal(input, &kat)
 	if err != nil {

--- a/sign/ed448/wycheproof_test.go
+++ b/sign/ed448/wycheproof_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -44,7 +44,10 @@ func (kat *Wycheproof) readFile(t *testing.T, fileName string) {
 		t.Fatalf("File %v can not be opened. Error: %v", fileName, err)
 	}
 	defer jsonFile.Close()
-	input, _ := ioutil.ReadAll(jsonFile)
+	input, err := io.ReadAll(jsonFile)
+	if err != nil {
+		t.Fatalf("File %v can not be read. Error: %v", fileName, err)
+	}
 
 	err = json.Unmarshal(input, &kat)
 	if err != nil {


### PR DESCRIPTION
This PR removes dependency on io/ioutil, since it was deprecated in https://tip.golang.org/doc/go1.16#ioutil
