### PR TITLE
Add ML-KEM decapsulation key check.

### DIFF
--- a/kem/kem.go
+++ b/kem/kem.go
@@ -113,6 +113,9 @@ var (
 	// ErrPubKey is the error used if the provided public key is invalid.
 	ErrPubKey = errors.New("invalid public key")
 
+	// ErrPrivKey is the error used if the provided private key is invalid.
+	ErrPrivKey = errors.New("invalid private key")
+
 	// ErrCipherText is the error used if the provided ciphertext is invalid.
 	ErrCipherText = errors.New("invalid ciphertext")
 )


### PR DESCRIPTION
Described in section 7.3 of FIPS 203.

The check is only required if the private key is from an untrusted source. We do not distinguish between a trusted and untrusted source in the current API, so we'll perform the check every time we unmarshal the private key.