### PR TITLE
Explicitly installs Go with version before CodeQL analysis.

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -124,6 +124,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:


### PR DESCRIPTION
Report from CodeQL

```
Newer Go version needed
[View workflow run](https://github.com/cloudflare/circl/actions/runs/7938355244)
Version v1.20.14 of Go is installed, but this is lower than v1.21 required by your project's go.mod. [Install a newer version of Go before analyzing your project](https://github.com/actions/setup-go#basic).
```