### PR TITLE
Bumping Go version for CI jobs.

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        GOVER: ['1.20', '1.19']
+        GOVER: ['1.21.1', '1.20.8']
     steps:
       - name: Setup Go-${{ matrix.GOVER }}
         uses: actions/setup-go@v3
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        CFG: [[arm64, arm64v8, '1.20']]
+        CFG: [[arm64, arm64v8, '1.21.1']]
     steps:
       - uses: actions/checkout@v3
       - name: Enabling Docker Experimental
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21.1'
       - name: Build as Static
         run: make circl_static
       - name: Build as Plugin
@@ -88,7 +88,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21.1'
       - name: Produce Coverage
         run: go test -coverprofile=./coverage.txt ./...
       - name: Upload Codecov
@@ -108,7 +108,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21.1'
       - name: Building
         run: go build -v ./...
       - name: Testing


### PR DESCRIPTION
Bumping up to versions 1.21 and 1.20