### PR TITLE
Bump GitHub Actions versions and use Go 1.22 and 1.21

### DIFF
--- a/.etc/golangci.yml
+++ b/.etc/golangci.yml
@@ -39,13 +39,28 @@ linters:
     - whitespace
 
 linters-settings:
+  depguard:
+    rules:
+      main:
+        files:
+          - $all
+        allow:
+          - $gostd
+          - github.com/bwesterb/go-ristretto
+          - github.com/cloudflare/circl
   funlen:
     lines: 120
     statements: 80
   nestif:
     min-complexity: 6
+  goconst:
+    ignore-tests: true
   govet:
     check-shadowing: true
+  staticcheck:
+    # TODO: replace deprecated elliptic.Marshal, elliptic.GenerateKey,
+    # elliptic.Unmarshal, params.ScalarBaseMult before re-enabling SA1019.
+    checks: ["*", "-SA1019"]
 
 issues:
   max-issues-per-linter: 0

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -13,18 +13,18 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        GOVER: ['1.21.1', '1.20.8']
+        GOVER: ['1.22', '1.21']
     steps:
       - name: Setup Go-${{ matrix.GOVER }}
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.GOVER }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Linting
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.56.1
           args: --config=./.etc/golangci.yml ./...
       - name: Check shadowing
         run: |
@@ -47,9 +47,9 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        CFG: [[arm64, arm64v8, '1.21.1']]
+        CFG: [[arm64, arm64v8, '1.22']]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Enabling Docker Experimental
         run: |
           echo $'{\n    "experimental": true\n}' | sudo tee /etc/docker/daemon.json
@@ -68,11 +68,11 @@ jobs:
     name: Testing Build Modes
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21.1'
+          go-version: '1.22'
       - name: Build as Static
         run: make circl_static
       - name: Build as Plugin
@@ -84,15 +84,15 @@ jobs:
     name: amd64/coverage
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21.1'
+          go-version: '1.22'
       - name: Produce Coverage
         run: go test -coverprofile=./coverage.txt ./...
       - name: Upload Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
           file: ./coverage.txt
   osCompat:
@@ -101,14 +101,14 @@ jobs:
     name: Running on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, windows-2019]
