### PR TITLE
all: enables dynamic linking, removes R15 is clobbered

### DIFF
--- a/.etc/all_imports.go
+++ b/.etc/all_imports.go
@@ -1,0 +1,49 @@
+//go:build ignore
+// +build ignore
+
+// Generates a Go program with all the public imports of CIRCL. It is used to
+// test compilation using static (buildmode=default) and dynamic linking
+// (buildmode=plugin).
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+)
+
+func main() {
+	outputFileName := flag.String("out", "circl.go", "name of the output file.")
+	flag.Parse()
+
+	f, err := os.Create(*outputFileName)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	skipDirs := []string{".", "testdata", "internal", "templates"}
+	circl := "github.com/cloudflare/circl/"
+
+	fmt.Fprintln(f, "package main")
+	err = fs.WalkDir(os.DirFS("."), ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			panic(err)
+		}
+		if d.IsDir() {
+			for _, sd := range skipDirs {
+				if strings.Contains(path, sd) {
+					return nil
+				}
+			}
+			fmt.Fprintf(f, "import _ \"%v%v\"\n", circl, path)
+		}
+		return nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Fprintln(f, "func main() {}")
+}

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -62,6 +62,21 @@ jobs:
       - name: Testing
         run: |
           docker run --rm -v `pwd`:`pwd` -w `pwd` ${{matrix.CFG[1]}}/golang:${{matrix.CFG[2]}} go test -v ./...
+  build_modes:
+    needs: [amd64_job]
+    runs-on: ubuntu-22.04
+    name: Testing Build Modes
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.20'
+      - name: Build as Static
+        run: make circl_static
+      - name: Build as Plugin
+        run: make circl_plugin
   coverage_amd64_job:
     needs: [amd64_job]
     if: github.event_name == 'push'

--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,17 @@ bootstrap:
 
 clean:
 	rm -rf $(GOPATH_BUILD)
+
+.INTERMEDIATE: circl.go circl_static.exe circl_plugin.so
+circl_static: circl_static.exe
+circl_static.exe: circl.go
+	go clean -cache -modcache
+	go build -buildmode=default -o $@ $^
+
+circl_plugin: circl_plugin.so
+circl_plugin.so: circl.go
+	go clean -cache -modcache
+	go build -buildmode=plugin -o $@ $^
+
+circl.go:
+	go run .etc/all_imports.go -out $@

--- a/abe/cpabe/doc.go
+++ b/abe/cpabe/doc.go
@@ -1,0 +1,2 @@
+// Package cpabe provides Ciphertext-Policy Attribute-based Encryption algorithms.
+package cpabe

--- a/abe/doc.go
+++ b/abe/doc.go
@@ -1,0 +1,2 @@
+// Package abe provides Attribute-based data encryption algorithms.
+package abe

--- a/cipher/doc.go
+++ b/cipher/doc.go
@@ -1,0 +1,2 @@
+// Package cipher provides data encryption algorithms.
+package cipher

--- a/dh/csidh/fp511_amd64.s
+++ b/dh/csidh/fp511_amd64.s
@@ -101,7 +101,7 @@ TEXT ·mulBmiAsm(SB),NOSPLIT,$8-24
     XORQ R12, R12
     XORQ R13, R13
     XORQ R14, R14
-    XORQ R15, R15
+    XORQ  CX,  CX
 
     MOVQ BP, 0(SP) // push: BP is Callee-save.
     XORQ BP, BP
@@ -113,42 +113,43 @@ TEXT ·mulBmiAsm(SB),NOSPLIT,$8-24
 #define MULS_MULX_512(idx, r0, r1, r2, r3, r4, r5, r6, r7, r8) \
     \ // Reduction step
     MOVQ  ( 0)(SI), DX      \
-    MULXQ ( 8*idx)(DI), DX, CX  \
+    MULXQ ( 8*idx)(DI), DX, AX  \
     ADDQ  r0, DX            \
-    MULXQ ·pNegInv(SB), DX, CX  \
+    MOVQ ·pNegInv(SB), AX \
+    MULXQ AX, DX, AX  \
     \
