### PR TITLE
tss/rsa: Rewrite serialization functions,

### DIFF
--- a/tss/rsa/keyshare.go
+++ b/tss/rsa/keyshare.go
@@ -3,15 +3,15 @@ package rsa
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"math/big"
 	"sync"
 
+	"github.com/cloudflare/circl/internal/conv"
 	"github.com/cloudflare/circl/zk/qndleq"
+	"golang.org/x/crypto/cryptobyte"
 )
 
 // VerifyKeys contains keys used to verify whether a signature share
@@ -23,15 +23,17 @@ type VerifyKeys struct {
 	VerifyKey *big.Int
 }
 
+func (v VerifyKeys) String() string {
+	return fmt.Sprintf("groupKey: 0x%v verifyKey: 0x%v",
+		v.GroupKey.Text(16), v.VerifyKey.Text(16))
+}
+
 // KeyShare represents a portion of the key. It can only be used to generate SignShare's. During the dealing phase (when Deal is called), one KeyShare is generated per player.
 type KeyShare struct {
-	si *big.Int
+	share
 
+	si         *big.Int
 	twoDeltaSi *big.Int // this value is used to marginally speed up SignShare generation in Sign.
-	Index      uint     // When KeyShare's are generated they are each assigned an index sequentially
-
-	Players   uint
-	Threshold uint
 
 	// It stores keys to produce verifiable signature shares.
 	// If it's nil, signature shares are still produced but
@@ -42,137 +44,89 @@ type KeyShare struct {
 }
 
 func (kshare KeyShare) String() string {
-	return fmt.Sprintf("(t,n): (%v,%v) index: %v si: 0x%v",
-		kshare.Threshold, kshare.Players, kshare.Index, kshare.si.Text(16))
+	return fmt.Sprintf("%v si: 0x%v twoDeltaSi: 0x%v vk: {%v}",
+		kshare.share, kshare.si.Text(16), kshare.twoDeltaSi.Text(16), kshare.vk,
+	)
 }
 
-// MarshalBinary encodes a KeyShare into a byte array in a format readable by UnmarshalBinary.
-// Note: Only Index's up to math.MaxUint16 are supported
-func (kshare *KeyShare) MarshalBinary() ([]byte, error) {
-	// The encoding format is
-	// | Players: uint16 | Threshold: uint16 | Index: uint16 | siLen: uint16 | si: []byte | twoDeltaSiNil: bool | twoDeltaSiLen: uint16 | twoDeltaSi: []byte |
-	// with all values in big-endian.
+func (kshare *KeyShare) MarshalBinary() ([]byte, error) { return conv.MarshalBinary(kshare) }
+func (kshare *KeyShare) UnmarshalBinary(b []byte) error { return conv.UnmarshalBinary(kshare, b) }
 
-	if kshare.Players > math.MaxUint16 {
-		return nil, fmt.Errorf("rsa_threshold: keyshare marshall: Players is too big to fit in a uint16")
+func (kshare *KeyShare) Marshal(b *cryptobyte.Builder) error {
+	buf := make([]byte, (kshare.ModulusLength+7)/8)
+	b.AddValue(&kshare.share)
+	b.AddBytes(kshare.si.FillBytes(buf))
+	b.AddBytes(kshare.twoDeltaSi.FillBytes(buf))
+
+	isVerifiable := kshare.IsVerifiable()
+	var flag uint8
+	if isVerifiable {
+		flag = 0x01
 	}
-
-	if kshare.Threshold > math.MaxUint16 {
-		return nil, fmt.Errorf("rsa_threshold: keyshare marshall: Threhsold is too big to fit in a uint16")
+	b.AddUint8(flag)
+	if isVerifiable {
+		b.AddBytes(kshare.vk.GroupKey.FillBytes(buf))
+		b.AddBytes(kshare.vk.VerifyKey.FillBytes(buf))
 	}
-
-	if kshare.Index > math.MaxUint16 {
-		return nil, fmt.Errorf("rsa_threshold: keyshare marshall: Index is too big to fit in a uint16")
-	}
-
-	players := uint16(kshare.Players)
-	threshold := uint16(kshare.Threshold)
-	index := uint16(kshare.Index)
-
-	twoDeltaSiBytes := kshare.twoDeltaSi.Bytes()
-	twoDeltaSiLen := len(twoDeltaSiBytes)
-
-	if twoDeltaSiLen > math.MaxInt16 {
-		return nil, fmt.Errorf("rsa_threshold: keyshare marshall: twoDeltaSiBytes is too big to fit it's length in a uint16")
-	}
-
-	siBytes := kshare.si.Bytes()
-
-	siLength := len(siBytes)
-
-	if siLength == 0 {
-		siLength = 1
-		siBytes = []byte{0}
-	}
-
-	if siLength > math.MaxInt16 {
-		return nil, fmt.Errorf("rsa_threshold: keyshare marshall: siBytes is too big to fit it's length in a uint16")
-	}
-
-	blen := 2 + 2 + 2 + 2 + 2 + 1 + siLength + twoDeltaSiLen
-	out := make([]byte, blen)
-
-	binary.BigEndian.PutUint16(out[0:2], players)
-	binary.BigEndian.PutUint16(out[2:4], threshold)
-	binary.BigEndian.PutUint16(out[4:6], index)
-
-	binary.BigEndian.PutUint16(out[6:8], uint16(siLength)) // okay because of conditions checked above
-
-	copy(out[8:8+siLength], siBytes)
-
-	out[8+siLength] = 1 // twoDeltaSiNil
-
-	binary.BigEndian.PutUint16(out[8+siLength+1:8+siLength+3], uint16(twoDeltaSiLen))
-
-	copy(out[8+siLength+3:8+siLength+3+twoDeltaSiLen], twoDeltaSiBytes)
-
-	return out, nil
-}
-
-// UnmarshalBinary recovers a KeyShare from a slice of bytes, or returns an error if the encoding is invalid.
-func (kshare *KeyShare) UnmarshalBinary(data []byte) error {
-	// The encoding format is
-	// | Players: uint16 | Threshold: uint16 | Index: uint16 | siLen: uint16 | si: []byte | twoDeltaSiNil: bool | twoDeltaSiLen: uint16 | twoDeltaSi: []byte |
-	// with all values in big-endian.
-	if len(data) < 6 {
-		return fmt.Errorf("rsa_threshold: keyshare unmarshalKeyShareTest failed: data length was too short for reading Players, Threashold, Index")
-	}
-
-	players := binary.BigEndian.Uint16(data[0:2])
-	threshold := binary.BigEndian.Uint16(data[2:4])
-	index := binary.BigEndian.Uint16(data[4:6])
-
-	if len(data[6:]) < 2 {
-		return fmt.Errorf("rsa_threshold: keyshare unmarshalKeyShareTest failed: data length was too short for reading siLen length")
-	}
-
-	siLen := binary.BigEndian.Uint16(data[6:8])
-
-	if siLen == 0 {
-		return fmt.Errorf("rsa_threshold: keyshare unmarshalKeyShareTest failed: si is a required field but siLen was 0")
-	}
-
-	if uint16(len(data[8:])) < siLen {
-		return fmt.Errorf("rsa_threshold: keyshare unmarshalKeyShareTest failed: data length was too short for reading si, needed: %d found: %d", siLen, len(data[8:]))
-	}
-
-	si := new(big.Int).SetBytes(data[8 : 8+siLen])
-
-	if len(data[8+siLen:]) < 1 {
-		return fmt.Errorf("rsa_threshold: keyshare unmarshalKeyShareTest failed: data length was too short for reading twoDeltaSiNil")
-	}
-
-	if len(data[8+siLen+1:]) < 2 {
-		return fmt.Errorf("rsa_threshold: keyshare unmarshalKeyShareTest failed: data length was too short for reading twoDeltaSiLen length")
-	}
-
-	twoDeltaSiLen := binary.BigEndian.Uint16(data[8+siLen+1 : 8+siLen+3])
-
-	if uint16(len(data[8+siLen+3:])) < twoDeltaSiLen {
-		return fmt.Errorf("rsa_threshold: keyshare unmarshalKeyShareTest failed: data length was too short for reading twoDeltaSi, needed: %d found: %d", twoDeltaSiLen, len(data[8+siLen+2:]))
-	}
-
-	twoDeltaSi := new(big.Int).SetBytes(data[8+siLen+3 : 8+siLen+3+twoDeltaSiLen])
-
-	kshare.Players = uint(players)
-	kshare.Threshold = uint(threshold)
-	kshare.Index = uint(index)
-	kshare.si = si
-	kshare.twoDeltaSi = twoDeltaSi
 
 	return nil
 }
 
-// Returns the cached value in twoDeltaSi or if nil, generates 2∆s_i, stores it in twoDeltaSi, and returns it
-func (kshare *KeyShare) get2DeltaSi(players int64) *big.Int {
-	// use the cached value if it exists
-	if kshare.twoDeltaSi != nil {
-		return kshare.twoDeltaSi
+func (kshare *KeyShare) ReadValue(r *cryptobyte.String) bool {
+	var sh share
+	ok := sh.ReadValue(r)
+	if !ok {
+		return false
 	}
+
+	mlen := int((sh.ModulusLength + 7) / 8)
+	var siBytes, twoDeltaSiBytes []byte
+	ok = r.ReadBytes(&siBytes, mlen) &&
+		r.ReadBytes(&twoDeltaSiBytes, mlen)
+	if !ok {
+		return false
+	}
+
+	var isVerifiable uint8
+	ok = r.ReadUint8(&isVerifiable)
+	if !ok {
+		return false
+	}
+
+	var vk *VerifyKeys
+	switch isVerifiable {
+	case 0:
+		vk = nil
+	case 1:
+		var groupKeyBytes, verifyKeyBytes []byte
+		ok = r.ReadBytes(&groupKeyBytes, mlen) &&
+			r.ReadBytes(&verifyKeyBytes, mlen)
+		if !ok {
+			return false
+		}
+
+		vk = &VerifyKeys{
+			GroupKey:  new(big.Int).SetBytes(groupKeyBytes),
+			VerifyKey: new(big.Int).SetBytes(verifyKeyBytes),
+		}
+	default:
+		return false
+	}
+
+	kshare.share = sh
+	kshare.si = new(big.Int).SetBytes(siBytes)
+	kshare.twoDeltaSi = new(big.Int).SetBytes(twoDeltaSiBytes)
+	kshare.vk = vk
+
+	return true
+}
+
+// Returns calculates and returns twoDeltaSi = 2∆s_i mod m.
+func (kshare *KeyShare) get2DeltaSi(players int64, m *big.Int) *big.Int {
 	delta := calculateDelta(players)
 	// 2∆s_i
 	// delta << 1 == delta * 2
-	delta.Lsh(delta, 1).Mul(delta, kshare.si)
+	delta.Lsh(delta, 1).Mul(delta, kshare.si).Mod(delta, m)
 	kshare.twoDeltaSi = delta
 	return delta
 }
@@ -182,17 +136,18 @@ func (kshare *KeyShare) get2DeltaSi(players int64) *big.Int {
 func (kshare *KeyShare) IsVerifiable() bool { return kshare.vk != nil }
 
 // VerifyKeys returns a copy of the verification keys used to verify
-// signature shares. Returns nil if the key share cannot produce
-// verifiable signature shares.
+// signature shares. Panics if the key share cannot produce
+// verifiable signature shares. Use the [IsVerifiable] method to
+// determine whether there are associated verification keys.
 func (kshare *KeyShare) VerifyKeys() (vk *VerifyKeys) {
-	if kshare.IsVerifiable() {
-		vk = &VerifyKeys{
-			GroupKey:  new(big.Int).Set(kshare.vk.GroupKey),
-			VerifyKey: new(big.Int).Set(kshare.vk.VerifyKey),
-		}
+	if !kshare.IsVerifiable() {
+		panic(ErrKeyShareNonVerifiable)
 	}
 
-	return
+	return &VerifyKeys{
+		GroupKey:  new(big.Int).Set(kshare.vk.GroupKey),
+		VerifyKey: new(big.Int).Set(kshare.vk.VerifyKey),
+	}
 }
 
 // Sign msg using a KeyShare. msg MUST be padded and hashed. Call PadHash before this method.
@@ -203,17 +158,14 @@ func (kshare *KeyShare) VerifyKeys() (vk *VerifyKeys) {
 // parallel indicates whether the blinding operations should use go routines to operate in parallel.
 // If parallel is false, blinding will take about 2x longer than nonbinding, otherwise it will take about the same time
 // (see benchmarks). If randSource is nil, parallel has no effect. parallel should almost always be set to true.
-func (kshare *KeyShare) Sign(randSource io.Reader, pub *rsa.PublicKey, digest []byte, parallel bool) (SignShare, error) {
+func (kshare *KeyShare) Sign(randSource io.Reader, pub *rsa.PublicKey, digest []byte, parallel bool) (*SignShare, error) {
 	x := &big.Int{}
 	x.SetBytes(digest)
 
-	exp := kshare.get2DeltaSi(int64(kshare.Players))
+	exp := kshare.twoDeltaSi
 
-	var signShare SignShare
-	signShare.Players = kshare.Players
-	signShare.Threshold = kshare.Threshold
-	signShare.Index = kshare.Index
-
+	signShare := new(SignShare)
+	signShare.share = kshare.share
 	signShare.xi = &big.Int{}
 
 	if randSource != nil {
@@ -226,7 +178,7 @@ func (kshare *KeyShare) Sign(randSource io.Reader, pub *rsa.PublicKey, digest []
 
 		r, err := rand.Int(randSource, pub.N)
 		if err != nil {
-			return SignShare{}, errors.New("rsa_threshold: unable to get random value for blinding")
+			return nil, errors.New("rsa_threshold: unable to get random value for blinding")
 		}
 		expPlusr := big.Int{}
 		// exp + r
@@ -254,7 +206,7 @@ func (kshare *KeyShare) Sign(randSource io.Reader, pub *rsa.PublicKey, digest []
 
 		if res == nil {
 			// extremely unlikely, somehow x^r is p or q
-			return SignShare{}, errors.New("rsa_threshold: no mod inverse")
+			return nil, errors.New("rsa_threshold: no mod inverse")
 		}
 
 		if wg != nil {
@@ -285,7 +237,7 @@ func (kshare *KeyShare) Sign(randSource io.Reader, pub *rsa.PublicKey, digest []
 			x4Delta, xiSqr,
 			pub.N, SecParam)
 		if err != nil {
-			return SignShare{}, err
+			return nil, err
 		}
 		signShare.proof = proof
 	}

--- a/tss/rsa/rsa_threshold_test.go
+++ b/tss/rsa/rsa_threshold_test.go
@@ -81,8 +81,9 @@ func TestComputeLambda(t *testing.T) {
 	// dem = (3 - 1) * (3 - 2) * (3 - 4) * (3 - 5) = 4
 	// num/dev = 40/4 = 10
 	// ∆ * 10 = 120 * 10 = 1200
-	shares := make([]SignShare, 5)
+	shares := make([]*SignShare, 5)
 	for i := uint(1); i <= 5; i++ {
+		shares[i-1] = new(SignShare)
 		shares[i-1].Index = i
 	}
 	i := int64(0)
@@ -192,7 +193,7 @@ func testIntegration(t *testing.T, algo crypto.Hash, priv *rsa.PrivateKey, thres
 		t.Fatal(err)
 	}
 
-	signshares := make([]SignShare, threshold)
+	signshares := make([]*SignShare, threshold)
 
 	for i := uint(0); i < threshold; i++ {
 		signshares[i], err = keys[i].Sign(rand.Reader, pub, msgPH, true)
@@ -308,7 +309,7 @@ func benchmarkSignCombineHelper(randSource io.Reader, parallel bool, b *testing.
 		b.Fatal(err)
 	}
 
-	signshares := make([]SignShare, threshold)
+	signshares := make([]*SignShare, threshold)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for i := uint(0); i < threshold; i++ {

--- a/tss/rsa/signShare_test.go
+++ b/tss/rsa/signShare_test.go
@@ -46,17 +46,23 @@ func unmarshalSignShareTest(t *testing.T, input []byte) {
 
 func TestMarshallSignShare(t *testing.T) {
 	marshalTestSignShare(SignShare{
-		xi:        big.NewInt(10),
-		Index:     30,
-		Players:   16,
-		Threshold: 18,
+		xi: big.NewInt(10),
+		share: share{
+			ModulusLength: 256,
+			Index:         30,
+			Players:       18,
+			Threshold:     16,
+		},
 	}, t)
 
 	marshalTestSignShare(SignShare{
-		xi:        big.NewInt(0),
-		Index:     0,
-		Players:   0,
-		Threshold: 0,
+		xi: big.NewInt(0),
+		share: share{
+			ModulusLength: 256,
+			Index:         1,
+			Players:       2,
+			Threshold:     1,
+		},
 	}, t)
 
 	unmarshalSignShareTest(t, []byte{})

--- a/tss/rsa/util.go
+++ b/tss/rsa/util.go
@@ -1,7 +1,10 @@
 package rsa
 
 import (
+	"fmt"
 	"math/big"
+
+	"golang.org/x/crypto/cryptobyte"
 )
 
 func calculateDelta(l int64) *big.Int {
@@ -9,4 +12,50 @@ func calculateDelta(l int64) *big.Int {
 	delta := big.Int{}
 	delta.MulRange(1, l)
 	return &delta
+}
+
+type share struct {
+	ModulusLength uint // Size of RSA modulus in bits.
+	Threshold     uint // Minimum number of shares to produce a signature.
+	Players       uint // Total number of signers.
+	Index         uint // Non-zero identifier of the signer.
+}
+
+func (s share) String() string {
+	return fmt.Sprintf("(t=%v,n=%v)-RSA-%v index: %v", s.Threshold, s.Players, s.ModulusLength, s.Index)
+}
+
+func (s *share) Marshal(b *cryptobyte.Builder) error {
+	b.AddUint16(uint16(s.ModulusLength))
+	b.AddUint16(uint16(s.Threshold))
+	b.AddUint16(uint16(s.Players))
+	b.AddUint16(uint16(s.Index))
+	return nil
+}
+
+func (s *share) ReadValue(r *cryptobyte.String) bool {
+	var ModulusLength, Index, Threshold, Players uint16
+	ok := r.ReadUint16(&ModulusLength) &&
+		r.ReadUint16(&Threshold) &&
+		r.ReadUint16(&Players) &&
+		r.ReadUint16(&Index)
+	if !ok {
+		return false
+	}
+
+	err := validateParams(uint(Players), uint(Threshold))
+	if err != nil {
+		panic(err)
+	}
+
+	if Index == 0 {
+		panic("index cannot be zero")
+	}
+
+	s.ModulusLength = uint(ModulusLength)
+	s.Threshold = uint(Threshold)
+	s.Players = uint(Players)
+	s.Index = uint(Index)
+
+	return true
 }

--- a/zk/qndleq/qndleq_test.go
+++ b/zk/qndleq/qndleq_test.go
@@ -30,7 +30,8 @@ func TestProve(t *testing.T) {
 
 		proof, err := qndleq.Prove(rand.Reader, x, g, gx, h, hx, N, SecParam)
 		test.CheckNoErr(t, err, "failed to generate proof")
-		test.CheckOk(proof.Verify(g, gx, h, hx, N), "failed to verify", t)
+		test.CheckMarshal(t, proof, new(qndleq.Proof))
+		test.CheckOk(proof.Verify(g, gx, h, hx, N, SecParam), "failed to verify", t)
 	}
 }
 
@@ -78,7 +79,7 @@ func Benchmark_qndleq(b *testing.B) {
 
 	b.Run("Verify", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			_ = proof.Verify(g, gx, h, hx, N)
+			_ = proof.Verify(g, gx, h, hx, N, SecParam)
 		}
 	})
 }


### PR DESCRIPTION
Use cryptoybyte to leverage TLS syntax. Serialization of KeyShare and SignShares.

Staked on top of #453 