### PR TITLE
Export HPKE ciphersuite algorithms

### DIFF
--- a/hpke/aead.go
+++ b/hpke/aead.go
@@ -29,7 +29,7 @@ type (
 // greater than 255*N bytes, where N is the size (in bytes) of the KDF's
 // output.
 func (c *encdecContext) Export(exporterContext []byte, length uint) []byte {
-	maxLength := uint(255 * c.suite.kdfID.ExtractSize())
+	maxLength := uint(255 * c.suite.Kdf.ExtractSize())
 	if length > maxLength {
 		panic(fmt.Errorf("output length must be lesser than %v bytes", maxLength))
 	}

--- a/hpke/aead_test.go
+++ b/hpke/aead_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestAeadExporter(t *testing.T) {
-	suite := Suite{kdfID: KDF_HKDF_SHA256, aeadID: AEAD_AES128GCM}
+	suite := Suite{Kdf: KDF_HKDF_SHA256, Aead: AEAD_AES128GCM}
 	exporter := &encdecContext{suite: suite}
-	maxLength := uint(255 * suite.kdfID.ExtractSize())
+	maxLength := uint(255 * suite.Kdf.ExtractSize())
 
 	err := test.CheckPanic(func() {
 		exporter.Export([]byte("exporter"), maxLength+1)
@@ -21,15 +21,15 @@ func TestAeadExporter(t *testing.T) {
 }
 
 func setupAeadTest() (*sealContext, *openContext, error) {
-	suite := Suite{aeadID: AEAD_AES128GCM}
-	key := make([]byte, suite.aeadID.KeySize())
+	suite := Suite{Aead: AEAD_AES128GCM}
+	key := make([]byte, suite.Aead.KeySize())
 	if n, err := rand.Read(key); err != nil {
 		return nil, nil, err
 	} else if n != len(key) {
 		return nil, nil, fmt.Errorf("unexpected key size: got %d; want %d", n, len(key))
 	}
 
-	aead, err := suite.aeadID.New(key)
+	aead, err := suite.Aead.New(key)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/hpke/hpke.go
+++ b/hpke/hpke.go
@@ -72,9 +72,9 @@ const (
 
 // Suite is an HPKE cipher suite consisting of a KEM, KDF, and AEAD algorithm.
 type Suite struct {
-	kemID  KEM
-	kdfID  KDF
-	aeadID AEAD
+	Kem  KEM
+	Kdf  KDF
+	Aead AEAD
 }
 
 // NewSuite builds a Suite from a specified set of algorithms. Panics
@@ -105,7 +105,7 @@ type Sender struct {
 
 // NewSender creates a Sender with knowledge of the receiver's public-key.
 func (suite Suite) NewSender(pkR kem.PublicKey, info []byte) (*Sender, error) {
-	if !suite.kemID.validatePublicKey(pkR) {
+	if !suite.Kem.validatePublicKey(pkR) {
 		return nil, ErrInvalidKEMPublicKey
 	}
 
@@ -127,7 +127,7 @@ func (s *Sender) Setup(rnd io.Reader) (enc []byte, seal Sealer, err error) {
 func (s *Sender) SetupAuth(rnd io.Reader, skS kem.PrivateKey) (
 	enc []byte, seal Sealer, err error,
 ) {
-	if !s.kemID.validatePrivateKey(skS) {
+	if !s.Kem.validatePrivateKey(skS) {
 		return nil, nil, ErrInvalidKEMPrivateKey
 	}
 
@@ -152,7 +152,7 @@ func (s *Sender) SetupPSK(rnd io.Reader, psk, pskID []byte) (
 func (s *Sender) SetupAuthPSK(rnd io.Reader, skS kem.PrivateKey, psk, pskID []byte) (
 	enc []byte, seal Sealer, err error,
 ) {
-	if !s.kemID.validatePrivateKey(skS) {
+	if !s.Kem.validatePrivateKey(skS) {
 		return nil, nil, ErrInvalidKEMPrivateKey
 	}
 
@@ -174,7 +174,7 @@ type Receiver struct {
 func (suite Suite) NewReceiver(skR kem.PrivateKey, info []byte) (
 	*Receiver, error,
 ) {
-	if !suite.kemID.validatePrivateKey(skR) {
+	if !suite.Kem.validatePrivateKey(skR) {
 		return nil, ErrInvalidKEMPrivateKey
 	}
 
@@ -192,7 +192,7 @@ func (r *Receiver) Setup(enc []byte) (Opener, error) {
 // SetupAuth generates a new HPKE context used for Auth Mode encryption.
 // SetupAuth takes an encapsulated key and a public key, and returns an Opener.
 func (r *Receiver) SetupAuth(enc []byte, pkS kem.PublicKey) (Opener, error) {
-	if !r.kemID.validatePublicKey(pkS) {
+	if !r.Kem.validatePublicKey(pkS) {
 		return nil, ErrInvalidKEMPublicKey
 	}
 
@@ -219,7 +219,7 @@ func (r *Receiver) SetupPSK(enc, psk, pskID []byte) (Opener, error) {
 func (r *Receiver) SetupAuthPSK(
 	enc, psk, pskID []byte, pkS kem.PublicKey,
 ) (Opener, error) {
-	if !r.kemID.validatePublicKey(pkS) {
+	if !r.Kem.validatePublicKey(pkS) {
 		return nil, ErrInvalidKEMPublicKey
 	}
 
@@ -232,7 +232,7 @@ func (r *Receiver) SetupAuthPSK(
 }
 
 func (s *Sender) allSetup(rnd io.Reader) ([]byte, Sealer, error) {
-	scheme := s.kemID.Scheme()
+	scheme := s.Kem.Scheme()
 
 	if rnd == nil {
 		rnd = rand.Reader
@@ -265,7 +265,7 @@ func (s *Sender) allSetup(rnd io.Reader) ([]byte, Sealer, error) {
 func (r *Receiver) allSetup() (Opener, error) {
 	var err error
 	var ss []byte
-	scheme := r.kemID.Scheme()
+	scheme := r.Kem.Scheme()
 	switch r.modeID {
 	case modeBase, modePSK:
 		ss, err = scheme.Decapsulate(r.skR, r.enc)

--- a/hpke/marshal.go
+++ b/hpke/marshal.go
@@ -9,9 +9,9 @@ import (
 // marshal serializes an HPKE context.
 func (c *encdecContext) marshal() ([]byte, error) {
 	var b cryptobyte.Builder
-	b.AddUint16(uint16(c.suite.kemID))
-	b.AddUint16(uint16(c.suite.kdfID))
-	b.AddUint16(uint16(c.suite.aeadID))
+	b.AddUint16(uint16(c.suite.Kem))
+	b.AddUint16(uint16(c.suite.Kdf))
+	b.AddUint16(uint16(c.suite.Aead))
 	b.AddUint8LengthPrefixed(func(b *cryptobyte.Builder) {
 		b.AddBytes(c.exporterSecret)
 	})
@@ -36,9 +36,9 @@ func unmarshalContext(raw []byte) (*encdecContext, error) {
 
 	c := new(encdecContext)
 	s := cryptobyte.String(raw)
-	if !s.ReadUint16((*uint16)(&c.suite.kemID)) ||
-		!s.ReadUint16((*uint16)(&c.suite.kdfID)) ||
-		!s.ReadUint16((*uint16)(&c.suite.aeadID)) ||
+	if !s.ReadUint16((*uint16)(&c.suite.Kem)) ||
+		!s.ReadUint16((*uint16)(&c.suite.Kdf)) ||
+		!s.ReadUint16((*uint16)(&c.suite.Aead)) ||
 		!s.ReadUint8LengthPrefixed(&t) ||
 		!t.ReadBytes(&c.exporterSecret, len(t)) ||
 		!s.ReadUint8LengthPrefixed(&t) ||
@@ -54,17 +54,17 @@ func unmarshalContext(raw []byte) (*encdecContext, error) {
 		return nil, ErrInvalidHPKESuite
 	}
 
-	Nh := c.suite.kdfID.ExtractSize()
+	Nh := c.suite.Kdf.ExtractSize()
 	if len(c.exporterSecret) != Nh {
 		return nil, errors.New("invalid exporter secret length")
 	}
 
-	Nk := int(c.suite.aeadID.KeySize())
+	Nk := int(c.suite.Aead.KeySize())
 	if len(c.key) != Nk {
 		return nil, errors.New("invalid key length")
 	}
 
-	c.AEAD, err = c.suite.aeadID.New(c.key)
+	c.AEAD, err = c.suite.Aead.New(c.key)
 	if err != nil {
 		return nil, err
 	}

--- a/hpke/marshal_test.go
+++ b/hpke/marshal_test.go
@@ -25,7 +25,7 @@ func TestContextSerialization(t *testing.T) {
 	s := NewSuite(KEM_P384_HKDF_SHA384, KDF_HKDF_SHA384, AEAD_AES256GCM)
 	info := []byte("some info string")
 
-	pk, sk, err := s.kemID.Scheme().GenerateKeyPair()
+	pk, sk, err := s.Kem.Scheme().GenerateKeyPair()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Callers construct a Suite from a (KEM, AEAD, KDF) tuple and use it for things like creating senders and receivers, but then they must still keep the tuple elements around if they want to get access to things like the KEM Scheme or the AEAD key size. It would be simpler if the caller could just hang onto a Suite value and then access the KEM, AEAD, and KDF values internally. So this change exports things to make that happen.