### PR TITLE
tss/rsa: Fixes RSA signature size.

### DIFF
--- a/tss/rsa/keyshare.go
+++ b/tss/rsa/keyshare.go
@@ -23,6 +23,11 @@ type KeyShare struct {
 	Threshold uint
 }
 
+func (kshare KeyShare) String() string {
+	return fmt.Sprintf("(t,n): (%v,%v) index: %v si: 0x%v",
+		kshare.Threshold, kshare.Players, kshare.Index, kshare.si.Text(16))
+}
+
 // MarshalBinary encodes a KeyShare into a byte array in a format readable by UnmarshalBinary.
 // Note: Only Index's up to math.MaxUint16 are supported
 func (kshare *KeyShare) MarshalBinary() ([]byte, error) {

--- a/tss/rsa/signShare.go
+++ b/tss/rsa/signShare.go
@@ -17,6 +17,11 @@ type SignShare struct {
 	Threshold uint
 }
 
+func (s SignShare) String() string {
+	return fmt.Sprintf("(t,n): (%v,%v) index: %v xi: 0x%v",
+		s.Threshold, s.Players, s.Index, s.xi.Text(16))
+}
+
 // MarshalBinary encodes SignShare into a byte array in a format readable by UnmarshalBinary.
 // Note: Only Index's up to math.MaxUint16 are supported
 func (s *SignShare) MarshalBinary() ([]byte, error) {


### PR DESCRIPTION
As per [RFC 8017 Section 8.2.2](https://www.rfc-editor.org/rfc/rfc8017#section-8.2.2)
> If the length of the signature S is not k octets (where k is the length in octets of the RSA modulus n), output "invalid signature" and stop.