-    XORQ  AX, AX \
-    MULXQ ·p+ 0(SB), AX, BX;             ; ADOXQ AX, r0 \
-    MULXQ ·p+ 8(SB), AX, CX; ADCXQ BX, r1; ADOXQ AX, r1 \
-    MULXQ ·p+16(SB), AX, BX; ADCXQ CX, r2; ADOXQ AX, r2 \
-    MULXQ ·p+24(SB), AX, CX; ADCXQ BX, r3; ADOXQ AX, r3 \
-    MULXQ ·p+32(SB), AX, BX; ADCXQ CX, r4; ADOXQ AX, r4 \
-    MULXQ ·p+40(SB), AX, CX; ADCXQ BX, r5; ADOXQ AX, r5 \
-    MULXQ ·p+48(SB), AX, BX; ADCXQ CX, r6; ADOXQ AX, r6 \
-    MULXQ ·p+56(SB), AX, CX; ADCXQ BX, r7; ADOXQ AX, r7 \
-    MOVQ  $0, AX           ; ADCXQ CX, r8; ADOXQ AX, r8 \
+    XORQ  AX, AX; \
+    MOVQ ·p+ 0(SB), AX; MULXQ AX, AX, BX;  ADOXQ AX, r0; ADCXQ BX, r1 \
+    MOVQ ·p+ 8(SB), AX; MULXQ AX, AX, BX;  ADOXQ AX, r1; ADCXQ BX, r2 \
+    MOVQ ·p+16(SB), AX; MULXQ AX, AX, BX;  ADOXQ AX, r2; ADCXQ BX, r3 \
+    MOVQ ·p+24(SB), AX; MULXQ AX, AX, BX;  ADOXQ AX, r3; ADCXQ BX, r4 \
+    MOVQ ·p+32(SB), AX; MULXQ AX, AX, BX;  ADOXQ AX, r4; ADCXQ BX, r5 \
+    MOVQ ·p+40(SB), AX; MULXQ AX, AX, BX;  ADOXQ AX, r5; ADCXQ BX, r6 \
+    MOVQ ·p+48(SB), AX; MULXQ AX, AX, BX;  ADOXQ AX, r6; ADCXQ BX, r7 \
+    MOVQ ·p+56(SB), AX; MULXQ AX, AX, BX;  ADOXQ AX, r7; ADCXQ BX, r8 \
+    MOVQ  $0, AX; ;;;;;;;;;;;;;;;;;;;;;;;  ADOXQ AX, r8; \
     \ // Multiplication step
     MOVQ (8*idx)(DI), DX \
     \
     XORQ  AX, AX \
-    MULXQ ( 0)(SI), AX, BX; ADOXQ AX, r0 \
-    MULXQ ( 8)(SI), AX, CX; ADCXQ BX, r1; ADOXQ AX, r1 \
-    MULXQ (16)(SI), AX, BX; ADCXQ CX, r2; ADOXQ AX, r2 \
-    MULXQ (24)(SI), AX, CX; ADCXQ BX, r3; ADOXQ AX, r3 \
-    MULXQ (32)(SI), AX, BX; ADCXQ CX, r4; ADOXQ AX, r4 \
-    MULXQ (40)(SI), AX, CX; ADCXQ BX, r5; ADOXQ AX, r5 \
-    MULXQ (48)(SI), AX, BX; ADCXQ CX, r6; ADOXQ AX, r6 \
-    MULXQ (56)(SI), AX, CX; ADCXQ BX, r7; ADOXQ AX, r7 \
-    MOVQ  $0, AX          ; ADCXQ CX, r8; ADOXQ AX, r8
+    MULXQ ( 0)(SI), AX, BX; ADOXQ AX, r0; ADCXQ BX, r1 \
+    MULXQ ( 8)(SI), AX, BX; ADOXQ AX, r1; ADCXQ BX, r2 \
+    MULXQ (16)(SI), AX, BX; ADOXQ AX, r2; ADCXQ BX, r3 \
+    MULXQ (24)(SI), AX, BX; ADOXQ AX, r3; ADCXQ BX, r4 \
+    MULXQ (32)(SI), AX, BX; ADOXQ AX, r4; ADCXQ BX, r5 \
+    MULXQ (40)(SI), AX, BX; ADOXQ AX, r5; ADCXQ BX, r6 \
+    MULXQ (48)(SI), AX, BX; ADOXQ AX, r6; ADCXQ BX, r7 \
+    MULXQ (56)(SI), AX, BX; ADOXQ AX, r7; ADCXQ BX, r8 \
+    MOVQ  $0, AX          ; ADOXQ AX, r8;
 
-    MULS_MULX_512(0,  R8,  R9, R10, R11, R12, R13, R14, R15,  BP)
-    MULS_MULX_512(1,  R9, R10, R11, R12, R13, R14, R15,  BP,  R8)
-    MULS_MULX_512(2, R10, R11, R12, R13, R14, R15,  BP,  R8,  R9)
-    MULS_MULX_512(3, R11, R12, R13, R14, R15,  BP,  R8,  R9, R10)
-    MULS_MULX_512(4, R12, R13, R14, R15,  BP,  R8,  R9, R10, R11)
-    MULS_MULX_512(5, R13, R14, R15,  BP,  R8,  R9, R10, R11, R12)
-    MULS_MULX_512(6, R14, R15,  BP,  R8,  R9, R10, R11, R12, R13)
-    MULS_MULX_512(7, R15,  BP,  R8,  R9, R10, R11, R12, R13, R14)
+    MULS_MULX_512(0,  R8,  R9, R10, R11, R12, R13, R14,  CX,  BP)
+    MULS_MULX_512(1,  R9, R10, R11, R12, R13, R14,  CX,  BP,  R8)
+    MULS_MULX_512(2, R10, R11, R12, R13, R14,  CX,  BP,  R8,  R9)
+    MULS_MULX_512(3, R11, R12, R13, R14,  CX,  BP,  R8,  R9, R10)
+    MULS_MULX_512(4, R12, R13, R14,  CX,  BP,  R8,  R9, R10, R11)
+    MULS_MULX_512(5, R13, R14,  CX,  BP,  R8,  R9, R10, R11, R12)
+    MULS_MULX_512(6, R14,  CX,  BP,  R8,  R9, R10, R11, R12, R13)
+    MULS_MULX_512(7,  CX,  BP,  R8,  R9, R10, R11, R12, R13, R14)
 #undef MULS_MULX_512
 
     MOVQ res+0(FP), DI

