### PR TITLE
tkn20: prevent panics on key gen errors

### DIFF
--- a/abe/cpabe/tkn20/tkn20.go
+++ b/abe/cpabe/tkn20/tkn20.go
@@ -62,7 +62,10 @@ func (msk *SystemSecretKey) KeyGen(rand io.Reader, attrs Attributes) (AttributeK
 		rand = cryptoRand.Reader
 	}
 	sk, err := tkn.DeriveAttributeKeysCCA(rand, &msk.sp, &attrs.attrs)
-	return AttributeKey{*sk}, err
+	if err != nil {
+		return AttributeKey{}, err
+	}
+	return AttributeKey{*sk}, nil
 }
 
 type AttributeKey struct {
@@ -150,5 +153,8 @@ func Setup(rand io.Reader) (PublicKey, SystemSecretKey, error) {
 		rand = cryptoRand.Reader
 	}
 	pp, sp, err := tkn.GenerateParams(rand)
-	return PublicKey{*pp}, SystemSecretKey{*sp}, err
+	if err != nil {
+		return PublicKey{}, SystemSecretKey{}, err
+	}
+	return PublicKey{*pp}, SystemSecretKey{*sp}, nil
 }


### PR DESCRIPTION
Both SystemSecretKey.KeyGen and Setup try to dereference the return values from abe/cpabe/tkn20/internal/tkn without checking for an error. On error, these values are nil and the functions panic.

This is easy to reproduce by passing an io.Reader that returns an error.