### PR TITLE
Use untyped consts for Kyber params

### DIFF
--- a/pke/kyber/internal/common/params/params.go
+++ b/pke/kyber/internal/common/params/params.go
@@ -8,10 +8,10 @@ const (
 	Q int16 = 3329
 
 	// N is the parameter N: the length of the polynomials
-	N int = 256
+	N = 256
 
 	// PolySize is the size of a packed polynomial.
-	PolySize int = 384
+	PolySize = 384
 
 	// PlaintextSize is the size of the plaintext
 	PlaintextSize = 32


### PR DESCRIPTION
These two constants are unnecessarily typed. This flows through all the way to the kem/kyber/kyberN packages where they cause `PrivateKeySize` and `PublicKeySize` to also be unnecessarily typed.