--- a/dh/sidh/internal/p434/arith_amd64.s
+++ b/dh/sidh/internal/p434/arith_amd64.s
@@ -29,27 +29,36 @@
 //   |-128-| x |--- 256 ---| = |------ 384 ------|
 // Assuming the first digit multiplication was already performed.
 #define MULX128x256(I1, M1, T1, T2, T3, T4, T5)    \
-    MULXQ   M1+ 8(SB), T4, T2   \
+    MOVQ    M1+ 8(SB), AX       \
+    MULXQ   AX, T4, T2          \
     XORQ    AX, AX              \
-    MULXQ   M1+16(SB), T5, T3   \
+    MOVQ    M1+16(SB), AX       \
+    MULXQ   AX, T5, T3          \
     ADOXQ   T4, T1              \ // T1: interm1
     ADOXQ   T5, T2              \ // T2: interm2
-    MULXQ   M1+24(SB), T5, T4   \
+    MOVQ    M1+24(SB), AX       \
+    MULXQ   AX, T5, T4          \
     ADOXQ   T5, T3              \ // T3: interm3
+    MOVL    $0, AX              \
     ADOXQ   AX, T4              \ // T4: interm4
     \
     XORQ    AX, AX              \
     MOVQ    I1, DX              \
-    MULXQ   M1+ 0(SB), T5, I1   \ // T0 <- C0
+    MOVQ    M1+ 0(SB), AX       \
+    MULXQ   AX, T5, I1          \ // T0 <- C0
     ADCXQ   T5, T1              \
     ADCXQ   I1, T2              \ // T1 <- C1
-    MULXQ   M1+ 8(SB), I1, T5   \
+    MOVQ    M1+ 8(SB), AX       \
+    MULXQ   AX, I1, T5          \
     ADCXQ   T5, T3              \
     ADOXQ   I1, T2              \ // T2 <- C2
-    MULXQ   M1+16(SB), I1, T5   \
+    MOVQ    M1+16(SB), AX       \
+    MULXQ   AX, I1, T5          \
     ADCXQ   T5, T4              \
     ADOXQ   I1, T3              \ // T3 <- C3
-    MULXQ   M1+24(SB), I1, T5   \
+    MOVQ    M1+24(SB), AX       \
+    MULXQ   AX, I1, T5          \
+    MOVL    $0, AX              \
     ADCXQ   AX, T5              \
     ADOXQ   I1, T4              \ // T4 <- C4
     ADOXQ   AX, T5                // T5 <- C5
@@ -63,13 +72,17 @@
 //   |64| x |--- 256 ---| = |----- 320 ----|
 // Assuming the first digit multiplication was already performed.
 #define MULX64x256(M1, T1, T2, T3, T4, T5) \
-    MULXQ   M1+ 8(SB), T4, T2   \
+    MOVQ    M1+ 8(SB), AX       \
+    MULXQ   AX, T4, T2          \
     XORQ    AX, AX              \
-    MULXQ   M1+16(SB), T5, T3   \
+    MOVQ    M1+16(SB), AX       \
+    MULXQ   AX, T5, T3          \
     ADOXQ   T4, T1              \ // T1 <- C1
     ADOXQ   T5, T2              \ // T2 <- C2
-    MULXQ   M1+24(SB), T5, T4   \
+    MOVQ    M1+24(SB), AX       \
+    MULXQ   AX, T5, T4          \
     ADOXQ   T5, T3              \ // T3 <- C3
+    MOVL    $0, AX              \
     ADOXQ   AX, T4                // T4 <- C4
 
 // Performs schoolbook multiplication of two 192-bit numbers
@@ -284,7 +297,8 @@
 #define REDC_MULX(P1, MUL01, MUL23, MUL45, MUL67) \
     MOVQ 0x0(DI), DX        \
     MOVQ 0x8(DI), R14       \
-    MULXQ P1, R8, R9        \
+    MOVQ  P1, AX            \
+    MULXQ AX, R8, R9        \
     MUL01                   \
     MOVQ 0x10(DI), DX       \
     MOVQ 0x48(DI), CX       \
@@ -295,12 +309,14 @@
     ADCQ   0x38(DI), R12    \
     ADCQ   0x40(DI), R13    \
     ADCQ   $0, CX           \
-    MULXQ P1, BX, BP        \
+    MOVQ  P1, AX            \
+    MULXQ AX, BX, BP        \
     MOVQ   R9,   0x0(SI)    \
     MOVQ   R10,  0x8(SI)    \
     MOVQ   R11, 0x10(SI)    \
     MOVQ   R12, 0x18(SI)    \
     MOVQ   R13, 0x20(SI)    \
+    MOVQ   CX,  0x28(SI)    \
     MOVQ   0x50(DI), R9     \
     MOVQ   0x58(DI), R10    \
     MOVQ   0x60(DI), R11    \
