### PR TITLE
Implement Granger-Scott faster squaring in the cyclotomic subgroup.

### DIFF
--- a/ecc/bls12381/ff/cyclo6_test.go
+++ b/ecc/bls12381/ff/cyclo6_test.go
@@ -82,6 +82,19 @@ func TestCyclo6(t *testing.T) {
 			}
 		}
 	})
+	t.Run("sqr_sqrfasr", func(t *testing.T) {
+		var want, got Cyclo6
+		for i := 0; i < testTimes; i++ {
+			x := randomCyclo6(t)
+
+			// Specialized square in cyclotomic vs Generic Square in Fp12
+			got.Sqr(x)
+			(*Fp12)(&want).Sqr((*Fp12)(x))
+			if got.IsEqual(&want) == 0 {
+				test.ReportError(t, got, want, x)
+			}
+		}
+	})
 
 	t.Run("invFp12_vs_invCyclo6", func(t *testing.T) {
 		var want, got Fp12

--- a/ecc/bls12381/ff/fp12cubic.go
+++ b/ecc/bls12381/ff/fp12cubic.go
@@ -29,7 +29,7 @@ func (z *Fp12Cubic) FromFp12(x *Fp12) {
 	z[2][1] = x[1][2] // w^5
 }
 
-func (z *Fp12) FromFp12Alt(x *Fp12Cubic) {
+func (z *Fp12) FromFp12Cubic(x *Fp12Cubic) {
 	z[0][0] = x[0][0] // w^0
 	z[1][0] = x[1][0] // w^1
 	z[0][1] = x[2][0] // w^2

--- a/ecc/bls12381/ff/fp12cubic_test.go
+++ b/ecc/bls12381/ff/fp12cubic_test.go
@@ -17,7 +17,7 @@ func TestFP12CubicAdd(t *testing.T) {
 		yalt.FromFp12(y)
 		zalt.Add(&xalt, &yalt)
 		z.Add(x, y)
-		zcmp.FromFp12Alt(&zalt)
+		zcmp.FromFp12Cubic(&zalt)
 		if z.IsEqual(&zcmp) == 0 {
 			test.ReportError(t, z, zcmp, x, y)
 		}
@@ -35,7 +35,7 @@ func TestFP12CubicMul(t *testing.T) {
 		yalt.FromFp12(y)
 		zalt.Mul(&xalt, &yalt)
 		z.Mul(x, y)
-		zcmp.FromFp12Alt(&zalt)
+		zcmp.FromFp12Cubic(&zalt)
 		if z.IsEqual(&zcmp) == 0 {
 			test.ReportError(t, z, zcmp, x, y)
 		}
@@ -51,7 +51,7 @@ func TestFP12AltSqr(t *testing.T) {
 		xalt.FromFp12(x)
 		zalt.Sqr(&xalt)
 		z.Sqr(x)
-		zcmp.FromFp12Alt(&zalt)
+		zcmp.FromFp12Cubic(&zalt)
 		if z.IsEqual(&zcmp) == 0 {
 			test.ReportError(t, z, zcmp, x)
 		}

--- a/ecc/bls12381/ff/fp4.go
+++ b/ecc/bls12381/ff/fp4.go
@@ -23,6 +23,8 @@ func (z *Fp4) IsEqual(x *Fp4) int {
 	return z[0].IsEqual(&x[0]) & z[1].IsEqual(&x[1])
 }
 
+func (z *Fp4) Cjg() { z[1].Neg() }
+
 func (z *Fp4) Neg() {
 	z[0].Neg()
 	z[1].Neg()

--- a/ecc/bls12381/pair.go
+++ b/ecc/bls12381/pair.go
@@ -32,7 +32,7 @@ func miller(f *ff.Fp12, P *G1, Q *G2) {
 			acc.MulLine(acc, g)
 		}
 	}
-	f.FromFp12Alt(acc)
+	f.FromFp12Cubic(acc)
 	f.Cjg() // inverts f as paramX is negative.
 }
 


### PR DESCRIPTION
Implement faster squaring by Granger-Scott.
See Page 7 of https://www.iacr.org/archive/pkc2010/60560212/60560212.pdf

```
BenchmarkFinalExpo/HardExp-16      1869311       1186504       -36.53%
BenchmarkFinalExpo/FinalExp-16     1941307       1283443       -33.89%
BenchmarkPair/Pair-16              2879087       2203070       -23.48%
BenchmarkPair/ProdPair3-16         10354636      9508109       -8.18%
```