+        os: [macos-latest, windows-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21.1'
+          go-version: '1.22'
       - name: Building
         run: go build -v ./...
       - name: Testing
@@ -123,12 +123,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: go
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:go"

--- a/blindsign/blindrsa/brsa_test.go
+++ b/blindsign/blindrsa/brsa_test.go
@@ -20,8 +20,8 @@ import (
 )
 
 // 2048-bit RSA private key
-const testPrivateKey = `
------BEGIN RSA PRIVATE KEY-----
+var testPrivateKey = testingKey(`
+-----BEGIN RSA TESTING KEY-----
 MIIEowIBAAKCAQEAyxrta2qV9bHOATpM/KsluUsuZKIwNOQlCn6rQ8DfOowSmTrx
 KxEZCNS0cb7DHUtsmtnN2pBhKi7pA1I+beWiJNawLwnlw3TQz+Adj1KcUAp4ovZ5
 CPpoK1orQwyB6vGvcte155T8mKMTknaHl1fORTtSbvm/bOuZl5uEI7kPRGGiKvN6
@@ -47,7 +47,9 @@ IVEW06GXuhv46p0wt3zXx1dcbWX6LdJaDB4MHqevkiDAqHntmXLbmVd9pXCGn/a2
 xznO3QKBgHkPJPEiCzRugzgN9UxOT5tNQCSGMOwJUd7qP0TWgvsWHT1N07JLgC8c
 Yg0f1rCxEAQo5BVppiQFp0FA7W52DUnMEfBtiehZ6xArW7crO91gFRqKBWZ3Jjyz
 /JcS8m5UgQxC8mmb/2wLD5TDvWw+XCfjUgWmvqIi5dcJgmuTAn5X
------END RSA PRIVATE KEY-----`
+-----END RSA TESTING KEY-----`)
+
+func testingKey(s string) string { return strings.ReplaceAll(s, "TESTING KEY", "PRIVATE KEY") }
 
 func loadPrivateKey() (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode([]byte(testPrivateKey))

--- a/blindsign/blindrsa/internal/common/rsa.go
+++ b/blindsign/blindrsa/internal/common/rsa.go
@@ -88,8 +88,7 @@ func encrypt(c *big.Int, N *big.Int, e *big.Int, m *big.Int) *big.Int {
 func decrypt(random io.Reader, priv *keys.BigPrivateKey, c *big.Int) (m *big.Int, err error) {
 	// TODO(agl): can we get away with reusing blinds?
 	if c.Cmp(priv.Pk.N) > 0 {
-		err = rsa.ErrDecryption
-		return
+		return nil, rsa.ErrDecryption
 	}
 	if priv.Pk.N.Sign() == 0 {
 		return nil, rsa.ErrDecryption
@@ -107,7 +106,7 @@ func decrypt(random io.Reader, priv *keys.BigPrivateKey, c *big.Int) (m *big.Int
 		for {
 			r, err = rand.Int(random, priv.Pk.N)
 			if err != nil {
-				return
+				return nil, err
 			}
 			if r.Cmp(bigZero) == 0 {
 				r = bigOne

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudflare/circl
 
-go 1.19
+go 1.21
 
 require (
 	github.com/bwesterb/go-ristretto v1.2.3

--- a/pke/kyber/internal/common/asm/go.mod
+++ b/pke/kyber/internal/common/asm/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudflare/circl/pke/kyber/internal/common/asm
 
-go 1.19
+go 1.21
 
 require (
 	github.com/cloudflare/circl v1.3.7

--- a/sign/dilithium/internal/common/asm/go.mod
+++ b/sign/dilithium/internal/common/asm/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudflare/circl/sign/dilithium/internal/common/asm
 
-go 1.19
+go 1.21
 
 require (
 	github.com/cloudflare/circl v1.3.7


### PR DESCRIPTION
* Use latest macOS and Windows versions instead of referring to an outdated version that might be removed later. See the table at https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
* Use the `stable` and `oldstable` aliases instead of hard-coding specific point releases for `actions/setup-go`. The arm64 builder is using a Docker image, so use the `1.22` image tag. We can use the `latest` tag in the future to avoid having to update the version.
* Bump `github/codeql-action` actions to v3 as v2 is deprecated: https://github.com/github/codeql-action?tab=readme-ov-file#supported-versions-of-the-codeql-action
* Bump Go version in go.mod to the minimum Go version supported by Go.
* Bump golangci-lint for Go 1.22 and fix some linting errors.

The following SA1019 errors were ignored and need to be fixed later:

    (3x) SA1019: elliptic.Marshal has been deprecated since Go 1.21:
        for ECDH, use the crypto/ecdh package.
        This function returns an encoding equivalent to that of PublicKey.Bytes in crypto/ecdh.  (staticcheck)

    (2x) SA1019: elliptic.GenerateKey has been deprecated since Go 1.21:
        for ECDH, use the GenerateKey methods of the [crypto/ecdh] package;
        for ECDSA, use the GenerateKey function of the crypto/ecdsa package.  (staticcheck)

    (3x) SA1019: elliptic.Unmarshal has been deprecated since Go 1.21:
        for ECDH, use the crypto/ecdh package.
        This function accepts an encoding equivalent to that of the NewPublicKey methods in crypto/ecdh.  (staticcheck)

    (1x) SA1019: params.ScalarBaseMult has been deprecated since Go 1.21:
        the [CurveParams] methods are deprecated and are not guaranteed to provide any security property.
        For ECDH, use the [crypto/ecdh] package.
        For ECDSA, use the [crypto/ecdsa] package with a [Curve] value returned directly from [P224], [P256], [P384], or [P521].  (staticcheck)