### PR TITLE
hpke: relax seed size check in DeriveKeyPair

### DIFF
--- a/hpke/hybridkem.go
+++ b/hpke/hybridkem.go
@@ -160,9 +160,6 @@ func (k *hybridKEMPubKey) Equal(pk kem.PublicKey) bool {
 func (h hybridKEM) DeriveKeyPair(seed []byte) (kem.PublicKey, kem.PrivateKey) {
 	// Implementation based on
 	// https://www.ietf.org/archive/id/draft-irtf-cfrg-hpke-07.html#name-derivekeypair
-	if len(seed) != h.SeedSize() {
-		panic(kem.ErrSeedSize)
-	}
 
 	outputSeedSize := h.kemA.SeedSize() + h.kemB.SeedSize()
 	dkpPrk := h.labeledExtract([]byte(""), []byte("dkp_prk"), seed)

--- a/hpke/shortkem.go
+++ b/hpke/shortkem.go
@@ -44,9 +44,6 @@ func (s shortKEM) calcDH(dh []byte, sk kem.PrivateKey, pk kem.PublicKey) error {
 func (s shortKEM) DeriveKeyPair(seed []byte) (kem.PublicKey, kem.PrivateKey) {
 	// Implementation based on
 	// https://www.ietf.org/archive/id/draft-irtf-cfrg-hpke-07.html#name-derivekeypair
-	if len(seed) != s.SeedSize() {
-		panic(kem.ErrSeedSize)
-	}
 
 	bitmask := byte(0xFF)
 	if s.Params().BitSize == 521 {

--- a/hpke/xkem.go
+++ b/hpke/xkem.go
@@ -55,9 +55,6 @@ func (x xKEM) calcDH(dh []byte, sk kem.PrivateKey, pk kem.PublicKey) error {
 func (x xKEM) DeriveKeyPair(seed []byte) (kem.PublicKey, kem.PrivateKey) {
 	// Implementation based on
 	// https://www.ietf.org/archive/id/draft-irtf-cfrg-hpke-07.html#name-derivekeypair
-	if len(seed) != x.SeedSize() {
-		panic(kem.ErrSeedSize)
-	}
 	sk := &xKEMPrivKey{scheme: x, priv: make([]byte, x.size)}
 	dkpPrk := x.labeledExtract([]byte(""), []byte("dkp_prk"), seed)
 	bytes := x.labeledExpand(


### PR DESCRIPTION
RFC 9180 section 7.1.3 says:

> For a given KEM, the ikm parameter given to DeriveKeyPair()
> SHOULD have length at least Nsk, and SHOULD have at least Nsk
> bytes of entropy.

Thus, it is not a requirement for HPKE to pass a seed with a fixed size. Protocols such as MLS rely on this.

Closes: https://github.com/cloudflare/circl/issues/486