### PR TITLE
Add deterministic blind RSA verifier

### DIFF
--- a/blindsign/blindrsa/blindrsa.go
+++ b/blindsign/blindrsa/blindrsa.go
@@ -18,9 +18,7 @@ import (
 	"github.com/cloudflare/circl/blindsign"
 )
 
-var (
-	errUnsupportedHashFunction = errors.New("unsupported hash function")
-)
+var errUnsupportedHashFunction = errors.New("unsupported hash function")
 
 // An RSAVerifier represents a Verifier in the RSA blind signature protocol.
 // It carries state needed to produce and validate an RSA blind signature.

--- a/blindsign/blindrsa/blindrsa.go
+++ b/blindsign/blindrsa/blindrsa.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	errUnsupportedHashFunction = errors.New("Unsupported hash function")
+	errUnsupportedHashFunction = errors.New("unsupported hash function")
 )
 
 // An RSAVerifier represents a Verifier in the RSA blind signature protocol.

--- a/blindsign/blindsign.go
+++ b/blindsign/blindsign.go
@@ -7,11 +7,17 @@
 // input during the BlindSign step.
 package blindsign
 
+import "io"
+
 // A Verifier represents a specific instance of a blind signature verifier.
 type Verifier interface {
 	// Blind produces an encoded protocol message and VerifierState based on
 	// the input message and Signer's public key.
-	Blind(message []byte) ([]byte, VerifierState, error)
+	Blind(random io.Reader, message []byte) ([]byte, VerifierState, error)
+
+	// Verify verifies a (message, signature) pair over and produces an error
+	// if the signature is invalid.
+	Verify(message, signature []byte) error
 }
 
 // A VerifierState represents the protocol state used to run and complete a


### PR DESCRIPTION
This is necessary for some prototyping work in PPM.

I also updated the blind signer `Verifier` interface to implement the signature verification routine, as before it was assumed that the caller would know the internal details of how to verify signatures produced using a verifier.