### PR TITLE
Formatting files with new go1.19 fmt tool.

### DIFF
--- a/dh/csidh/csidh.go
+++ b/dh/csidh/csidh.go
@@ -283,7 +283,9 @@ func GeneratePublicKey(pub *PublicKey, prv *PrivateKey, rng io.Reader) {
 // Validate returns true if 'pub' is a valid cSIDH public key,
 // otherwise false.
 // More precisely, the function verifies that curve
-//            y^2 = x^3 + pub.a * x^2 + x
+//
+//	y^2 = x^3 + pub.a * x^2 + x
+//
 // is supersingular.
 func Validate(pub *PublicKey, rng io.Reader) bool {
 	// Check if in range

--- a/dh/csidh/curve.go
+++ b/dh/csidh/curve.go
@@ -2,7 +2,9 @@ package csidh
 
 // xAdd implements differential arithmetic in P^1 for Montgomery
 // curves E(x): x^3 + A*x^2 + x by using x-coordinate only arithmetic.
-//    x(PaQ) = x(P) + x(Q) by using x(P-Q)
+//
+//	x(PaQ) = x(P) + x(Q) by using x(P-Q)
+//
 // This algorithms is correctly defined only for cases when
 // P!=inf, Q!=inf, P!=Q and P!=-Q.
 func xAdd(PaQ, P, Q, PdQ *point) {
@@ -23,7 +25,9 @@ func xAdd(PaQ, P, Q, PdQ *point) {
 
 // xDbl implements point doubling on a Montgomery curve
 // E(x): x^3 + A*x^2 + x by using x-coordinate onlyh arithmetic.
-//   x(Q) = [2]*x(P)
+//
+//	x(Q) = [2]*x(P)
+//
 // It is correctly defined for all P != inf.
 func xDbl(Q, P, A *point) {
 	var t0, t1, t2 fp
@@ -45,8 +49,9 @@ func xDbl(Q, P, A *point) {
 // xDblAdd implements combined doubling of point P
 // and addition of points P and Q on a Montgomery curve
 // E(x): x^3 + A*x^2 + x by using x-coordinate onlyh arithmetic.
-//   x(PaP) = x(2*P)
-//   x(PaQ) = x(P+Q)
+//
+//	x(PaP) = x(2*P)
+//	x(PaQ) = x(P+Q)
 func xDblAdd(PaP, PaQ, P, Q, PdQ *point, A24 *coeff) {
 	var t0, t1, t2 fp
 

--- a/dh/csidh/doc.go
+++ b/dh/csidh/doc.go
@@ -5,7 +5,6 @@
 // for securing systems.
 //
 // References:
-//  - cSIDH:        ia.cr/2018/383
-//  - Faster cSIDH: ia.cr/2018/782
-//
+//   - cSIDH:        ia.cr/2018/383
+//   - Faster cSIDH: ia.cr/2018/782
 package csidh

--- a/dh/csidh/fp511.go
+++ b/dh/csidh/fp511.go
@@ -178,8 +178,10 @@ func modExpRdc64(r, b *fp, e uint64) {
 // isNonQuadRes checks whether value v is quadratic residue.
 // Implementation uses Fermat's little theorem (or
 // Euler's criterion)
-//      a^(p-1) == 1, hence
-//      (a^2) ((p-1)/2) == 1
+//
+//	a^(p-1) == 1, hence
+//	(a^2) ((p-1)/2) == 1
+//
 // Which means v is a quadratic residue iff v^((p-1)/2) == 1.
 // Caller provided v must be in montgomery domain.
 // Returns 0 in case v is quadratic residue or 1 in case

--- a/dh/curve4q/doc.go
+++ b/dh/curve4q/doc.go
@@ -2,7 +2,6 @@
 // at the 128-bit security level.
 //
 // References:
-//  - https://eprint.iacr.org/2015/565
-//  - https://tools.ietf.org/html/draft-ladd-cfrg-4q-01
-//
+//   - https://eprint.iacr.org/2015/565
+//   - https://tools.ietf.org/html/draft-ladd-cfrg-4q-01
 package curve4q

--- a/dh/sidh/doc.go
+++ b/dh/sidh/doc.go
@@ -1,13 +1,13 @@
 // Package sidh is deprecated, it provides SIDH and SIKE key encapsulation
 // mechanisms.
 //
-// DEPRECATION NOTICE
+// # DEPRECATION NOTICE
 //
 // SIDH and SIKE are deprecated as were shown vulnerable to a key recovery
 // attack by Castryck-Decru's paper (https://eprint.iacr.org/2022/975). New
 // systems should not rely on this package. This package is frozen.
 //
-// SIDH and SIKE
+// # SIDH and SIKE
 //
 // This package provides implementation of experimental post-quantum
 // Supersingular Isogeny Diffie-Hellman (SIDH) as well as Supersingular
@@ -38,7 +38,6 @@
 //
 // References:
 //
-//  - [SIDH] https://eprint.iacr.org/2011/506
-//  - [SIKE] http://www.sike.org/files/SIDH-spec.pdf
-//
+//   - [SIDH] https://eprint.iacr.org/2011/506
+//   - [SIKE] http://www.sike.org/files/SIDH-spec.pdf
 package sidh

--- a/dh/sidh/internal/p434/arith_decl.go
+++ b/dh/sidh/internal/p434/arith_decl.go
@@ -13,40 +13,49 @@ import (
 // If choice = 0, leave x unchanged. If choice = 1, sets x to y.
 // If choice is neither 0 nor 1 then behaviour is undefined.
 // This function executes in constant time.
+//
 //go:noescape
 func cmovP434(x, y *Fp, choice uint8)
 
 // If choice = 0, leave x,y unchanged. If choice = 1, set x,y = y,x.
 // If choice is neither 0 nor 1 then behaviour is undefined.
 // This function executes in constant time.
+//
 //go:noescape
 func cswapP434(x, y *Fp, choice uint8)
 
 // Compute z = x + y (mod p).
+//
 //go:noescape
 func addP434(z, x, y *Fp)
 
 // Compute z = x - y (mod p).
+//
 //go:noescape
 func subP434(z, x, y *Fp)
 
 // Compute z = x + y, without reducing mod p.
+//
 //go:noescape
 func adlP434(z, x, y *FpX2)
 
 // Compute z = x - y, without reducing mod p.
+//
 //go:noescape
 func sulP434(z, x, y *FpX2)
 
 // Reduce a field element in [0, 2*p) to one in [0,p).
+//
 //go:noescape
 func modP434(x *Fp)
 
 // Computes z = x * y.
+//
 //go:noescape
 func mulP434(z *FpX2, x, y *Fp)
 
 // Computes the Montgomery reduction z = x R^{-1} (mod 2*p). On return value
 // of x may be changed. z=x not allowed.
+//
 //go:noescape
 func rdcP434(z *Fp, x *FpX2)

--- a/dh/sidh/internal/p434/curve.go
+++ b/dh/sidh/internal/p434/curve.go
@@ -258,8 +258,9 @@ func ScalarMul3Pt(cparams *ProjectiveCurveParameters, P, Q, PmQ *ProjectivePoint
 // three-isogeny phi : E_(A:C) -> E_(A:C)/<P_3> = E_(A':C').
 //
 // Input: (XP_3: ZP_3), where P_3 has exact order 3 on E_A/C
-// Output: * Curve coordinates (A' + 2C', A' - 2C') corresponding to E_A'/C' = A_E/C/<P3>
-//         * Isogeny phi with constants in F_p^2
+// Output:
+//   - Curve coordinates (A' + 2C', A' - 2C') corresponding to E_A'/C' = A_E/C/<P3>
+//   - Isogeny phi with constants in F_p^2
 func (phi *isogeny3) GenerateCurve(p *ProjectivePoint) CurveCoefficientsEquiv {
 	var t0, t1, t2, t3, t4 Fp2
 	var coefEq CurveCoefficientsEquiv
@@ -314,8 +315,9 @@ func (phi *isogeny3) EvaluatePoint(p *ProjectivePoint) {
 // four-isogeny phi : E_(A:C) -> E_(A:C)/<P_4> = E_(A':C').
 //
 // Input: (XP_4: ZP_4), where P_4 has exact order 4 on E_A/C
-// Output: * Curve coordinates (A' + 2C', 4C') corresponding to E_A'/C' = A_E/C/<P4>
-//         * Isogeny phi with constants in F_p^2
+// Output:
+//   - Curve coordinates (A' + 2C', 4C') corresponding to E_A'/C' = A_E/C/<P4>
+//   - Isogeny phi with constants in F_p^2
 func (phi *isogeny4) GenerateCurve(p *ProjectivePoint) CurveCoefficientsEquiv {
 	var coefEq CurveCoefficientsEquiv
 	xp4, zp4 := &p.X, &p.Z

--- a/dh/sidh/internal/p434/fp2.go
+++ b/dh/sidh/internal/p434/fp2.go
@@ -147,8 +147,10 @@ func sqr(dest, x *common.Fp2) {
 }
 
 // In case choice == 1, performs following swap in constant time:
-// 	xPx <-> xQx
+//
+//	xPx <-> xQx
 //	xPz <-> xQz
+//
 // Otherwise returns xPx, xPz, xQx, xQz unchanged
 func cswap(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
 	cswapP434(&xPx.A, &xQx.A, choice)
@@ -158,8 +160,10 @@ func cswap(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
 }
 
 // In case choice == 1, performs following moves in constant time:
-//     xPx <- xQx
-//     xPz <- xQz
+//
+//	xPx <- xQx
+//	xPz <- xQz
+//
 // Otherwise returns xPx, xPz, xQx, xQz unchanged
 func cmov(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
 	cmovP434(&xPx.A, &xQx.A, choice)

--- a/dh/sidh/internal/p503/arith_decl.go
+++ b/dh/sidh/internal/p503/arith_decl.go
@@ -13,40 +13,49 @@ import (
 // If choice = 0, leave x unchanged. If choice = 1, sets x to y.
 // If choice is neither 0 nor 1 then behaviour is undefined.
 // This function executes in constant time.
+//
 //go:noescape
 func cmovP503(x, y *Fp, choice uint8)
 
 // If choice = 0, leave x,y unchanged. If choice = 1, set x,y = y,x.
 // If choice is neither 0 nor 1 then behaviour is undefined.
 // This function executes in constant time.
+//
 //go:noescape
 func cswapP503(x, y *Fp, choice uint8)
 
 // Compute z = x + y (mod p).
+//
 //go:noescape
 func addP503(z, x, y *Fp)
 
 // Compute z = x - y (mod p).
+//
 //go:noescape
 func subP503(z, x, y *Fp)
 
 // Compute z = x + y, without reducing mod p.
+//
 //go:noescape
 func adlP503(z, x, y *FpX2)
 
 // Compute z = x - y, without reducing mod p.
+//
 //go:noescape
 func sulP503(z, x, y *FpX2)
 
 // Reduce a field element in [0, 2*p) to one in [0,p).
+//
 //go:noescape
 func modP503(x *Fp)
 
 // Computes z = x * y.
+//
 //go:noescape
 func mulP503(z *FpX2, x, y *Fp)
 
 // Computes the Montgomery reduction z = x R^{-1} (mod 2*p). On return value
 // of x may be changed. z=x not allowed.
+//
 //go:noescape
 func rdcP503(z *Fp, x *FpX2)

--- a/dh/sidh/internal/p503/curve.go
+++ b/dh/sidh/internal/p503/curve.go
@@ -258,8 +258,9 @@ func ScalarMul3Pt(cparams *ProjectiveCurveParameters, P, Q, PmQ *ProjectivePoint
 // three-isogeny phi : E_(A:C) -> E_(A:C)/<P_3> = E_(A':C').
 //
 // Input: (XP_3: ZP_3), where P_3 has exact order 3 on E_A/C
-// Output: * Curve coordinates (A' + 2C', A' - 2C') corresponding to E_A'/C' = A_E/C/<P3>
-//         * Isogeny phi with constants in F_p^2
+// Output:
+//   - Curve coordinates (A' + 2C', A' - 2C') corresponding to E_A'/C' = A_E/C/<P3>
+//   - Isogeny phi with constants in F_p^2
 func (phi *isogeny3) GenerateCurve(p *ProjectivePoint) CurveCoefficientsEquiv {
 	var t0, t1, t2, t3, t4 Fp2
 	var coefEq CurveCoefficientsEquiv
@@ -314,8 +315,9 @@ func (phi *isogeny3) EvaluatePoint(p *ProjectivePoint) {
 // four-isogeny phi : E_(A:C) -> E_(A:C)/<P_4> = E_(A':C').
 //
 // Input: (XP_4: ZP_4), where P_4 has exact order 4 on E_A/C
-// Output: * Curve coordinates (A' + 2C', 4C') corresponding to E_A'/C' = A_E/C/<P4>
-//         * Isogeny phi with constants in F_p^2
+// Output:
+//   - Curve coordinates (A' + 2C', 4C') corresponding to E_A'/C' = A_E/C/<P4>
+//   - Isogeny phi with constants in F_p^2
 func (phi *isogeny4) GenerateCurve(p *ProjectivePoint) CurveCoefficientsEquiv {
 	var coefEq CurveCoefficientsEquiv
 	xp4, zp4 := &p.X, &p.Z

--- a/dh/sidh/internal/p503/fp2.go
+++ b/dh/sidh/internal/p503/fp2.go
@@ -147,8 +147,10 @@ func sqr(dest, x *common.Fp2) {
 }
 
 // In case choice == 1, performs following swap in constant time:
-// 	xPx <-> xQx
+//
+//	xPx <-> xQx
 //	xPz <-> xQz
+//
 // Otherwise returns xPx, xPz, xQx, xQz unchanged
 func cswap(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
 	cswapP503(&xPx.A, &xQx.A, choice)
@@ -158,8 +160,10 @@ func cswap(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
 }
 
 // In case choice == 1, performs following moves in constant time:
-//     xPx <- xQx
-//     xPz <- xQz
+//
+//	xPx <- xQx
+//	xPz <- xQz
+//
 // Otherwise returns xPx, xPz, xQx, xQz unchanged
 func cmov(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
 	cmovP503(&xPx.A, &xQx.A, choice)

--- a/dh/sidh/internal/p751/arith_decl.go
+++ b/dh/sidh/internal/p751/arith_decl.go
@@ -13,40 +13,49 @@ import (
 // If choice = 0, leave x unchanged. If choice = 1, sets x to y.
 // If choice is neither 0 nor 1 then behaviour is undefined.
 // This function executes in constant time.
+//
 //go:noescape
 func cmovP751(x, y *Fp, choice uint8)
 
 // If choice = 0, leave x,y unchanged. If choice = 1, set x,y = y,x.
 // If choice is neither 0 nor 1 then behaviour is undefined.
 // This function executes in constant time.
+//
 //go:noescape
 func cswapP751(x, y *Fp, choice uint8)
 
 // Compute z = x + y (mod p).
+//
 //go:noescape
 func addP751(z, x, y *Fp)
 
 // Compute z = x - y (mod p).
+//
 //go:noescape
 func subP751(z, x, y *Fp)
 
 // Compute z = x + y, without reducing mod p.
+//
 //go:noescape
 func adlP751(z, x, y *FpX2)
 
 // Compute z = x - y, without reducing mod p.
+//
 //go:noescape
 func sulP751(z, x, y *FpX2)
 
 // Reduce a field element in [0, 2*p) to one in [0,p).
+//
 //go:noescape
 func modP751(x *Fp)
 
 // Computes z = x * y.
+//
 //go:noescape
 func mulP751(z *FpX2, x, y *Fp)
 
 // Computes the Montgomery reduction z = x R^{-1} (mod 2*p). On return value
 // of x may be changed. z=x not allowed.
+//
 //go:noescape
 func rdcP751(z *Fp, x *FpX2)

--- a/dh/sidh/internal/p751/curve.go
+++ b/dh/sidh/internal/p751/curve.go
@@ -258,8 +258,9 @@ func ScalarMul3Pt(cparams *ProjectiveCurveParameters, P, Q, PmQ *ProjectivePoint
 // three-isogeny phi : E_(A:C) -> E_(A:C)/<P_3> = E_(A':C').
 //
 // Input: (XP_3: ZP_3), where P_3 has exact order 3 on E_A/C
-// Output: * Curve coordinates (A' + 2C', A' - 2C') corresponding to E_A'/C' = A_E/C/<P3>
-//         * Isogeny phi with constants in F_p^2
+// Output:
+//   - Curve coordinates (A' + 2C', A' - 2C') corresponding to E_A'/C' = A_E/C/<P3>
+//   - Isogeny phi with constants in F_p^2
 func (phi *isogeny3) GenerateCurve(p *ProjectivePoint) CurveCoefficientsEquiv {
 	var t0, t1, t2, t3, t4 Fp2
 	var coefEq CurveCoefficientsEquiv
@@ -314,8 +315,9 @@ func (phi *isogeny3) EvaluatePoint(p *ProjectivePoint) {
 // four-isogeny phi : E_(A:C) -> E_(A:C)/<P_4> = E_(A':C').
 //
 // Input: (XP_4: ZP_4), where P_4 has exact order 4 on E_A/C
-// Output: * Curve coordinates (A' + 2C', 4C') corresponding to E_A'/C' = A_E/C/<P4>
-//         * Isogeny phi with constants in F_p^2
+// Output:
+//   - Curve coordinates (A' + 2C', 4C') corresponding to E_A'/C' = A_E/C/<P4>
+//   - Isogeny phi with constants in F_p^2
 func (phi *isogeny4) GenerateCurve(p *ProjectivePoint) CurveCoefficientsEquiv {
 	var coefEq CurveCoefficientsEquiv
 	xp4, zp4 := &p.X, &p.Z

--- a/dh/sidh/internal/p751/fp2.go
+++ b/dh/sidh/internal/p751/fp2.go
@@ -147,8 +147,10 @@ func sqr(dest, x *common.Fp2) {
 }
 
 // In case choice == 1, performs following swap in constant time:
-// 	xPx <-> xQx
+//
+//	xPx <-> xQx
 //	xPz <-> xQz
+//
 // Otherwise returns xPx, xPz, xQx, xQz unchanged
 func cswap(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
 	cswapP751(&xPx.A, &xQx.A, choice)
@@ -158,8 +160,10 @@ func cswap(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
 }
 
 // In case choice == 1, performs following moves in constant time:
-//     xPx <- xQx
-//     xPz <- xQz
+//
+//	xPx <- xQx
+//	xPz <- xQz
+//
 // Otherwise returns xPx, xPz, xQx, xQz unchanged
 func cmov(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
 	cmovP751(&xPx.A, &xQx.A, choice)

--- a/dh/sidh/internal/templates/arith_decl.gotemp
+++ b/dh/sidh/internal/templates/arith_decl.gotemp
@@ -13,40 +13,49 @@ import (
 // If choice = 0, leave x unchanged. If choice = 1, sets x to y.
 // If choice is neither 0 nor 1 then behaviour is undefined.
 // This function executes in constant time.
+//
 //go:noescape
 func cmov{{.FIELD}}(x, y *Fp, choice uint8)
 
 // If choice = 0, leave x,y unchanged. If choice = 1, set x,y = y,x.
 // If choice is neither 0 nor 1 then behaviour is undefined.
 // This function executes in constant time.
+//
 //go:noescape
 func cswap{{.FIELD}}(x, y *Fp, choice uint8)
 
 // Compute z = x + y (mod p).
+//
 //go:noescape
 func add{{.FIELD}}(z, x, y *Fp)
 
 // Compute z = x - y (mod p).
+//
 //go:noescape
 func sub{{.FIELD}}(z, x, y *Fp)
 
 // Compute z = x + y, without reducing mod p.
+//
 //go:noescape
 func adl{{.FIELD}}(z, x, y *FpX2)
 
 // Compute z = x - y, without reducing mod p.
+//
 //go:noescape
 func sul{{.FIELD}}(z, x, y *FpX2)
 
 // Reduce a field element in [0, 2*p) to one in [0,p).
+//
 //go:noescape
 func mod{{.FIELD}}(x *Fp)
 
 // Computes z = x * y.
+//
 //go:noescape
 func mul{{.FIELD}}(z *FpX2, x, y *Fp)
 
 // Computes the Montgomery reduction z = x R^{-1} (mod 2*p). On return value
 // of x may be changed. z=x not allowed.
+//
 //go:noescape
 func rdc{{.FIELD}}(z *Fp, x *FpX2)

--- a/dh/sidh/internal/templates/curve.gotemp
+++ b/dh/sidh/internal/templates/curve.gotemp
@@ -242,7 +242,7 @@ func ScalarMul3Pt(cparams *ProjectiveCurveParameters, P, Q, PmQ *ProjectivePoint
 	R2 = *PmQ
 	R0 = *Q
 
-	
+
 	// Iterate over the bits of the scalar, bottom to top
 	prevBit := uint8(0)
 	for i := uint(0); i < nbits; i++ {
@@ -260,8 +260,9 @@ func ScalarMul3Pt(cparams *ProjectiveCurveParameters, P, Q, PmQ *ProjectivePoint
 // three-isogeny phi : E_(A:C) -> E_(A:C)/<P_3> = E_(A':C').
 //
 // Input: (XP_3: ZP_3), where P_3 has exact order 3 on E_A/C
-// Output: * Curve coordinates (A' + 2C', A' - 2C') corresponding to E_A'/C' = A_E/C/<P3>
-//         * Isogeny phi with constants in F_p^2
+// Output:
+//   - Curve coordinates (A' + 2C', A' - 2C') corresponding to E_A'/C' = A_E/C/<P3>
+//   - Isogeny phi with constants in F_p^2
 func (phi *isogeny3) GenerateCurve(p *ProjectivePoint) CurveCoefficientsEquiv {
 	var t0, t1, t2, t3, t4 Fp2
 	var coefEq CurveCoefficientsEquiv
@@ -316,8 +317,9 @@ func (phi *isogeny3) EvaluatePoint(p *ProjectivePoint) {
 // four-isogeny phi : E_(A:C) -> E_(A:C)/<P_4> = E_(A':C').
 //
 // Input: (XP_4: ZP_4), where P_4 has exact order 4 on E_A/C
-// Output: * Curve coordinates (A' + 2C', 4C') corresponding to E_A'/C' = A_E/C/<P4>
-//         * Isogeny phi with constants in F_p^2
+// Output:
+//   - Curve coordinates (A' + 2C', 4C') corresponding to E_A'/C' = A_E/C/<P4>
+//   - Isogeny phi with constants in F_p^2
 func (phi *isogeny4) GenerateCurve(p *ProjectivePoint) CurveCoefficientsEquiv {
 	var coefEq CurveCoefficientsEquiv
 	xp4, zp4 := &p.X, &p.Z
@@ -361,14 +363,14 @@ func (phi *isogeny4) EvaluatePoint(p *ProjectivePoint) {
 	mul(zq, zq, &t0)
 }
 
-// PublicKeyValidation preforms public key/ciphertext validation using the CLN test. 
+// PublicKeyValidation preforms public key/ciphertext validation using the CLN test.
 // CLN test: Check that P and Q are both of order 3^e3 and they generate the torsion E_A[3^e3]
 // A countermeasure for remote timing attacks on SIKE; suggested by https://eprint.iacr.org/2022/054.pdf
-// Any curve E_A (SIKE 434, 503, 751) that passes CLN test is supersingular. 
+// Any curve E_A (SIKE 434, 503, 751) that passes CLN test is supersingular.
 // Input: The public key / ciphertext P, Q, PmQ. The projective coordinate A of the curve defined by (P, Q, PmQ)
 // Outputs: Whether (P,Q,PmQ) follows the CLN test
 func PublicKeyValidation(cparams *ProjectiveCurveParameters, P, Q, PmQ *ProjectivePoint, nbits uint) error {
-	
+
 
 	var PmQX, PmQZ Fp2
 	FromMontgomery(&PmQX, &PmQ.X)
@@ -378,29 +380,29 @@ func PublicKeyValidation(cparams *ProjectiveCurveParameters, P, Q, PmQ *Projecti
 	if((isZero(&PmQX)==1)||(isZero(&PmQZ)==1)){
 		return errors.New("curve: PmQ is invalid")
 	}
-	
+
 	cparam := CalcCurveParamsEquiv3(cparams)
 
 	// Compute e_3 = log3(2^(nbits+1))
 	var e3 uint32
 	e3_float := float64(int(nbits)+1)/math.Log2(3)
 	e3 = uint32(e3_float)
-	
+
 	// Verify that P and Q generate E_A[3^e_3] by checking: [3^(e_3-1)]P != [+-3^(e_3-1)]Q
 	var test_P, test_Q ProjectivePoint
 	test_P = *P
 	test_Q = *Q
 
-	
+
 	Pow3k(&test_P, &cparam, e3-1)
 	Pow3k(&test_Q, &cparam, e3-1)
 
-    
+
 	var PZ, QZ Fp2
 	FromMontgomery(&PZ, &test_P.Z)
 	FromMontgomery(&QZ, &test_Q.Z)
 
-	
+
 	// P, Q are not of full order 3^e_3
 	if((isZero(&PZ)==1)||(isZero(&QZ)==1)){
 		return errors.New("curve: ciphertext/public key are not of full order 3^e3")
@@ -426,13 +428,10 @@ func PublicKeyValidation(cparams *ProjectiveCurveParameters, P, Q, PmQ *Projecti
 
 	FromMontgomery(&PZ, &test_P.Z)
 	FromMontgomery(&QZ, &test_Q.Z)
-	
+
 	// P, Q are not of correct order 3^e_3
 	if((isZero(&PZ)==0)||(isZero(&QZ)==0)){
 		return errors.New("curve: ciphertext/public key are not of correct order 3^e3")
 	}
 	return nil
 }
-
-
-

--- a/dh/sidh/internal/templates/fp2.gotemp
+++ b/dh/sidh/internal/templates/fp2.gotemp
@@ -147,8 +147,10 @@ func sqr(dest, x *common.Fp2) {
 }
 
 // In case choice == 1, performs following swap in constant time:
-// 	xPx <-> xQx
-//	xPz <-> xQz
+//
+// 	   xPx <-> xQx
+//	   xPz <-> xQz
+//
 // Otherwise returns xPx, xPz, xQx, xQz unchanged
 func cswap(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
 	cswap{{.FIELD}}(&xPx.A, &xQx.A, choice)
@@ -158,8 +160,10 @@ func cswap(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
 }
 
 // In case choice == 1, performs following moves in constant time:
+//
 //     xPx <- xQx
 //     xPz <- xQz
+//
 // Otherwise returns xPx, xPz, xQx, xQz unchanged
 func cmov(xPx, xPz, xQx, xQz *common.Fp2, choice uint8) {
 	cmov{{.FIELD}}(&xPx.A, &xQx.A, choice)

--- a/dh/sidh/sidh_test.go
+++ b/dh/sidh/sidh_test.go
@@ -15,6 +15,7 @@ import (
 /* -------------------------------------------------------------------------
    Test data
    -------------------------------------------------------------------------*/
+
 type sidhVec struct {
 	id   uint8
 	name string
@@ -361,6 +362,7 @@ func TestKeyAgreementP751_AliceEvenNumber(t *testing.T) {
 /* -------------------------------------------------------------------------
    Wrappers for 'testing' SIDH
    -------------------------------------------------------------------------*/
+
 func testSidhVec(t *testing.T, m *map[uint8]sidhVec, f func(t *testing.T, v sidhVec)) {
 	for i := range *m {
 		v := (*m)[i]
@@ -376,6 +378,7 @@ func TestPrivateKeyBelowMax(t *testing.T) { testSidhVec(t, &tdataSidh, testPriva
 /* -------------------------------------------------------------------------
    Benchmarking
    -------------------------------------------------------------------------*/
+
 func BenchmarkSidhKeyAgreementP751(b *testing.B) {
 	// KeyPairs
 	alicePublic := convToPub(tdataSidh[Fp751].PkA, KeyVariantSidhA, Fp751)

--- a/dh/sidh/sike_test.go
+++ b/dh/sidh/sike_test.go
@@ -423,6 +423,7 @@ func testKAT(t *testing.T, v sikeVec) {
 /* -------------------------------------------------------------------------
    Wrappers for 'testing' SIDH
    -------------------------------------------------------------------------*/
+
 func testSike(t *testing.T, m *map[uint8]sikeVec, f func(*testing.T, sikeVec)) {
 	for i := range *m {
 		v := (*m)[i]

--- a/dh/x25519/doc.go
+++ b/dh/x25519/doc.go
@@ -11,10 +11,9 @@ internally and returns false when the public key is invalid (i.e., it
 is a low-order point).
 
 References:
- - [1] RFC7748 by Langley, Hamburg, Turner (https://rfc-editor.org/rfc/rfc7748.txt)
- - [2] Curve25519 by Bernstein (https://cr.yp.to/ecdh.html)
- - [3] Bernstein (https://cr.yp.to/ecdh.html#validate)
- - [4] Cremers&Jackson (https://eprint.iacr.org/2019/526)
-
+  - [1] RFC7748 by Langley, Hamburg, Turner (https://rfc-editor.org/rfc/rfc7748.txt)
+  - [2] Curve25519 by Bernstein (https://cr.yp.to/ecdh.html)
+  - [3] Bernstein (https://cr.yp.to/ecdh.html#validate)
+  - [4] Cremers&Jackson (https://eprint.iacr.org/2019/526)
 */
 package x25519

--- a/dh/x25519/table.go
+++ b/dh/x25519/table.go
@@ -3,7 +3,9 @@ package x25519
 import "github.com/cloudflare/circl/math/fp25519"
 
 // tableGenerator contains the set of points:
-//    t[i] = (xi+1)/(xi-1),
+//
+//	t[i] = (xi+1)/(xi-1),
+//
 // where (xi,yi) = 2^iG and G is the generator point
 // Size = (256)*(256/8) = 8192 bytes.
 var tableGenerator = [256 * fp25519.Size]byte{

--- a/dh/x448/doc.go
+++ b/dh/x448/doc.go
@@ -11,10 +11,9 @@ internally and returns false when the public key is invalid (i.e., it
 is a low-order point).
 
 References:
- - [1] RFC7748 by Langley, Hamburg, Turner (https://rfc-editor.org/rfc/rfc7748.txt)
- - [2] Curve25519 by Bernstein (https://cr.yp.to/ecdh.html)
- - [3] Bernstein (https://cr.yp.to/ecdh.html#validate)
- - [4] Cremers&Jackson (https://eprint.iacr.org/2019/526)
-
+  - [1] RFC7748 by Langley, Hamburg, Turner (https://rfc-editor.org/rfc/rfc7748.txt)
+  - [2] Curve25519 by Bernstein (https://cr.yp.to/ecdh.html)
+  - [3] Bernstein (https://cr.yp.to/ecdh.html#validate)
+  - [4] Cremers&Jackson (https://eprint.iacr.org/2019/526)
 */
 package x448

--- a/dh/x448/table.go
+++ b/dh/x448/table.go
@@ -3,7 +3,9 @@ package x448
 import fp "github.com/cloudflare/circl/math/fp448"
 
 // tableGenerator contains the set of points:
-//    t[i] = (xi+1)/(xi-1),
+//
+//	t[i] = (xi+1)/(xi-1),
+//
 // where (xi,yi) = 2^iG and G is the generator point
 // Size = (448)*(448/8) = 25088 bytes.
 var tableGenerator = [448 * fp.Size]byte{

--- a/ecc/bls12381/constants.go
+++ b/ecc/bls12381/constants.go
@@ -12,7 +12,8 @@ type Scalar = ff.Scalar
 const ScalarSize = ff.ScalarSize
 
 // Order returns the order of the pairing groups, returned as a big-endian slice.
-//  Order = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
+//
+//	Order = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
 func Order() []byte { return ff.ScalarOrder() }
 
 var (

--- a/ecc/bls12381/doc.go
+++ b/ecc/bls12381/doc.go
@@ -5,9 +5,10 @@
 // Scalars can be used interchangeably between groups.
 //
 // These groups have the same order equal to:
-//  Order = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
 //
-// Serialization Format
+//	Order = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
+//
+// # Serialization Format
 //
 // Elements of G1 and G2 can be encoded in uncompressed form (the x-coordinate
 // followed by the y-coordinate) or in compressed form (just the x-coordinate).
@@ -31,24 +32,23 @@
 // is the lexicographically largest of the two associated with the encoded
 // x-coordinate.
 //
-//  |----------------------------------------------------|
-//  |                Serialization Format                |
-//  |-----|-------|-------|---------------|--------------|
-//  | MSB | MSB-1 | MSB-2 |  Description  | Encoding     |
-//  |-----|-------|-------|---------------|--------------|
-//  |  0  |   X   |   X   | Uncompressed  |  e || x || y |
-//  |  1  |   X   |   X   | Compressed    |  e || x      |
-//  |-----|-------|-------|---------------|--------------|
-//  |  X  |   0   |   X   | Non-Infinity  |  e || x || y |
-//  |  X  |   1   |   X   | Infinity      |  e || 0 || 0 |
-//  |-----|-------|-------|---------------|--------------|
-//  |     |       |       | Compressed,   |              |
-//  |  1  |   0   |   1   | Non-Infinity, |  e || x      |
-//  |     |       |       | Big y-coord   |              |
-//  |-----|-------|-------|---------------|--------------|
-//  |     |       |       | Compressed,   |              |
-//  |  1  |   0   |   0   | Non-Infinity, |  e || x      |
-//  |     |       |       | Small y-coord |              |
-//  |----------------------------------------------------|
-//
+//	|----------------------------------------------------|
+//	|                Serialization Format                |
+//	|-----|-------|-------|---------------|--------------|
+//	| MSB | MSB-1 | MSB-2 |  Description  | Encoding     |
+//	|-----|-------|-------|---------------|--------------|
+//	|  0  |   X   |   X   | Uncompressed  |  e || x || y |
+//	|  1  |   X   |   X   | Compressed    |  e || x      |
+//	|-----|-------|-------|---------------|--------------|
+//	|  X  |   0   |   X   | Non-Infinity  |  e || x || y |
+//	|  X  |   1   |   X   | Infinity      |  e || 0 || 0 |
+//	|-----|-------|-------|---------------|--------------|
+//	|     |       |       | Compressed,   |              |
+//	|  1  |   0   |   1   | Non-Infinity, |  e || x      |
+//	|     |       |       | Big y-coord   |              |
+//	|-----|-------|-------|---------------|--------------|
+//	|     |       |       | Compressed,   |              |
+//	|  1  |   0   |   0   | Non-Infinity, |  e || x      |
+//	|     |       |       | Small y-coord |              |
+//	|----------------------------------------------------|
 package bls12381

--- a/ecc/bls12381/ff/cyclo6.go
+++ b/ecc/bls12381/ff/cyclo6.go
@@ -1,7 +1,6 @@
 package ff
 
 // Cyclo6 represents an element of the 6th cyclotomic group.
-//
 type Cyclo6 Fp12
 
 func (z Cyclo6) String() string           { return (Fp12)(z).String() }

--- a/ecc/bls12381/ff/doc.go
+++ b/ecc/bls12381/ff/doc.go
@@ -1,47 +1,57 @@
 // Package ff provides finite fields and groups useful for the BLS12-381 curve.
 //
-// Fp
+// # Fp
 //
 // Fp are elements of the prime field GF(p), where
-//  p = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+//
+//	p = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+//
 // The binary representation takes FpSize = 48 bytes encoded in big-endian form.
 //
-// Fp2
+// # Fp2
 //
 // Fp2 are elements of the finite field GF(p^2) = Fp[u]/(u^2+1) represented as
-//  (a[1]u + a[0]) in Fp2, where a[0],a[1] in Fp
+//
+//	(a[1]u + a[0]) in Fp2, where a[0],a[1] in Fp
+//
 // The binary representation takes Fp2Size = 96 bytes encoded as a[1] || a[0]
 // all in big-endian form.
 //
-// Fp4
+// # Fp4
 //
 // Fp4 is GF(p^4)=Fp2[t]/(t^2-(u+1)). We use the repesentation  a[1]v+a[0].
 // There is no fixed external form.
 //
-// Fp6
+// # Fp6
 //
 // Fp6 are elements of the finite field GF(p^6) = Fp2[v]/(v^3-u-1) represented as
-//  (a[2]v^2 + a[1]v + a[0]) in Fp6, where a[0],a[1],a[2] in Fp2
+//
+//	(a[2]v^2 + a[1]v + a[0]) in Fp6, where a[0],a[1],a[2] in Fp2
+//
 // The binary representation takes Fp6Size = 288 bytes encoded as a[2] || a[1] || a[0]
 // all in big-endian form.
 //
-// Fp12
+// # Fp12
 //
 // Fp12 are elements of the finite field GF(p^12) = Fp6[w]/(w^2-v) represented as
-//  (a[1]w + a[0]) in Fp12, where a[0],a[1] in Fp6
+//
+//	(a[1]w + a[0]) in Fp12, where a[0],a[1] in Fp6
+//
 // The binary representation takes Fp12Size = 576 bytes encoded as a[1] || a[0]
 // all in big-endian form.
 //
 // We can also represent this field via Fp4[w]/(w^3-t). This is the struct Fp12alt,
 // used to accelerate the pairing calculation.
 //
-// Scalar
+// # Scalar
 //
 // Scalar are elements of the prime field GF(r), where
-//  r = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
+//
+//	r = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
+//
 // The binary representation takes ScalarSize = 32 bytes encoded in big-endian form.
 //
-// Groups
+// # Groups
 //
 // Cyclo6 are elements of the 6th cyclotomic group contained in Fp12.
 // For efficient arithmetic see Granger-Scott "Faster Squaring in the Cyclotomic Subgroup of Sixth

--- a/ecc/bls12381/ff/fp.go
+++ b/ecc/bls12381/ff/fp.go
@@ -64,7 +64,8 @@ func (z *Fp) CMov(x, y *Fp, b int) {
 }
 
 // FpOrder is the order of the base field for towering returned as a big-endian slice.
-//  FpOrder = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab.
+//
+//	FpOrder = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab.
 func FpOrder() []byte { o := fpOrder; return o[:] }
 
 // ExpVarTime calculates z=x^n, where n is the exponent in big-endian order.

--- a/ecc/bls12381/ff/fp12.go
+++ b/ecc/bls12381/ff/fp12.go
@@ -110,8 +110,9 @@ func (z Fp12) MarshalBinary() (b []byte, e error) {
 }
 
 // frob12W1 is Fp2 = [toMont(frob12W1_0), toMont(frob12W1_1) ], where
-//  frob12W1_0 = 0x1904d3bf02bb0667c231beb4202c0d1f0fd603fd3cbd5f4f7b2443d784bab9c4f67ea53d63e7813d8d0775ed92235fb8
-//  frob12W1_1 = 0xfc3e2b36c4e03288e9e902231f9fb854a14787b6c7b36fec0c8ec971f63c5f282d5ac14d6c7ec22cf78a126ddc4af3
+//
+//	frob12W1_0 = 0x1904d3bf02bb0667c231beb4202c0d1f0fd603fd3cbd5f4f7b2443d784bab9c4f67ea53d63e7813d8d0775ed92235fb8
+//	frob12W1_1 = 0xfc3e2b36c4e03288e9e902231f9fb854a14787b6c7b36fec0c8ec971f63c5f282d5ac14d6c7ec22cf78a126ddc4af3
 var frob12W1 = Fp2{
 	Fp{fpMont{ // (little-endian)
 		0x07089552b319d465, 0xc6695f92b50a8313, 0x97e83cccd117228f,

--- a/ecc/bls12381/ff/fpMont381.go
+++ b/ecc/bls12381/ff/fpMont381.go
@@ -43,17 +43,23 @@ import "math/bits"
 // The function fiatFpMontAdd adds two field elements in the Montgomery domain.
 //
 // Preconditions:
-//   0 ≤ eval arg1 < m
-//   0 ≤ eval arg2 < m
+//
+//	0 ≤ eval arg1 < m
+//	0 ≤ eval arg2 < m
+//
 // Postconditions:
-//   eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) + eval (from_montgomery arg2)) mod m
-//   0 ≤ eval out1 < m
+//
+//	eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) + eval (from_montgomery arg2)) mod m
+//	0 ≤ eval out1 < m
 //
 // Input Bounds:
-//   arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
-//   arg2: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
+//	arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//	arg2: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
 // Output Bounds:
-//   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
+//	out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 func fiatFpMontAdd(out1 *[6]uint64, arg1 *[6]uint64, arg2 *[6]uint64) {
 	var x1 uint64
 	var x2 uint64
@@ -116,17 +122,23 @@ func fiatFpMontAdd(out1 *[6]uint64, arg1 *[6]uint64, arg2 *[6]uint64) {
 // The function fiatFpMontSub subtracts two field elements in the Montgomery domain.
 //
 // Preconditions:
-//   0 ≤ eval arg1 < m
-//   0 ≤ eval arg2 < m
+//
+//	0 ≤ eval arg1 < m
+//	0 ≤ eval arg2 < m
+//
 // Postconditions:
-//   eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) - eval (from_montgomery arg2)) mod m
-//   0 ≤ eval out1 < m
+//
+//	eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) - eval (from_montgomery arg2)) mod m
+//	0 ≤ eval out1 < m
 //
 // Input Bounds:
-//   arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
-//   arg2: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
+//	arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//	arg2: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
 // Output Bounds:
-//   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
+//	out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 func fiatFpMontSub(out1 *[6]uint64, arg1 *[6]uint64, arg2 *[6]uint64) {
 	var x1 uint64
 	var x2 uint64
@@ -176,17 +188,23 @@ func fiatFpMontSub(out1 *[6]uint64, arg1 *[6]uint64, arg2 *[6]uint64) {
 // The function fiatFpMontMul multiplies two field elements in the Montgomery domain.
 //
 // Preconditions:
-//   0 ≤ eval arg1 < m
-//   0 ≤ eval arg2 < m
+//
+//	0 ≤ eval arg1 < m
+//	0 ≤ eval arg2 < m
+//
 // Postconditions:
-//   eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) * eval (from_montgomery arg2)) mod m
-//   0 ≤ eval out1 < m
+//
+//	eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) * eval (from_montgomery arg2)) mod m
+//	0 ≤ eval out1 < m
 //
 // Input Bounds:
-//   arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
-//   arg2: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
+//	arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//	arg2: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
 // Output Bounds:
-//   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
+//	out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 func fiatFpMontMul(out1 *[6]uint64, arg1 *[6]uint64, arg2 *[6]uint64) {
 	x1 := arg1[1]
 	x2 := arg1[2]
@@ -887,15 +905,21 @@ func fiatFpMontMul(out1 *[6]uint64, arg1 *[6]uint64, arg2 *[6]uint64) {
 // The function fiatFpMontSquare squares a field element in the Montgomery domain.
 //
 // Preconditions:
-//   0 ≤ eval arg1 < m
+//
+//	0 ≤ eval arg1 < m
+//
 // Postconditions:
-//   eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) * eval (from_montgomery arg1)) mod m
-//   0 ≤ eval out1 < m
+//
+//	eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) * eval (from_montgomery arg1)) mod m
+//	0 ≤ eval out1 < m
 //
 // Input Bounds:
-//   arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
+//	arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
 // Output Bounds:
-//   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
+//	out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 func fiatFpMontSquare(out1 *[6]uint64, arg1 *[6]uint64) {
 	x1 := arg1[1]
 	x2 := arg1[2]

--- a/ecc/bls12381/ff/scMont255.go
+++ b/ecc/bls12381/ff/scMont255.go
@@ -43,17 +43,23 @@ import "math/bits"
 // The function fiatScMontAdd adds two field elements in the Montgomery domain.
 //
 // Preconditions:
-//   0 ≤ eval arg1 < m
-//   0 ≤ eval arg2 < m
+//
+//	0 ≤ eval arg1 < m
+//	0 ≤ eval arg2 < m
+//
 // Postconditions:
-//   eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) + eval (from_montgomery arg2)) mod m
-//   0 ≤ eval out1 < m
+//
+//	eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) + eval (from_montgomery arg2)) mod m
+//	0 ≤ eval out1 < m
 //
 // Input Bounds:
-//   arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
-//   arg2: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
+//	arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//	arg2: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
 // Output Bounds:
-//   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
+//	out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 func fiatScMontAdd(out1 *[4]uint64, arg1 *[4]uint64, arg2 *[4]uint64) {
 	var x1 uint64
 	var x2 uint64
@@ -98,17 +104,23 @@ func fiatScMontAdd(out1 *[4]uint64, arg1 *[4]uint64, arg2 *[4]uint64) {
 // The function fiatScMontSub subtracts two field elements in the Montgomery domain.
 //
 // Preconditions:
-//   0 ≤ eval arg1 < m
-//   0 ≤ eval arg2 < m
+//
+//	0 ≤ eval arg1 < m
+//	0 ≤ eval arg2 < m
+//
 // Postconditions:
-//   eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) - eval (from_montgomery arg2)) mod m
-//   0 ≤ eval out1 < m
+//
+//	eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) - eval (from_montgomery arg2)) mod m
+//	0 ≤ eval out1 < m
 //
 // Input Bounds:
-//   arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
-//   arg2: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
+//	arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//	arg2: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
 // Output Bounds:
-//   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
+//	out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 func fiatScMontSub(out1 *[4]uint64, arg1 *[4]uint64, arg2 *[4]uint64) {
 	var x1 uint64
 	var x2 uint64
@@ -144,17 +156,23 @@ func fiatScMontSub(out1 *[4]uint64, arg1 *[4]uint64, arg2 *[4]uint64) {
 // The function fiatScMontMul multiplies two field elements in the Montgomery domain.
 //
 // Preconditions:
-//   0 ≤ eval arg1 < m
-//   0 ≤ eval arg2 < m
+//
+//	0 ≤ eval arg1 < m
+//	0 ≤ eval arg2 < m
+//
 // Postconditions:
-//   eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) * eval (from_montgomery arg2)) mod m
-//   0 ≤ eval out1 < m
+//
+//	eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) * eval (from_montgomery arg2)) mod m
+//	0 ≤ eval out1 < m
 //
 // Input Bounds:
-//   arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
-//   arg2: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
+//	arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//	arg2: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
 // Output Bounds:
-//   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
+//	out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 func fiatScMontMul(out1 *[4]uint64, arg1 *[4]uint64, arg2 *[4]uint64) {
 	x1 := arg1[1]
 	x2 := arg1[2]
@@ -479,15 +497,21 @@ func fiatScMontMul(out1 *[4]uint64, arg1 *[4]uint64, arg2 *[4]uint64) {
 // The function fiatScMontSquare squares a field element in the Montgomery domain.
 //
 // Preconditions:
-//   0 ≤ eval arg1 < m
+//
+//	0 ≤ eval arg1 < m
+//
 // Postconditions:
-//   eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) * eval (from_montgomery arg1)) mod m
-//   0 ≤ eval out1 < m
+//
+//	eval (from_montgomery out1) mod m = (eval (from_montgomery arg1) * eval (from_montgomery arg1)) mod m
+//	0 ≤ eval out1 < m
 //
 // Input Bounds:
-//   arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
+//	arg1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
 // Output Bounds:
-//   out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
+//
+//	out1: [[0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff], [0x0 ~> 0xffffffffffffffff]]
 func fiatScMontSquare(out1 *[4]uint64, arg1 *[4]uint64) {
 	x1 := arg1[1]
 	x2 := arg1[2]

--- a/ecc/bls12381/ff/scalar.go
+++ b/ecc/bls12381/ff/scalar.go
@@ -36,7 +36,8 @@ func (z Scalar) fromMont() (out scRaw)     { fiatScMontMul(&out, &z.i, &scMont{1
 
 // ScalarOrder is the order of the scalar field of the pairing groups, order is
 // returned as a big-endian slice.
-//  ScalarOrder = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
+//
+//	ScalarOrder = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
 func ScalarOrder() []byte { o := scOrder; return o[:] }
 
 // exp calculates z=x^n, where n is in big-endian order.

--- a/ecc/bls12381/g1.go
+++ b/ecc/bls12381/g1.go
@@ -168,7 +168,9 @@ func (g *G1) isRTorsion() bool {
 //
 // This method multiplies g times (1-z) rather than (z-1)^2/3, where z is the
 // BLS12 parameter. This is enough to remove points of order
-//  h \in {3, 11, 10177, 859267, 52437899},
+//
+//	h \in {3, 11, 10177, 859267, 52437899},
+//
 // and because there are no points of order h^2. See Section 5 of Wahby-Boneh
 // "Fast and simple constant-time hashing to the BLS12-381 elliptic curve" at
 // https://eprint.iacr.org/2019/403

--- a/ecc/bls12381/g2.go
+++ b/ecc/bls12381/g2.go
@@ -165,7 +165,8 @@ func (g *G2) psi() {
 //
 // The explicit formulas for BLS curves are in Section 4.1 of Budroni-Pintore
 // "Efficient hash maps to G2 on BLS curves" at https://eprint.iacr.org/2017/419
-//  h(a)P = [x^2-x-1]P + [x-1]ψ(P) + ψ^2(2P)
+//
+//	h(a)P = [x^2-x-1]P + [x-1]ψ(P) + ψ^2(2P)
 func (g *G2) clearCofactor() {
 	x := bls12381.minusZ[:]
 	xP, psiP := &G2{}, &G2{}

--- a/ecc/bls12381/pair.go
+++ b/ecc/bls12381/pair.go
@@ -38,7 +38,8 @@ func miller(f *ff.Fp12, P *G1, Q *G2) {
 
 // line contains the coefficients of a sparse element of Fp12.
 // Evaluating the line on P' = (xP',yP') results in
-//   f = evalLine(P') = l[0]*xP' + l[1]*yP' + l[2] \in Fp12.
+//
+//	f = evalLine(P') = l[0]*xP' + l[1]*yP' + l[2] \in Fp12.
 type line [3]ff.Fp2
 
 // evalLine updates f = f * line(P'), where f lives in Fp12 = Fp6[w]/(w^2-v)

--- a/ecc/fourq/doc.go
+++ b/ecc/fourq/doc.go
@@ -4,8 +4,6 @@
 // contains an AMD64-optimized implementation. In particular, this package does
 // not implement FourQ's endomorphisms or lattice reduction techniques.
 //
-//
 // References:
-//  - https://eprint.iacr.org/2015/565
-//
+//   - https://eprint.iacr.org/2015/565
 package fourq

--- a/ecc/fourq/point.go
+++ b/ecc/fourq/point.go
@@ -139,9 +139,10 @@ func div2subY(x *[5]uint64, y int64) {
 // mLSBRecoding is the odd-only modified LSB-set.
 //
 // Reference:
-//  "Efficient and secure algorithms for GLV-based scalar multiplication and
-//   their implementation on GLV–GLS curves" by (Faz-Hernandez et al.)
-//   http://doi.org/10.1007/s13389-014-0085-7.
+//
+//	"Efficient and secure algorithms for GLV-based scalar multiplication and
+//	 their implementation on GLV–GLS curves" by (Faz-Hernandez et al.)
+//	 http://doi.org/10.1007/s13389-014-0085-7.
 func mLSBRecoding(L []int8, k []byte) {
 	const e = (fxT + fxW*fxV - 1) / (fxW * fxV)
 	const d = e * fxV

--- a/ecc/goldilocks/scalar.go
+++ b/ecc/goldilocks/scalar.go
@@ -8,7 +8,7 @@ import (
 // ScalarSize is the size (in bytes) of scalars.
 const ScalarSize = 56 // 448 / 8
 
-//_N is the number of 64-bit words to store scalars.
+// _N is the number of 64-bit words to store scalars.
 const _N = 7 // 448 / 64
 
 // Scalar represents a positive integer stored in little-endian order.

--- a/ecc/p384/doc.go
+++ b/ecc/p384/doc.go
@@ -1,11 +1,10 @@
 // Package p384 provides optimized elliptic curve operations on the P-384 curve.
 //
 // These are some improvements over crypto/elliptic package:
-//  - Around 10x faster in amd64 architecture.
-//  - Reduced number of memory allocations.
-//  - Native support for arm64 architecture.
-//  - ScalarMult is performed using a constant-time algorithm.
-//  - ScalarBaseMult fallbacks into ScalarMult.
-//  - A new method included for double-point multiplication.
-//
+//   - Around 10x faster in amd64 architecture.
+//   - Reduced number of memory allocations.
+//   - Native support for arm64 architecture.
+//   - ScalarMult is performed using a constant-time algorithm.
+//   - ScalarBaseMult fallbacks into ScalarMult.
+//   - A new method included for double-point multiplication.
 package p384

--- a/hpke/marshal.go
+++ b/hpke/marshal.go
@@ -87,20 +87,20 @@ func unmarshalContext(raw []byte) (*encdecContext, error) {
 //
 // enum { sealer(0), opener(1) } HpkeRole;
 //
-// struct {
-//     HpkeKemId kem_id;   // draft-irtf-cfrg-hpke-07
-//     HpkeKdfId kdf_id;   // draft-irtf-cfrg-hpke-07
-//     HpkeAeadId aead_id; // draft-irtf-cfrg-hpke-07
-//     opaque exporter_secret<0..255>;
-//     opaque key<0..255>;
-//     opaque base_nonce<0..255>;
-//     opaque seq<0..255>;
-// } HpkeContext;
+//	struct {
+//	    HpkeKemId kem_id;   // draft-irtf-cfrg-hpke-07
+//	    HpkeKdfId kdf_id;   // draft-irtf-cfrg-hpke-07
+//	    HpkeAeadId aead_id; // draft-irtf-cfrg-hpke-07
+//	    opaque exporter_secret<0..255>;
+//	    opaque key<0..255>;
+//	    opaque base_nonce<0..255>;
+//	    opaque seq<0..255>;
+//	} HpkeContext;
 //
-// struct {
-//   HpkeRole role = 0; // sealer
-//   HpkeContext context;
-// } HpkeSealer;
+//	struct {
+//	  HpkeRole role = 0; // sealer
+//	  HpkeContext context;
+//	} HpkeSealer;
 func (c *sealContext) MarshalBinary() ([]byte, error) {
 	rawContext, err := c.encdecContext.marshal()
 	if err != nil {
@@ -125,10 +125,10 @@ func UnmarshalSealer(raw []byte) (Sealer, error) {
 // below. (Expressed in TLS syntax.) Note that this format is not defined by the
 // HPKE standard.
 //
-// struct {
-//   HpkeRole role = 1; // opener
-//   HpkeContext context;
-// } HpkeOpener;
+//	struct {
+//	  HpkeRole role = 1; // opener
+//	  HpkeContext context;
+//	} HpkeOpener;
 func (c *openContext) MarshalBinary() ([]byte, error) {
 	rawContext, err := c.encdecContext.marshal()
 	if err != nil {

--- a/internal/sha3/doc.go
+++ b/internal/sha3/doc.go
@@ -8,8 +8,7 @@
 // Both types of hash function use the "sponge" construction and the Keccak
 // permutation. For a detailed specification see http://keccak.noekeon.org/
 //
-//
-// Guidance
+// # Guidance
 //
 // If you aren't sure what function you need, use SHAKE256 with at least 64
 // bytes of output. The SHAKE instances are faster than the SHA3 instances;
@@ -19,8 +18,7 @@
 // secret key to the input, hash with SHAKE256 and read at least 32 bytes of
 // output.
 //
-//
-// Security strengths
+// # Security strengths
 //
 // The SHA3-x (x equals 224, 256, 384, or 512) functions have a security
 // strength against preimage attacks of x bits. Since they only produce "x"
@@ -31,8 +29,7 @@
 // is used.  Requesting more than 64 or 32 bytes of output, respectively, does
 // not increase the collision-resistance of the SHAKE functions.
 //
-//
-// The sponge construction
+// # The sponge construction
 //
 // A sponge builds a pseudo-random function from a public pseudo-random
 // permutation, by applying the permutation to a state of "rate + capacity"
@@ -50,8 +47,7 @@
 // Since the KeccakF-1600 permutation is 1600 bits (200 bytes) wide, this means
 // that the security strength of a sponge instance is equal to (1600 - bitrate) / 2.
 //
-//
-// Recommendations
+// # Recommendations
 //
 // The SHAKE functions are recommended for most new uses. They can produce
 // output of arbitrary length. SHAKE256, with an output length of at least

--- a/kem/frodo/doc.go
+++ b/kem/frodo/doc.go
@@ -5,6 +5,7 @@
 // implementation [2].
 //
 // References:
-//  [1] https://frodokem.org/files/FrodoKEM-specification-20210604.pdf
-//  [2] https://github.com/PQClean/PQClean/tree/master/crypto_kem/frodokem640shake/clean
+//
+//	[1] https://frodokem.org/files/FrodoKEM-specification-20210604.pdf
+//	[2] https://github.com/PQClean/PQClean/tree/master/crypto_kem/frodokem640shake/clean
 package frodo

--- a/kem/hybrid/hybrid.go
+++ b/kem/hybrid/hybrid.go
@@ -3,8 +3,8 @@
 // KEMs are combined by simple concatenation of shared secrets, cipher texts,
 // public keys, etc, see
 //
-//   https://datatracker.ietf.org/doc/draft-ietf-tls-hybrid-design/
-//   https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Cr2.pdf
+//	https://datatracker.ietf.org/doc/draft-ietf-tls-hybrid-design/
+//	https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Cr2.pdf
 //
 // Note that this is only fine if the shared secret is used in its entirety
 // in a next step, such as being hashed or used as key.

--- a/kem/kem.go
+++ b/kem/kem.go
@@ -2,7 +2,7 @@
 //
 // A register of schemes is available in the package
 //
-//  github.com/cloudflare/circl/kem/schemes
+//	github.com/cloudflare/circl/kem/schemes
 package kem
 
 import (

--- a/kem/kyber/doc.go
+++ b/kem/kyber/doc.go
@@ -4,7 +4,7 @@
 // key encapsulation mechanism (KEM) as submitted to round 3 of the NIST PQC
 // competition and described in
 //
-//  https://pq-crystals.org/kyber/data/kyber-specification-round3.pdf
+//	https://pq-crystals.org/kyber/data/kyber-specification-round3.pdf
 //
 // The related public key encryption scheme CRYSTALS-Kyber.CPAPKE can be
 // found in the package github.com/cloudflare/circl/pke/kyber.

--- a/kem/schemes/schemes.go
+++ b/kem/schemes/schemes.go
@@ -1,14 +1,19 @@
 // Package schemes contains a register of KEM schemes.
 //
-// Schemes Implemented
+// # Schemes Implemented
 //
 // Based on standard elliptic curves:
-//  HPKE_KEM_P256_HKDF_SHA256, HPKE_KEM_P384_HKDF_SHA384, HPKE_KEM_P521_HKDF_SHA512
+//
+//	HPKE_KEM_P256_HKDF_SHA256, HPKE_KEM_P384_HKDF_SHA384, HPKE_KEM_P521_HKDF_SHA512
+//
 // Based on standard Diffie-Hellman functions:
-//  HPKE_KEM_X25519_HKDF_SHA256, HPKE_KEM_X448_HKDF_SHA512
+//
+//	HPKE_KEM_X25519_HKDF_SHA256, HPKE_KEM_X448_HKDF_SHA512
+//
 // Post-quantum kems:
-//  FrodoKEM-640-SHAKE
-//  Kyber512, Kyber768, Kyber1024
+//
+//	FrodoKEM-640-SHAKE
+//	Kyber512, Kyber768, Kyber1024
 package schemes
 
 import (

--- a/kem/sike/doc.go
+++ b/kem/sike/doc.go
@@ -2,10 +2,9 @@
 
 // Package sike is deprecated, it contains the SIKE key encapsulation mechanism.
 //
-// DEPRECATION NOTICE
+// # DEPRECATION NOTICE
 //
 // SIDH and SIKE are deprecated as were shown vulnerable to a key recovery
 // attack by Castryck-Decru's paper (https://eprint.iacr.org/2022/975). New
 // systems should not rely on this package. This package is frozen.
-//
 package sike

--- a/kem/sike/sikep434/sike.go
+++ b/kem/sike/sikep434/sike.go
@@ -2,12 +2,11 @@
 
 // Package sikep434 is deprecated, it implements the key encapsulation mechanism SIKEp434.
 //
-// DEPRECATION NOTICE
+// # DEPRECATION NOTICE
 //
 // SIDH and SIKE are deprecated as were shown vulnerable to a key recovery
 // attack by Castryck-Decru's paper (https://eprint.iacr.org/2022/975). New
 // systems should not rely on this package. This package is frozen.
-//
 package sikep434
 
 import (

--- a/kem/sike/sikep503/sike.go
+++ b/kem/sike/sikep503/sike.go
@@ -2,12 +2,11 @@
 
 // Package sikep503 is deprecated, it implements the key encapsulation mechanism SIKEp503.
 //
-// DEPRECATION NOTICE
+// # DEPRECATION NOTICE
 //
 // SIDH and SIKE are deprecated as were shown vulnerable to a key recovery
 // attack by Castryck-Decru's paper (https://eprint.iacr.org/2022/975). New
 // systems should not rely on this package. This package is frozen.
-//
 package sikep503
 
 import (

--- a/kem/sike/sikep751/sike.go
+++ b/kem/sike/sikep751/sike.go
@@ -2,12 +2,11 @@
 
 // Package sikep751 is deprecated, it implements the key encapsulation mechanism SIKEp751.
 //
-// DEPRECATION NOTICE
+// # DEPRECATION NOTICE
 //
 // SIDH and SIKE are deprecated as were shown vulnerable to a key recovery
 // attack by Castryck-Decru's paper (https://eprint.iacr.org/2022/975). New
 // systems should not rely on this package. This package is frozen.
-//
 package sikep751
 
 import (

--- a/kem/sike/templates/pkg.templ.go
+++ b/kem/sike/templates/pkg.templ.go
@@ -6,12 +6,11 @@
 
 // Package {{.Pkg}} is deprecated, it implements the key encapsulation mechanism {{.Name}}.
 //
-// DEPRECATION NOTICE
+// # DEPRECATION NOTICE
 //
 // SIDH and SIKE are deprecated as were shown vulnerable to a key recovery
 // attack by Castryck-Decru's paper (https://eprint.iacr.org/2022/975). New
 // systems should not rely on this package. This package is frozen.
-//
 package {{.Pkg}}
 
 import (

--- a/math/fp448/fuzzer.go
+++ b/math/fp448/fuzzer.go
@@ -2,11 +2,12 @@
 // +build gofuzz
 
 // How to run the fuzzer:
-//  $ go get -u github.com/dvyukov/go-fuzz/go-fuzz
-//  $ go get -u github.com/dvyukov/go-fuzz/go-fuzz-build
-//  $ go-fuzz-build -libfuzzer -func FuzzReduction -o lib.a
-//  $ clang -fsanitize=fuzzer lib.a -o fu.exe
-//  $ ./fu.exe
+//
+//	$ go get -u github.com/dvyukov/go-fuzz/go-fuzz
+//	$ go get -u github.com/dvyukov/go-fuzz/go-fuzz-build
+//	$ go-fuzz-build -libfuzzer -func FuzzReduction -o lib.a
+//	$ clang -fsanitize=fuzzer lib.a -o fu.exe
+//	$ ./fu.exe
 package fp448
 
 import (

--- a/math/mlsbset/mlsbset.go
+++ b/math/mlsbset/mlsbset.go
@@ -2,8 +2,8 @@
 //
 // References: "Efficient and secure algorithms for GLV-based scalar
 // multiplication and their implementation on GLV–GLS curves" by (Faz-Hernandez et al.)
-//  - https://doi.org/10.1007/s13389-014-0085-7
-//  - https://eprint.iacr.org/2013/158
+//   - https://doi.org/10.1007/s13389-014-0085-7
+//   - https://eprint.iacr.org/2013/158
 package mlsbset
 
 import (

--- a/math/wnaf.go
+++ b/math/wnaf.go
@@ -9,15 +9,15 @@ import "math/big"
 // output has ceil(l/(w-1)) digits.
 //
 // Restrictions:
-//  - n is odd and n > 0.
-//  - 1 < w < 32.
-//  - l >= bit length of n.
+//   - n is odd and n > 0.
+//   - 1 < w < 32.
+//   - l >= bit length of n.
 //
 // References:
-//  - Alg.6 in "Exponent Recoding and Regular Exponentiation Algorithms"
-//    by Joye-Tunstall. http://doi.org/10.1007/978-3-642-02384-2_21
-//  - Alg.6 in "Selecting Elliptic Curves for Cryptography: An Efficiency and
-//    Security Analysis" by Bos et al. http://doi.org/10.1007/s13389-015-0097-y
+//   - Alg.6 in "Exponent Recoding and Regular Exponentiation Algorithms"
+//     by Joye-Tunstall. http://doi.org/10.1007/978-3-642-02384-2_21
+//   - Alg.6 in "Selecting Elliptic Curves for Cryptography: An Efficiency and
+//     Security Analysis" by Bos et al. http://doi.org/10.1007/s13389-015-0097-y
 func SignedDigit(n *big.Int, w, l uint) []int32 {
 	if n.Sign() <= 0 || n.Bit(0) == 0 {
 		panic("n must be non-zero, odd, and positive")
@@ -51,8 +51,8 @@ func SignedDigit(n *big.Int, w, l uint) []int32 {
 // 1 < w < 32. The returned slice L holds n = sum( L[i]*2^i ).
 //
 // Reference:
-//  - Alg.9 "Efficient arithmetic on Koblitz curves" by Solinas.
-//    http://doi.org/10.1023/A:1008306223194
+//   - Alg.9 "Efficient arithmetic on Koblitz curves" by Solinas.
+//     http://doi.org/10.1023/A:1008306223194
 func OmegaNAF(n *big.Int, w uint) (L []int32) {
 	if n.Sign() < 0 {
 		panic("n must be positive")

--- a/oprf/oprf.go
+++ b/oprf/oprf.go
@@ -6,26 +6,25 @@
 //
 // This package is compatible with the OPRF specification at draft-irtf-cfrg-voprf [1].
 //
-//
-// Protocol Overview
+// # Protocol Overview
 //
 // This diagram shows the steps of the protocol that are common for all operation modes.
 //
-//   Client(info*)                               Server(sk, pk, info*)
-//   =================================================================
-//   finData, evalReq = Blind(input)
+//	Client(info*)                               Server(sk, pk, info*)
+//	=================================================================
+//	finData, evalReq = Blind(input)
 //
-//                               evalReq
-//                             ---------->
+//	                            evalReq
+//	                          ---------->
 //
-//                               evaluation = Evaluate(evalReq, info*)
+//	                            evaluation = Evaluate(evalReq, info*)
 //
-//                              evaluation
-//                             <----------
+//	                           evaluation
+//	                          <----------
 //
-//   output = Finalize(finData, evaluation, info*)
+//	output = Finalize(finData, evaluation, info*)
 //
-// Operation Modes
+// # Operation Modes
 //
 // Each operation mode provides different properties to the PRF.
 //
@@ -42,10 +41,9 @@
 // All three modes can perform batches of PRF evaluations, so passing an array
 // of inputs will produce an array of outputs.
 //
-// References
+// # References
 //
 // [1] draft-irtf-cfrg-voprf: https://datatracker.ietf.org/doc/draft-irtf-cfrg-voprf
-//
 package oprf
 
 import (

--- a/pke/kyber/internal/common/ntt.go
+++ b/pke/kyber/internal/common/ntt.go
@@ -3,16 +3,16 @@ package common
 // Zetas lists precomputed powers of the primitive root of unity in
 // Montgomery representation used for the NTT:
 //
-//  Zetas[i] = ζᵇʳᵛ⁽ⁱ⁾ R mod q
+//	Zetas[i] = ζᵇʳᵛ⁽ⁱ⁾ R mod q
 //
 // where ζ = 17, brv(i) is the bitreversal of a 7-bit number and R=2¹⁶ mod q.
 //
 // The following Python code generates the Zetas arrays:
 //
-//    q = 13*2**8 + 1; zeta = 17
-//    R = 2**16 % q # Montgomery const.
-//    def brv(x): return int(''.join(reversed(bin(x)[2:].zfill(7))),2)
-//    print([(pow(zeta, brv(i), q)*R)%q for i in range(128)])
+//	q = 13*2**8 + 1; zeta = 17
+//	R = 2**16 % q # Montgomery const.
+//	def brv(x): return int(''.join(reversed(bin(x)[2:].zfill(7))),2)
+//	print([(pow(zeta, brv(i), q)*R)%q for i in range(128)])
 var Zetas = [128]int16{
 	2285, 2571, 2970, 1812, 1493, 1422, 287, 202, 3158, 622, 1577, 182,
 	962, 2127, 1855, 1468, 573, 2004, 264, 383, 2500, 1458, 1727, 3199,

--- a/pke/kyber/kyber.go
+++ b/pke/kyber/kyber.go
@@ -3,7 +3,7 @@
 // Package kyber implements the CRYSTALS-Kyber.CPAPKE public key encrpyption
 // as submitted to round 3 of the NIST PQC competition and described in
 //
-// 	https://pq-crystals.org/kyber/data/kyber-specification-round3.pdf
+//	https://pq-crystals.org/kyber/data/kyber-specification-round3.pdf
 //
 // The related key encapsulation mechanism (KEM) CRYSTALS-Kyber.CCAKEM can
 // be found in the package github.com/cloudflare/circl/kem/kyber.

--- a/sign/dilithium/dilithium.go
+++ b/sign/dilithium/dilithium.go
@@ -9,7 +9,7 @@
 // subpackage.  For instance, Dilithium2 (the recommended mode)
 // can be found in
 //
-//  github.com/cloudflare/circl/sign/dilithium/mode2
+//	github.com/cloudflare/circl/sign/dilithium/mode2
 //
 // If your choice for mode is fixed compile-time, use the subpackages.
 // This package provides a convenient wrapper around all of the subpackages
@@ -18,8 +18,8 @@
 // The authors of Dilithium recommend to combine it with a "pre-quantum"
 // signature scheme.  The packages
 //
-//  github.com/cloudflare/circl/sign/eddilithium2
-//  github.com/cloudflare/circl/sign/eddilithium3
+//	github.com/cloudflare/circl/sign/eddilithium2
+//	github.com/cloudflare/circl/sign/eddilithium3
 //
 // implement such hybrids of Dilithium2 with Ed25519 respectively and
 // Dilithium3 with Ed448.  These packages are a drop in replacements for the

--- a/sign/dilithium/internal/common/ntt.go
+++ b/sign/dilithium/internal/common/ntt.go
@@ -3,19 +3,19 @@ package common
 // Zetas lists precomputed powers of the root of unity in Montgomery
 // representation used for the NTT:
 //
-//     Zetas[i] = zetaᵇʳᵛ⁽ⁱ⁾ R mod q,
+//	Zetas[i] = zetaᵇʳᵛ⁽ⁱ⁾ R mod q,
 //
 // where zeta = 1753, brv(i) is the bitreversal of a 8-bit number
 // and R=2³² mod q.
 //
 // The following Python code generates the Zetas (and InvZetas) lists:
 //
-//    q = 2**23 - 2**13 + 1; zeta = 1753
-//    R = 2**32 % q # Montgomery const.
-//    def brv(x): return int(''.join(reversed(bin(x)[2:].zfill(8))),2)
-//    def inv(x): return pow(x, q-2, q) # inverse in F(q)
-//    print([(pow(zeta, brv(i), q)*R)%q for i in range(256)])
-//    print([(pow(inv(zeta), -(brv(255-i)-256), q)*R)%q for i in range(256)])
+//	q = 2**23 - 2**13 + 1; zeta = 1753
+//	R = 2**32 % q # Montgomery const.
+//	def brv(x): return int(''.join(reversed(bin(x)[2:].zfill(8))),2)
+//	def inv(x): return pow(x, q-2, q) # inverse in F(q)
+//	print([(pow(zeta, brv(i), q)*R)%q for i in range(256)])
+//	print([(pow(inv(zeta), -(brv(255-i)-256), q)*R)%q for i in range(256)])
 var Zetas = [N]uint32{
 	4193792, 25847, 5771523, 7861508, 237124, 7602457, 7504169,
 	466468, 1826347, 2353451, 8021166, 6288512, 3119733, 5495562,
@@ -59,7 +59,7 @@ var Zetas = [N]uint32{
 // InvZetas lists precomputed powers of the inverse root of unity in Montgomery
 // representation used for the inverse NTT:
 //
-//     InvZetas[i] = zetaᵇʳᵛ⁽²⁵⁵⁻ⁱ⁾⁻²⁵⁶ R mod q,
+//	InvZetas[i] = zetaᵇʳᵛ⁽²⁵⁵⁻ⁱ⁾⁻²⁵⁶ R mod q,
 //
 // where zeta = 1753, brv(i) is the bitreversal of a 8-bit number
 // and R=2³² mod q.

--- a/sign/dilithium/mode2/internal/rounding.go
+++ b/sign/dilithium/mode2/internal/rounding.go
@@ -50,7 +50,7 @@ func decompose(a uint32) (a0plusQ, a1 uint32) {
 // we can reconstruct r1 using only r' = r - f, which is done by useHint().
 // To wit:
 //
-//     useHint( r - f, makeHint( r0 - f, r1 ) ) = r1.
+//	useHint( r - f, makeHint( r0 - f, r1 ) ) = r1.
 //
 // Assumes 0 ≤ z0 < Q.
 func makeHint(z0, r1 uint32) uint32 {

--- a/sign/dilithium/mode2aes/internal/rounding.go
+++ b/sign/dilithium/mode2aes/internal/rounding.go
@@ -50,7 +50,7 @@ func decompose(a uint32) (a0plusQ, a1 uint32) {
 // we can reconstruct r1 using only r' = r - f, which is done by useHint().
 // To wit:
 //
-//     useHint( r - f, makeHint( r0 - f, r1 ) ) = r1.
+//	useHint( r - f, makeHint( r0 - f, r1 ) ) = r1.
 //
 // Assumes 0 ≤ z0 < Q.
 func makeHint(z0, r1 uint32) uint32 {

--- a/sign/dilithium/mode3/internal/rounding.go
+++ b/sign/dilithium/mode3/internal/rounding.go
@@ -48,7 +48,7 @@ func decompose(a uint32) (a0plusQ, a1 uint32) {
 // we can reconstruct r1 using only r' = r - f, which is done by useHint().
 // To wit:
 //
-//     useHint( r - f, makeHint( r0 - f, r1 ) ) = r1.
+//	useHint( r - f, makeHint( r0 - f, r1 ) ) = r1.
 //
 // Assumes 0 ≤ z0 < Q.
 func makeHint(z0, r1 uint32) uint32 {

--- a/sign/dilithium/mode3aes/internal/rounding.go
+++ b/sign/dilithium/mode3aes/internal/rounding.go
@@ -50,7 +50,7 @@ func decompose(a uint32) (a0plusQ, a1 uint32) {
 // we can reconstruct r1 using only r' = r - f, which is done by useHint().
 // To wit:
 //
-//     useHint( r - f, makeHint( r0 - f, r1 ) ) = r1.
+//	useHint( r - f, makeHint( r0 - f, r1 ) ) = r1.
 //
 // Assumes 0 ≤ z0 < Q.
 func makeHint(z0, r1 uint32) uint32 {

--- a/sign/dilithium/mode5/internal/rounding.go
+++ b/sign/dilithium/mode5/internal/rounding.go
@@ -50,7 +50,7 @@ func decompose(a uint32) (a0plusQ, a1 uint32) {
 // we can reconstruct r1 using only r' = r - f, which is done by useHint().
 // To wit:
 //
-//     useHint( r - f, makeHint( r0 - f, r1 ) ) = r1.
+//	useHint( r - f, makeHint( r0 - f, r1 ) ) = r1.
 //
 // Assumes 0 ≤ z0 < Q.
 func makeHint(z0, r1 uint32) uint32 {

--- a/sign/dilithium/mode5aes/internal/rounding.go
+++ b/sign/dilithium/mode5aes/internal/rounding.go
@@ -50,7 +50,7 @@ func decompose(a uint32) (a0plusQ, a1 uint32) {
 // we can reconstruct r1 using only r' = r - f, which is done by useHint().
 // To wit:
 //
-//     useHint( r - f, makeHint( r0 - f, r1 ) ) = r1.
+//	useHint( r - f, makeHint( r0 - f, r1 ) ) = r1.
 //
 // Assumes 0 ≤ z0 < Q.
 func makeHint(z0, r1 uint32) uint32 {

--- a/sign/ed25519/ed25519.go
+++ b/sign/ed25519/ed25519.go
@@ -3,12 +3,12 @@
 // This package provides optimized implementations of the three signature
 // variants and maintaining closer compatiblilty with crypto/ed25519.
 //
-//  | Scheme Name | Sign Function     | Verification  | Context           |
-//  |-------------|-------------------|---------------|-------------------|
-//  | Ed25519     | Sign              | Verify        | None              |
-//  | Ed25519Ph   | SignPh            | VerifyPh      | Yes, can be empty |
-//  | Ed25519Ctx  | SignWithCtx       | VerifyWithCtx | Yes, non-empty    |
-//  | All above   | (PrivateKey).Sign | VerifyAny     | As above          |
+//	| Scheme Name | Sign Function     | Verification  | Context           |
+//	|-------------|-------------------|---------------|-------------------|
+//	| Ed25519     | Sign              | Verify        | None              |
+//	| Ed25519Ph   | SignPh            | VerifyPh      | Yes, can be empty |
+//	| Ed25519Ctx  | SignWithCtx       | VerifyWithCtx | Yes, non-empty    |
+//	| All above   | (PrivateKey).Sign | VerifyAny     | As above          |
 //
 // Specific functions for sign and verify are defined. A generic signing
 // function for all schemes is available through the crypto.Signer interface,
@@ -20,7 +20,7 @@
 // in this package. While Ed25519Ph accepts an empty context, Ed25519Ctx
 // enforces non-empty context strings.
 //
-// Compatibility with crypto.ed25519
+// # Compatibility with crypto.ed25519
 //
 // These functions are compatible with the “Ed25519” function defined in
 // RFC-8032. However, unlike RFC 8032's formulation, this package's private
@@ -30,9 +30,9 @@
 //
 // References
 //
-//  - RFC-8032: https://rfc-editor.org/rfc/rfc8032.txt
-//  - Ed25519: https://ed25519.cr.yp.to/
-//  - EdDSA: High-speed high-security signatures. https://doi.org/10.1007/s13389-012-0027-1
+//   - RFC-8032: https://rfc-editor.org/rfc/rfc8032.txt
+//   - Ed25519: https://ed25519.cr.yp.to/
+//   - EdDSA: High-speed high-security signatures. https://doi.org/10.1007/s13389-012-0027-1
 package ed25519
 
 import (

--- a/sign/ed25519/mult.go
+++ b/sign/ed25519/mult.go
@@ -29,9 +29,10 @@ const (
 // mLSBRecoding is the odd-only modified LSB-set.
 //
 // Reference:
-//  "Efficient and secure algorithms for GLV-based scalar multiplication and
-//   their implementation on GLV–GLS curves" by (Faz-Hernandez et al.)
-//   http://doi.org/10.1007/s13389-014-0085-7.
+//
+//	"Efficient and secure algorithms for GLV-based scalar multiplication and
+//	 their implementation on GLV–GLS curves" by (Faz-Hernandez et al.)
+//	 http://doi.org/10.1007/s13389-014-0085-7.
 func mLSBRecoding(L []int8, k []byte) {
 	const ee = (fxT + fxW*fxV - 1) / (fxW * fxV)
 	const dd = ee * fxV

--- a/sign/ed448/ed448.go
+++ b/sign/ed448/ed448.go
@@ -2,11 +2,11 @@
 //
 // This package implements two signature variants.
 //
-//  | Scheme Name | Sign Function     | Verification  | Context           |
-//  |-------------|-------------------|---------------|-------------------|
-//  | Ed448       | Sign              | Verify        | Yes, can be empty |
-//  | Ed448Ph     | SignPh            | VerifyPh      | Yes, can be empty |
-//  | All above   | (PrivateKey).Sign | VerifyAny     | As above          |
+//	| Scheme Name | Sign Function     | Verification  | Context           |
+//	|-------------|-------------------|---------------|-------------------|
+//	| Ed448       | Sign              | Verify        | Yes, can be empty |
+//	| Ed448Ph     | SignPh            | VerifyPh      | Yes, can be empty |
+//	| All above   | (PrivateKey).Sign | VerifyAny     | As above          |
 //
 // Specific functions for sign and verify are defined. A generic signing
 // function for all schemes is available through the crypto.Signer interface,
@@ -18,9 +18,9 @@
 //
 // References:
 //
-//  - RFC8032 https://rfc-editor.org/rfc/rfc8032.txt
-//  - EdDSA for more curves https://eprint.iacr.org/2015/677
-//  - High-speed high-security signatures. https://doi.org/10.1007/s13389-012-0027-1
+//   - RFC8032: https://rfc-editor.org/rfc/rfc8032.txt
+//   - EdDSA for more curves: https://eprint.iacr.org/2015/677
+//   - High-speed high-security signatures: https://doi.org/10.1007/s13389-012-0027-1
 package ed448
 
 import (

--- a/sign/schemes/schemes.go
+++ b/sign/schemes/schemes.go
@@ -1,10 +1,11 @@
 // Package schemes contains a register of signature algorithms.
 //
 // Implemented schemes:
-//  Ed25519
-//  Ed448
-//  Ed25519-Dilithium2
-//  Ed448-Dilithium3
+//
+//	Ed25519
+//	Ed448
+//	Ed25519-Dilithium2
+//	Ed448-Dilithium3
 package schemes
 
 import (

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -2,7 +2,7 @@
 //
 // A register of schemes is available in the package
 //
-//  github.com/cloudflare/circl/sign/schemes
+//	github.com/cloudflare/circl/sign/schemes
 package sign
 
 import (

--- a/simd/keccakf1600/f1600x.go
+++ b/simd/keccakf1600/f1600x.go
@@ -4,7 +4,7 @@
 // Keccak, SHA3 and SHAKE. Running two or four permutations in parallel is
 // useful in some scenarios like in hash-based signatures.
 //
-// Limitations
+// # Limitations
 //
 // Note that not all the architectures support SIMD instructions. This package
 // uses AVX2 instructions that are available in some AMD64 architectures

--- a/xof/xof.go
+++ b/xof/xof.go
@@ -1,6 +1,6 @@
 // Package xof provides an interface for eXtendable-Output Functions.
 //
-// Available Functions
+// # Available Functions
 //
 // SHAKE functions are defined in FIPS-202, see https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf.
 // BLAKE2Xb and BLAKE2Xs are defined in https://www.blake2.net/blake2x.pdf.


### PR DESCRIPTION
This PR formats files using `go fmt` tool with go1.19 (see https://tip.golang.org/doc/comment)

No changes in code, just formatting comments.