### PR TITLE
expander,tkn20: remove superfluous Reset calls

### DIFF
--- a/abe/cpabe/tkn20/internal/tkn/util.go
+++ b/abe/cpabe/tkn20/internal/tkn/util.go
@@ -30,7 +30,6 @@ func HashStringToScalar(key []byte, value string) *pairing.Scalar {
 	if err != nil {
 		return nil
 	}
-	xof.Reset()
 	_, err = xof.Write([]byte(value))
 	if err != nil {
 		return nil

--- a/expander/expander.go
+++ b/expander/expander.go
@@ -54,7 +54,6 @@ func (e *expanderMD) Expand(in []byte, n uint) []byte {
 	libStr[1] = byte(n & 0xFF)
 	dstPrime := e.calcDSTPrime()
 
-	H.Reset()
 	mustWrite(H, zPad)
 	mustWrite(H, in)
 	mustWrite(H, libStr)


### PR DESCRIPTION
These are both called when the blake2b.XOF / hash.Hash has just been freshly created.