### PR TITLE
sign/mldsa: Add test for ML-DSA signature verification.

### DIFF
--- a/sign/dilithium/templates/acvp.templ.go
+++ b/sign/dilithium/templates/acvp.templ.go
@@ -53,6 +53,7 @@ func TestACVP(t *testing.T) {
 	for _, sub := range []string{
 		"keyGen",
 		"sigGen",
+		"sigVer",
 	} {
 		t.Run(sub, func(t *testing.T) {
 			testACVP(t, sub)
@@ -254,7 +255,7 @@ func testACVP(t *testing.T, sub string) {
 					t.Fatal(err)
 				}
 
-				passed2 := scheme.Verify(pk, test.Message, test.Signature, nil)
+				passed2 := unsafeVerifyInternal(pk.(*PublicKey), test.Message, test.Signature)
 				if passed2 != result.TestPassed {
 					t.Fatalf("verification %v ≠ %v", passed2, result.TestPassed)
 				}

--- a/sign/dilithium/templates/pkg.templ.go
+++ b/sign/dilithium/templates/pkg.templ.go
@@ -121,12 +121,23 @@ func (sk *PrivateKey) unsafeSignInternal(msg []byte, rnd [32]byte) []byte {
 	internal.SignTo(
 		(*internal.PrivateKey)(sk),
 		func (w io.Writer) {
-			w.Write(msg)
+			_, _ = w.Write(msg)
 		},
 		rnd,
 		ret[:],
 	)
 	return ret[:]
+}
+
+// Do not use. Implements ML-DSA.Verify_internal used for compatibility tests.
+func unsafeVerifyInternal(pk *PublicKey, msg, sig []byte) bool {
+	return internal.Verify(
+		(*internal.PublicKey)(pk),
+		func(w io.Writer) {
+			_, _ = w.Write(msg)
+		},
+		sig,
+	)
 }
 {{- end }}
 

--- a/sign/mldsa/mldsa44/acvp_test.go
+++ b/sign/mldsa/mldsa44/acvp_test.go
@@ -49,6 +49,7 @@ func TestACVP(t *testing.T) {
 	for _, sub := range []string{
 		"keyGen",
 		"sigGen",
+		"sigVer",
 	} {
 		t.Run(sub, func(t *testing.T) {
 			testACVP(t, sub)
@@ -250,7 +251,7 @@ func testACVP(t *testing.T, sub string) {
 					t.Fatal(err)
 				}
 
-				passed2 := scheme.Verify(pk, test.Message, test.Signature, nil)
+				passed2 := unsafeVerifyInternal(pk.(*PublicKey), test.Message, test.Signature)
 				if passed2 != result.TestPassed {
 					t.Fatalf("verification %v ≠ %v", passed2, result.TestPassed)
 				}

--- a/sign/mldsa/mldsa44/dilithium.go
+++ b/sign/mldsa/mldsa44/dilithium.go
@@ -88,12 +88,23 @@ func (sk *PrivateKey) unsafeSignInternal(msg []byte, rnd [32]byte) []byte {
 	internal.SignTo(
 		(*internal.PrivateKey)(sk),
 		func(w io.Writer) {
-			w.Write(msg)
+			_, _ = w.Write(msg)
 		},
 		rnd,
 		ret[:],
 	)
 	return ret[:]
+}
+
+// Do not use. Implements ML-DSA.Verify_internal used for compatibility tests.
+func unsafeVerifyInternal(pk *PublicKey, msg, sig []byte) bool {
+	return internal.Verify(
+		(*internal.PublicKey)(pk),
+		func(w io.Writer) {
+			_, _ = w.Write(msg)
+		},
+		sig,
+	)
 }
 
 // Verify checks whether the given signature by pk on msg is valid.

--- a/sign/mldsa/mldsa65/acvp_test.go
+++ b/sign/mldsa/mldsa65/acvp_test.go
@@ -49,6 +49,7 @@ func TestACVP(t *testing.T) {
 	for _, sub := range []string{
 		"keyGen",
 		"sigGen",
+		"sigVer",
 	} {
 		t.Run(sub, func(t *testing.T) {
 			testACVP(t, sub)
@@ -250,7 +251,7 @@ func testACVP(t *testing.T, sub string) {
 					t.Fatal(err)
 				}
 
-				passed2 := scheme.Verify(pk, test.Message, test.Signature, nil)
+				passed2 := unsafeVerifyInternal(pk.(*PublicKey), test.Message, test.Signature)
 				if passed2 != result.TestPassed {
 					t.Fatalf("verification %v ≠ %v", passed2, result.TestPassed)
 				}

--- a/sign/mldsa/mldsa65/dilithium.go
+++ b/sign/mldsa/mldsa65/dilithium.go
@@ -88,12 +88,23 @@ func (sk *PrivateKey) unsafeSignInternal(msg []byte, rnd [32]byte) []byte {
 	internal.SignTo(
 		(*internal.PrivateKey)(sk),
 		func(w io.Writer) {
-			w.Write(msg)
+			_, _ = w.Write(msg)
 		},
 		rnd,
 		ret[:],
 	)
 	return ret[:]
+}
+
+// Do not use. Implements ML-DSA.Verify_internal used for compatibility tests.
+func unsafeVerifyInternal(pk *PublicKey, msg, sig []byte) bool {
+	return internal.Verify(
+		(*internal.PublicKey)(pk),
+		func(w io.Writer) {
+			_, _ = w.Write(msg)
+		},
+		sig,
+	)
 }
 
 // Verify checks whether the given signature by pk on msg is valid.

--- a/sign/mldsa/mldsa87/acvp_test.go
+++ b/sign/mldsa/mldsa87/acvp_test.go
@@ -49,6 +49,7 @@ func TestACVP(t *testing.T) {
 	for _, sub := range []string{
 		"keyGen",
 		"sigGen",
+		"sigVer",
 	} {
 		t.Run(sub, func(t *testing.T) {
 			testACVP(t, sub)
@@ -250,7 +251,7 @@ func testACVP(t *testing.T, sub string) {
 					t.Fatal(err)
 				}
 
-				passed2 := scheme.Verify(pk, test.Message, test.Signature, nil)
+				passed2 := unsafeVerifyInternal(pk.(*PublicKey), test.Message, test.Signature)
 				if passed2 != result.TestPassed {
 					t.Fatalf("verification %v ≠ %v", passed2, result.TestPassed)
 				}

--- a/sign/mldsa/mldsa87/dilithium.go
+++ b/sign/mldsa/mldsa87/dilithium.go
@@ -88,12 +88,23 @@ func (sk *PrivateKey) unsafeSignInternal(msg []byte, rnd [32]byte) []byte {
 	internal.SignTo(
 		(*internal.PrivateKey)(sk),
 		func(w io.Writer) {
-			w.Write(msg)
+			_, _ = w.Write(msg)
 		},
 		rnd,
 		ret[:],
 	)
 	return ret[:]
+}
+
+// Do not use. Implements ML-DSA.Verify_internal used for compatibility tests.
+func unsafeVerifyInternal(pk *PublicKey, msg, sig []byte) bool {
+	return internal.Verify(
+		(*internal.PublicKey)(pk),
+		func(w io.Writer) {
+			_, _ = w.Write(msg)
+		},
+		sig,
+	)
 }
 
 // Verify checks whether the given signature by pk on msg is valid.


### PR DESCRIPTION
Adds testing for internal verification function.

Closes #516 