### PR TITLE
Check for crypto/rand errors and ReadFull io.Readers

### DIFF
--- a/abe/cpabe/tkn20/internal/tkn/bk.go
+++ b/abe/cpabe/tkn20/internal/tkn/bk.go
@@ -78,7 +78,7 @@ func DeriveAttributeKeysCCA(rand io.Reader, sp *SecretParams, attrs *Attributes)
 
 func EncryptCCA(rand io.Reader, public *PublicParams, policy *Policy, msg []byte) ([]byte, error) {
 	seed := make([]byte, macKeySeedSize)
-	_, err := rand.Read(seed)
+	_, err := io.ReadFull(rand, seed)
 	if err != nil {
 		return nil, err
 	}

--- a/blindsign/blindrsa/blindrsa.go
+++ b/blindsign/blindrsa/blindrsa.go
@@ -183,7 +183,7 @@ func (v RSAVerifier) Blind(random io.Reader, message []byte) ([]byte, blindsign.
 	}
 
 	salt := make([]byte, v.hash.Size())
-	_, err := random.Read(salt)
+	_, err := io.ReadFull(random, salt)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudflare/circl
 go 1.19
 
 require (
-	github.com/bwesterb/go-ristretto v1.2.2
+	github.com/bwesterb/go-ristretto v1.2.3
 	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a
 	golang.org/x/sys v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/bwesterb/go-ristretto v1.2.2 h1:S2C0mmSjCLS3H9+zfXoIoKzl+cOncvBvt6pE+zTm5Ms=
 github.com/bwesterb/go-ristretto v1.2.2/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
+github.com/bwesterb/go-ristretto v1.2.3 h1:1w53tCkGhCQ5djbat3+MH0BAQ5Kfgbt56UZQ/JMzngw=
+github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a h1:diz9pEYuTIuLMJLs3rGDkeaTsNyRs6duYdFyPAxzE/U=
 golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
 golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=

--- a/kem/frodo/frodo640shake/frodo.go
+++ b/kem/frodo/frodo640shake/frodo.go
@@ -160,7 +160,9 @@ func generateKeyPair(rand io.Reader) (*PublicKey, *PrivateKey, error) {
 func (pk *PublicKey) EncapsulateTo(ct []byte, ss []byte, seed []byte) {
 	if seed == nil {
 		seed = make([]byte, EncapsulationSeedSize)
-		_, _ = cryptoRand.Read(seed[:])
+		if _, err := cryptoRand.Read(seed[:]); err != nil {
+			panic(err)
+		}
 	}
 	if len(seed) != EncapsulationSeedSize {
 		panic("seed must be of length EncapsulationSeedSize")

--- a/kem/kyber/kyber1024/kyber.go
+++ b/kem/kyber/kyber1024/kyber.go
@@ -106,7 +106,9 @@ func GenerateKeyPair(rand io.Reader) (*PublicKey, *PrivateKey, error) {
 func (pk *PublicKey) EncapsulateTo(ct, ss []byte, seed []byte) {
 	if seed == nil {
 		seed = make([]byte, EncapsulationSeedSize)
-		cryptoRand.Read(seed[:])
+		if _, err := cryptoRand.Read(seed[:]); err != nil {
+			panic(err)
+		}
 	} else {
 		if len(seed) != EncapsulationSeedSize {
 			panic("seed must be of length EncapsulationSeedSize")

--- a/kem/kyber/kyber512/kyber.go
+++ b/kem/kyber/kyber512/kyber.go
@@ -106,7 +106,9 @@ func GenerateKeyPair(rand io.Reader) (*PublicKey, *PrivateKey, error) {
 func (pk *PublicKey) EncapsulateTo(ct, ss []byte, seed []byte) {
 	if seed == nil {
 		seed = make([]byte, EncapsulationSeedSize)
-		cryptoRand.Read(seed[:])
+		if _, err := cryptoRand.Read(seed[:]); err != nil {
+			panic(err)
+		}
 	} else {
 		if len(seed) != EncapsulationSeedSize {
 			panic("seed must be of length EncapsulationSeedSize")

--- a/kem/kyber/kyber768/kyber.go
+++ b/kem/kyber/kyber768/kyber.go
@@ -106,7 +106,9 @@ func GenerateKeyPair(rand io.Reader) (*PublicKey, *PrivateKey, error) {
 func (pk *PublicKey) EncapsulateTo(ct, ss []byte, seed []byte) {
 	if seed == nil {
 		seed = make([]byte, EncapsulationSeedSize)
-		cryptoRand.Read(seed[:])
+		if _, err := cryptoRand.Read(seed[:]); err != nil {
+			panic(err)
+		}
 	} else {
 		if len(seed) != EncapsulationSeedSize {
 			panic("seed must be of length EncapsulationSeedSize")

--- a/kem/kyber/templates/pkg.templ.go
+++ b/kem/kyber/templates/pkg.templ.go
@@ -110,7 +110,9 @@ func GenerateKeyPair(rand io.Reader) (*PublicKey, *PrivateKey, error) {
 func (pk *PublicKey) EncapsulateTo(ct, ss []byte, seed []byte) {
 	if seed == nil {
 		seed = make([]byte, EncapsulationSeedSize)
-		cryptoRand.Read(seed[:])
+		if _, err := cryptoRand.Read(seed[:]); err != nil {
+			panic(err)
+		}
 	} else {
 		if len(seed) != EncapsulationSeedSize {
 			panic("seed must be of length EncapsulationSeedSize")

--- a/kem/sike/sikep434/sike.go
+++ b/kem/sike/sikep434/sike.go
@@ -130,7 +130,9 @@ func (*scheme) DeriveKeyPair(seed []byte) (kem.PublicKey, kem.PrivateKey) {
 
 func (sch *scheme) Encapsulate(pk kem.PublicKey) (ct []byte, ss []byte, err error) {
 	var seed [EncapsulationSeedSize]byte
-	cryptoRand.Read(seed[:])
+	if _, err := cryptoRand.Read(seed[:]); err != nil {
+		return nil, nil, err
+	}
 	return sch.EncapsulateDeterministically(pk, seed[:])
 }
 

--- a/kem/sike/sikep503/sike.go
+++ b/kem/sike/sikep503/sike.go
@@ -130,7 +130,9 @@ func (*scheme) DeriveKeyPair(seed []byte) (kem.PublicKey, kem.PrivateKey) {
 
 func (sch *scheme) Encapsulate(pk kem.PublicKey) (ct []byte, ss []byte, err error) {
 	var seed [EncapsulationSeedSize]byte
-	cryptoRand.Read(seed[:])
+	if _, err := cryptoRand.Read(seed[:]); err != nil {
+		return nil, nil, err
+	}
 	return sch.EncapsulateDeterministically(pk, seed[:])
 }
 

--- a/kem/sike/sikep751/sike.go
+++ b/kem/sike/sikep751/sike.go
@@ -130,7 +130,9 @@ func (*scheme) DeriveKeyPair(seed []byte) (kem.PublicKey, kem.PrivateKey) {
 
 func (sch *scheme) Encapsulate(pk kem.PublicKey) (ct []byte, ss []byte, err error) {
 	var seed [EncapsulationSeedSize]byte
-	cryptoRand.Read(seed[:])
+	if _, err := cryptoRand.Read(seed[:]); err != nil {
+		return nil, nil, err
+	}
 	return sch.EncapsulateDeterministically(pk, seed[:])
 }
 

--- a/kem/sike/templates/pkg.templ.go
+++ b/kem/sike/templates/pkg.templ.go
@@ -135,7 +135,9 @@ func (*scheme) DeriveKeyPair(seed []byte) (kem.PublicKey, kem.PrivateKey) {
 
 func (sch *scheme) Encapsulate(pk kem.PublicKey) (ct []byte, ss []byte, err error) {
 	var seed [EncapsulationSeedSize]byte
-	cryptoRand.Read(seed[:])
+	if _, err := cryptoRand.Read(seed[:]); err != nil {
+		return nil, nil, err
+	}
 	return sch.EncapsulateDeterministically(pk, seed[:])
 }
 


### PR DESCRIPTION
In practice crypto/rand.Read never returns an error, but that is not guaranteed. Check for those errors.

In contrast to crypto/rand.Reader, a user-provided io.Reader, might not fill the buffer without returning an error. Though marginal, we should deal with that corner-case as well.