@@ -315,11 +331,14 @@
     ADCQ   0x10(SI), BP     \
     ADCQ   0x18(SI), R12    \
     ADCQ   0x20(SI), R13    \
-    ADCQ   CX, R14          \
+    ADCQ   0x28(SI), R14    \
+    MOVQ   R14, 0x18(SI)    \
+    MOVQ   CX, R14          \
     MOVQ   $0, CX           \
-    ADCQ   R9, R15          \
+    ADCQ   R9, R14          \
     ADCQ   R10, CX          \
-    MULXQ P1, R8, R9        \
+    MOVQ  P1, AX            \
+    MULXQ AX, R8, R9        \
     MOVQ   BP, 0x0(SI)      \
     MOVQ   R12, 0x8(SI)     \
     MOVQ   R13, 0x10(SI)    \
@@ -329,22 +348,23 @@
     MOVQ 0x0(SI), DX        \
     ADDQ   0x8(SI), R8      \
     ADCQ   0x10(SI), R9     \
-    ADCQ   R14, R10         \
-    ADCQ   R15, BP          \
+    ADCQ   0x18(SI), R10    \
+    ADCQ   R14, BP          \
     ADCQ   CX, R12          \
     ADCQ   R11, R13         \
     ADCQ   $0, DI           \
-    MULXQ P1, R14, R15      \
+    MOVQ  P1, AX            \
+    MULXQ AX, R14, BX       \
     MOVQ   R8,   0x0(SI)    \
     MOVQ   R9,   0x8(SI)    \
     MUL67                   \
     ADDQ   R10, R14         \
-    ADCQ   BP, R15          \
+    ADCQ   BP, BX           \
     ADCQ   R12, R8          \
     ADCQ   R13, R9          \
     ADCQ   DI, R11          \
     MOVQ   R14, 0x10(SI)    \
-    MOVQ   R15, 0x18(SI)    \
+    MOVQ   BX, 0x18(SI)     \
     MOVQ   R8, 0x20(SI)     \
     MOVQ   R9, 0x28(SI)     \
     MOVQ   R11, 0x30(SI)
@@ -1314,9 +1334,9 @@ TEXT ·rdcP434(SB),$0-16
 // available on Broadwell micro-architectures and newer.
 redc_bdw:
 #define MULX01 MULX128x256(R14,·P434p1+(8*P434_P1_ZEROS),R9 ,R10,R11,R12,R13)
-#define MULX23 MULX128x256(R8 ,·P434p1+(8*P434_P1_ZEROS),BP ,R12,R13,R14,R15)
+#define MULX23 MULX128x256(R8 ,·P434p1+(8*P434_P1_ZEROS),BP ,R12,R13,R14,CX )
 #define MULX45 MULX128x256(BX ,·P434p1+(8*P434_P1_ZEROS),R9 ,R10,BP ,R12,R13)
-#define MULX67 MULX64x256 (    ·P434p1+(8*P434_P1_ZEROS),R15,R8 ,R9 ,R11,CX )
+#define MULX67 MULX64x256 (    ·P434p1+(8*P434_P1_ZEROS),BX ,R8 ,R9 ,R11,CX )
     REDC_MULX(·P434p1+(8*P434_P1_ZEROS)+0(SB), MULX01, MULX23, MULX45, MULX67)
 #undef MULX01
 #undef MULX23

--- a/dh/sidh/internal/p751/arith_amd64.s
+++ b/dh/sidh/internal/p751/arith_amd64.s
@@ -1431,44 +1431,58 @@ TEXT ·mulP751(SB), $96-24
 // C points to the place to store the result and should be at least 192 bits.
 // This should only be used when the BMI2 and ADX instruction set extensions
 // are available.
-#define mul256x448bmi2adx(M0, M1, C, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) \
+#define mul256x448bmi2adx(M0, M1, C, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9) \
 	MOVQ	0+M0, DX		\
-	MULXQ	M1+40(SB), T1, T0	\
-	MULXQ	M1+48(SB), T3, T2	\
+	MOVQ    M1+40(SB), AX   \
+	MULXQ	AX, T1, T0      \
+	MOVQ    M1+48(SB), AX   \
+	MULXQ	AX, T3, T2   	\
 	MOVQ	T1, 0+C			\	// C0_final
-	XORQ	AX, AX			\
-	MULXQ	M1+56(SB), T5, T4	\
+	MOVQ    M1+56(SB), AX   \
+	MULXQ	AX, T5, T4	    \
 	ADOXQ	T3, T0			\
 	ADOXQ	T5, T2			\
-	MULXQ	M1+64(SB), T3, T1	\
+	MOVQ    M1+64(SB), AX   \
+	MULXQ	AX, T3, T1	    \
 	ADOXQ	T3, T4			\
-	MULXQ	M1+72(SB), T6, T5	\
+	MOVQ    M1+72(SB), AX   \
+	MULXQ	AX, T6, T5	    \
 	ADOXQ	T6, T1			\
-	MULXQ	M1+80(SB), T7, T3	\
+	MOVQ    M1+80(SB), AX   \
+	MULXQ	AX, T7, T3	    \
 	ADOXQ	T7, T5			\
