### PR TITLE
Bumps golangci-lint action

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -124,6 +124,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Linting
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.56.1
+          version: v1.56.2
           args: --config=./.etc/golangci.yml ./...
       - name: Check shadowing
         run: |


### PR DESCRIPTION
Bumps golangci-lint action so it fixes errors on the node version used internally.