-	MULXQ	M1+88(SB), T8, T6	\
+	MOVQ    M1+88(SB), AX   \
+	MULXQ	AX, T8, T6	    \
 	ADOXQ	T8, T3			\
+	MOVL	$0, AX			\
 	ADOXQ	AX, T6			\
 					\
 	MOVQ	8+M0, DX		\
-	MULXQ	M1+40(SB), T7, T8	\
-	XORQ	AX, AX			\
+	MOVQ    M1+40(SB), AX   \
+	MULXQ	AX, T7, T8	    \
 	ADCXQ	T7, T0			\
 	MOVQ	T0, 8+C			\	// C1_final
 	ADCXQ	T8, T2			\
-	MULXQ	M1+48(SB), T8, T7	\
+	MOVQ    M1+48(SB), AX   \
+	MULXQ	AX, T8, T7	    \
 	ADOXQ	T8, T2			\
 	ADCXQ	T7, T4			\
-	MULXQ	M1+56(SB), T8, T0	\
+	MOVQ    M1+56(SB), AX   \
+	MULXQ	AX, T8, T0	    \
 	ADOXQ	T8, T4			\
 	ADCXQ	T1, T0			\
-	MULXQ	M1+64(SB), T7, T1	\
+	MOVQ    M1+64(SB), AX   \
+	MULXQ	AX, T7, T1      \
 	ADCXQ	T5, T1			\
-	MULXQ	M1+72(SB), T8, T5	\
+	MOVQ    M1+72(SB), AX   \
+	MULXQ	AX, T8, T5	    \
 	ADCXQ	T5, T3			\
-	MULXQ	M1+80(SB), T9, T5	\
+	MOVQ    M1+80(SB), AX   \
+	MULXQ	AX, T9, T5   	\
 	ADCXQ	T5, T6			\
-	MULXQ	M1+88(SB), DX, T5	\
+	MOVQ    M1+88(SB), AX   \
+	MULXQ	AX, DX, T5	    \
+	MOVL	$0, AX			\
 	ADCXQ	AX, T5			\
 					\
 	ADOXQ	T7, T0			\
@@ -1478,24 +1492,31 @@ TEXT ·mulP751(SB), $96-24
 	ADOXQ	AX, T5			\
 					\
 	MOVQ	16+M0, DX		\
-	MULXQ	M1+40(SB), T7, T8	\
-	XORQ	AX, AX			\
+	MOVQ    M1+40(SB), AX   \
+	MULXQ	AX, T7, T8	    \
 	ADCXQ	T7, T2			\
 	MOVQ	T2, 16+C		\	// C2_final
 	ADCXQ	T8, T4			\
-	MULXQ	M1+48(SB), T7, T8	\
+	MOVQ    M1+48(SB), AX   \
+	MULXQ	AX, T7, T8	    \
 	ADOXQ	T7, T4			\
 	ADCXQ	T8, T0			\
-	MULXQ	M1+56(SB), T8, T2	\
+	MOVQ    M1+56(SB), AX   \
+	MULXQ	AX, T8, T2	    \
 	ADOXQ	T8, T0			\
 	ADCXQ	T2, T1			\
-	MULXQ	M1+64(SB), T7, T2	\
+	MOVQ    M1+64(SB), AX   \
+	MULXQ	AX, T7, T2	    \
 	ADCXQ	T2, T3			\
-	MULXQ	M1+72(SB), T8, T2	\
+	MOVQ    M1+72(SB), AX   \
+	MULXQ	AX, T8, T2	    \
 	ADCXQ	T2, T6			\
-	MULXQ	M1+80(SB), T9, T2	\
+	MOVQ    M1+80(SB), AX   \
+	MULXQ	AX, T9, T2	    \
 	ADCXQ	T2, T5			\
-	MULXQ	M1+88(SB), DX, T2	\
+	MOVQ    M1+88(SB), AX   \
+	MULXQ	AX, DX, T2      \
+	MOVL	$0, AX			\
 	ADCXQ	AX, T2			\
 					\
 	ADOXQ	T7, T1			\
@@ -1505,26 +1526,33 @@ TEXT ·mulP751(SB), $96-24
 	ADOXQ	AX, T2			\
 					\
 	MOVQ	24+M0, DX		\
-	MULXQ	M1+40(SB), T7, T8	\
-	XORQ	AX, AX			\
+	MOVQ    M1+40(SB), AX   \
+	MULXQ	AX, T7, T8	    \
 	ADCXQ	T4, T7			\
 	ADCXQ	T8, T0			\
-	MULXQ	M1+48(SB), T10, T8	\
-	ADOXQ	T10, T0			\
+	MOVQ    M1+48(SB), AX   \
+	MULXQ	AX, T9, T8		\
+	ADOXQ	T9, T0			\
 	ADCXQ	T8, T1			\
-	MULXQ	M1+56(SB), T8, T4	\
+	MOVQ    M1+56(SB), AX   \
+	MULXQ	AX, T8, T4      \
 	ADOXQ	T8, T1			\
 	ADCXQ	T4, T3			\
-	MULXQ	M1+64(SB), T10, T4	\
+	MOVQ    M1+64(SB), AX   \
+	MULXQ	AX, AX, T4		\
 	ADCXQ	T4, T6			\
-	MULXQ	M1+72(SB), T8, T4	\
+	ADOXQ	AX, T3			\
+	MOVQ    M1+72(SB), AX   \
+	MULXQ	AX, T8, T4	    \
 	ADCXQ	T4, T5			\
-	MULXQ	M1+80(SB), T9, T4	\
+	MOVQ    M1+80(SB), AX   \
+	MULXQ	AX, T9, T4	    \
 	ADCXQ	T4, T2			\
-	MULXQ	M1+88(SB), DX, T4	\
+	MOVQ    M1+88(SB), AX   \
+	MULXQ	AX, DX, T4	    \
+	MOVL	$0, AX			\
 	ADCXQ	AX, T4			\
 					\
-	ADOXQ	T10, T3			\
 	ADOXQ	T8, T6			\
 	ADOXQ	T9, T5			\
 	ADOXQ	DX, T2			\
@@ -1535,44 +1563,57 @@ TEXT ·mulP751(SB), $96-24
 // C points to the place to store the result and should be at least 192 bits.
 // This should only be used when the BMI2 instruction set extension is
 // available.
-#define mul256x448bmi2(M0, M1, C, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) \
+#define mul256x448bmi2(M0, M1, C, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9) \
 	MOVQ	0+M0, DX		\
-	MULXQ	M1+40(SB), T1, T0	\
-	MULXQ	M1+48(SB), T3, T2	\
+	MOVQ    M1+40(SB), AX   \
+	MULXQ	AX, T1, T0   	\
+	MOVQ    M1+48(SB), AX   \
+	MULXQ	AX, T3, T2	    \
 	MOVQ	T1, 0+C			\	// C0_final
-	XORQ	AX, AX			\
-	MULXQ	M1+56(SB), T5, T4	\
+	MOVQ    M1+56(SB), AX   \
+	MULXQ	AX, T5, T4	    \
 	ADDQ	T3, T0			\
 	ADCQ	T5, T2			\
-	MULXQ	M1+64(SB), T3, T1	\
+	MOVQ    M1+64(SB), AX   \
+	MULXQ	AX, T3, T1	    \
 	ADCQ	T3, T4			\
-	MULXQ	M1+72(SB), T6, T5	\
+	MOVQ    M1+72(SB), AX   \
+	MULXQ	AX, T6, T5	    \
 	ADCQ	T6, T1			\
-	MULXQ	M1+80(SB), T7, T3	\
+	MOVQ    M1+80(SB), AX   \
+	MULXQ	AX, T7, T3	    \
 	ADCQ	T7, T5			\
-	MULXQ	M1+88(SB), T8, T6	\
+	MOVQ    M1+88(SB), AX   \
+	MULXQ	AX, T8, T6	    \
 	ADCQ	T8, T3			\
-	ADCQ	AX, T6			\
+	ADCQ	$0, T6			\
 					\
 	MOVQ	8+M0, DX		\
-	MULXQ	M1+40(SB), T7, T8	\
+	MOVQ    M1+40(SB), AX   \
+	MULXQ	AX, T7, T8	    \
 	ADDQ	T7, T0			\
 	MOVQ	T0, 8+C			\	// C1_final
 	ADCQ	T8, T2			\
-	MULXQ	M1+48(SB), T8, T7	\
+	MOVQ    M1+48(SB), AX   \
+	MULXQ	AX, T8, T7	    \
 	MOVQ	T8, 32+C		\
 	ADCQ	T7, T4			\
-	MULXQ	M1+56(SB), T8, T0	\
-	MOVQ	T8, 40+C		\
+	MOVQ    M1+56(SB), AX   \
+	MULXQ	AX, T8, T0	    \
+	MOVQ	T8, 40+C	 	\
 	ADCQ	T1, T0			\
-	MULXQ	M1+64(SB), T7, T1	\
+	MOVQ    M1+64(SB), AX   \
+	MULXQ	AX, T7, T1	    \
 	ADCQ	T5, T1			\
-	MULXQ	M1+72(SB), T8, T5	\
+	MOVQ    M1+72(SB), AX   \
+	MULXQ	AX, T8, T5	    \
 	ADCQ	T5, T3			\
-	MULXQ	M1+80(SB), T9, T5	\
+	MOVQ    M1+80(SB), AX   \
+	MULXQ	AX, T9, T5	    \
 	ADCQ	T5, T6			\
-	MULXQ	M1+88(SB), DX, T5	\
-	ADCQ	AX, T5			\
+	MOVQ    M1+88(SB), AX   \
+	MULXQ	AX, DX, T5	    \
+	ADCQ	$0, T5			\
 					\
 	XORQ	AX, AX			\
 	ADDQ	32+C, T2		\
@@ -1584,24 +1625,31 @@ TEXT ·mulP751(SB), $96-24
 	ADCQ	AX, T5			\
 					\
 	MOVQ	16+M0, DX		\
-	MULXQ	M1+40(SB), T7, T8	\
+	MOVQ    M1+40(SB), AX   \
+	MULXQ	AX, T7, T8	    \
 	ADDQ	T7, T2			\
 	MOVQ	T2, 16+C		\	// C2_final
 	ADCQ	T8, T4			\
-	MULXQ	M1+48(SB), T7, T8	\
+	MOVQ    M1+48(SB), AX   \
+	MULXQ	AX, T7, T8	    \
 	MOVQ	T7, 32+C		\
 	ADCQ	T8, T0			\
-	MULXQ	M1+56(SB), T8, T2	\
+	MOVQ    M1+56(SB), AX   \
+	MULXQ	AX, T8, T2	    \
 	MOVQ	T8, 40+C		\
 	ADCQ	T2, T1			\
-	MULXQ	M1+64(SB), T7, T2	\
+	MOVQ    M1+64(SB), AX   \
+	MULXQ	AX, T7, T2	    \
 	ADCQ	T2, T3			\
-	MULXQ	M1+72(SB), T8, T2	\
+	MOVQ    M1+72(SB), AX   \
+	MULXQ	AX, T8, T2	    \
 	ADCQ	T2, T6			\
-	MULXQ	M1+80(SB), T9, T2	\
+	MOVQ    M1+80(SB), AX   \
+	MULXQ	AX, T9, T2	    \
 	ADCQ	T2, T5			\
-	MULXQ	M1+88(SB), DX, T2	\
-	ADCQ	AX, T2			\
+	MOVQ    M1+88(SB), AX   \
+	MULXQ	AX, DX, T2	    \
+	ADCQ	$0, T2			\
 					\
 	XORQ	AX, AX			\
 	ADDQ	32+C, T4		\
@@ -1613,32 +1661,41 @@ TEXT ·mulP751(SB), $96-24
 	ADCQ	AX, T2			\
 					\
 	MOVQ	24+M0, DX		\
-	MULXQ	M1+40(SB), T7, T8	\
+	MOVQ    M1+40(SB), AX   \
+	MULXQ	AX, T7, T8	    \
 	ADDQ	T4, T7			\
+	MOVQ    T7, 8(SP) /* push T7 */ \
 	ADCQ	T8, T0			\
-	MULXQ	M1+48(SB), T10, T8	\
-	MOVQ	T10, 32+C		\
+	MOVQ    M1+48(SB), AX   \
+	MULXQ	AX, T9, T8  	\
+	MOVQ	T9, 32+C 		\
 	ADCQ	T8, T1			\
-	MULXQ	M1+56(SB), T8, T4	\
+	MOVQ    M1+56(SB), AX   \
+	MULXQ	AX, T8, T4	    \
 	MOVQ	T8, 40+C		\
 	ADCQ	T4, T3			\
-	MULXQ	M1+64(SB), T10, T4	\
+	MOVQ    M1+64(SB), AX   \
+	MULXQ	AX, T7, T4		\
 	ADCQ	T4, T6			\
-	MULXQ	M1+72(SB), T8, T4	\
+	MOVQ    M1+72(SB), AX   \
+	MULXQ	AX, T8, T4	    \
 	ADCQ	T4, T5			\
-	MULXQ	M1+80(SB), T9, T4	\
+	MOVQ    M1+80(SB), AX   \
+	MULXQ	AX, T9, T4	    \
 	ADCQ	T4, T2			\
-	MULXQ	M1+88(SB), DX, T4	\
-	ADCQ	AX, T4			\
+	MOVQ    M1+88(SB), AX   \
+	MULXQ	AX, DX, T4	    \
+	ADCQ	$0, T4			\
 					\
 	XORQ	AX, AX			\
 	ADDQ	32+C, T0		\
 	ADCQ	40+C, T1		\
-	ADCQ	T10, T3			\
+	ADCQ	T7, T3			\
 	ADCQ	T8, T6			\
 	ADCQ	T9, T5			\
 	ADCQ	DX, T2			\
-	ADCQ	AX, T4
+	ADCQ	AX, T4			\
+	MOVQ 8(SP), T7 /* pop T7 */
 
 // Template for calculating the Montgomery reduction algorithm described in
 // section 5.2.3 of https://eprint.iacr.org/2017/1015.pdf. Template must be
@@ -1651,7 +1708,7 @@ TEXT ·mulP751(SB), $96-24
 // Output: OUT 768-bit
 #define REDC(C, M0, MULS) 	\
     \ // a[0-3] x p751p1_nz --> result: [reg_p2+48], [reg_p2+56], [reg_p2+64], and rbp, r8:r14
-    MULS(M0, ·P751p1, 48+C, R8, R9, R13, R10, R14, R12, R11, BP, BX, CX, R15) \
+    MULS(M0, ·P751p1, 48+C, R8, R9, R13, R10, R14, R12, R11, BP, BX, CX) \
     XORQ    R15, R15        \
     MOVQ    48+C, AX        \
     MOVQ    56+C, DX        \
@@ -1702,7 +1759,7 @@ TEXT ·mulP751(SB), $96-24
     MOVQ    R13, 176+M0     \
     MOVQ    R14, 184+M0     \
     \ // a[4-7] x p751p1_nz --> result: [reg_p2+48], [reg_p2+56], [reg_p2+64], and rbp, r8:r14
-    MULS(32+M0, ·P751p1, 48+C, R8, R9, R13, R10, R14, R12, R11, BP, BX, CX, R15) \
+    MULS(32+M0, ·P751p1, 48+C, R8, R9, R13, R10, R14, R12, R11, BP, BX, CX) \
     XORQ    R15, R15          \
     MOVQ    48+C, AX        \
     MOVQ    56+C, DX        \
@@ -1741,7 +1798,7 @@ TEXT ·mulP751(SB), $96-24
     MOVQ    R13, 176+M0     \
     MOVQ    R14, 184+M0     \
     \ // a[8-11] x p751p1_nz --> result: [reg_p2+48], [reg_p2+56], [reg_p2+64], and rbp, r8:r14
-    MULS(64+M0, ·P751p1, 48+C, R8, R9, R13, R10, R14, R12, R11, BP, BX, CX, R15) \
+    MULS(64+M0, ·P751p1, 48+C, R8, R9, R13, R10, R14, R12, R11, BP, BX, CX) \
     MOVQ    48+C, AX        \   // Final result c1:c11
     MOVQ    56+C, DX        \
     MOVQ    64+C, BX        \
@@ -1768,7 +1825,7 @@ TEXT ·mulP751(SB), $96-24
     MOVQ    R13, 80+C       \
     MOVQ    R14, 88+C
 
-TEXT ·rdcP751(SB), $8-16
+TEXT ·rdcP751(SB), $16-16
 	MOVQ z+0(FP), REG_P2
 	MOVQ x+8(FP), REG_P1
 

--- a/ecc/fourq/fq_amd64.h
+++ b/ecc/fourq/fq_amd64.h
@@ -9,6 +9,7 @@
     _fpSub(16+c,16+a,16+b)
 
 #define _fqMulBmi2(c, a, b) \
+    MOVL $0, R15 \
     \ // T0 = a0 * b0, R11:R10:R9:R8 <- 0+ra:8+ra * 0+rb:8+rb
     MOVQ 0+b, DX \
     MULXQ 0+a, R8, R9 \

--- a/math/fp25519/fp_amd64.h
+++ b/math/fp25519/fp_amd64.h
@@ -99,6 +99,7 @@
 // Uses: AX, DX, R8-R15, FLAGS
 // Instr: x86_64, bmi2, adx
 #define integerMulAdx(z,x,y) \
+    MOVL    $0,R15; \
     MOVQ   0+y, DX;       XORL  AX,  AX; \
     MULXQ  0+x, AX,  R8;  MOVQ  AX, 0+z; \
     MULXQ  8+x, AX,  R9;  ADCXQ AX,  R8; \

--- a/math/fp448/fp_amd64.h
+++ b/math/fp448/fp_amd64.h
@@ -158,6 +158,7 @@
 // Uses: AX, DX, R8-R15, FLAGS
 // Instr: x86_64, bmi2, adx
 #define integerMulAdx(z,x,y) \
+    MOVL    $0,R15; \
     MOVQ   0+y, DX;  XORL AX, AX;  MOVQ $0, R8; \
     MULXQ  0+x, AX,  R9;  MOVQ  AX, 0+z; \
     MULXQ  8+x, AX, R10;  ADCXQ AX,  R9; \

--- a/ot/doc.go
+++ b/ot/doc.go
@@ -1,0 +1,2 @@
+// Package ot provides oblivious-transfer protocols.
+package ot

--- a/tss/doc.go
+++ b/tss/doc.go
@@ -1,0 +1,1 @@
+package tss

--- a/zk/doc.go
+++ b/zk/doc.go
@@ -1,0 +1,2 @@
+// Package zk provides primitives for zero-knowledge proofs of knowledge.
+package zk


### PR DESCRIPTION
**Issue:** CIRCL cannot be compiled as a plugin, i.e., cannot be dynamically linked.
Fixes #391 

### Detection

Adds a CI job that checks whether CIRCL can be compiled using `-buildmode=plugin`.

When compiling, the compiler shows errors such as:

```sh
asm: arith_amd64.s:2450: when dynamic linking, R15 is clobbered by a global variable access and is used here
   ADCQ AX, R15
   MULXQ AX, R15, BX
   MULXQ AX, BX, R15
```

**Why?**: The main reason is that Go compiler uses R15 to access to global variables, so it alters its value (do not restore it).

### Solution

There are two solutions: 
1. reduce the use of global variables when possible. (In our case, some global variables store constant values, which can be replaced by immediate addressing. e.g. `MOV $0x22434, AX`)
2. make sure R15 is not used after accessing a global variable.

Using R15 is still possible if there are no reads to R15 after accessing a global variable. Writes to R15 are allowed.

**Note:** I detected that MULXQ is _incorrectly signaled_ as clobbered. This is a bug in the compiler (https://github.com/golang/go/issues/58632).

For example: In these two cases, R15 is the output of MULX, and the compiler stops the compilation with error.
```asm
   MULXQ AX, R15, BX
   MULXQ AX, BX, R15
```
In this case R15 is used as an input, so the compiler should stop with error.
```asm
   MULXQ R15, AX, BX
```

### Changes

* Updated assembly functions in all cases in which R15 is clobbered.

The best way to review this PR is going commit by commit.