### PR TITLE
kem/hybrid: ensure X25519 hybrids fails with low order points

### DIFF
--- a/kem/hybrid/ckem.go
+++ b/kem/hybrid/ckem.go
@@ -159,6 +159,9 @@ func (pk *cPublicKey) X(sk *cPrivateKey) []byte {
 
 	sharedKey, err := sk.key.ECDH(pk.key)
 	if err != nil {
+		// ECDH cannot fail for NIST curves as NewPublicKey rejects
+		// invalid points and the point in infinity, and NewPrivateKey
+		// rejects invalid scalars and the zero value.
 		panic(err)
 	}
 	return sharedKey

--- a/kem/hybrid/xkem_test.go
+++ b/kem/hybrid/xkem_test.go
@@ -1,0 +1,68 @@
+package hybrid
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/cloudflare/circl/kem"
+)
+
+func mustDecodeString(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// patchHybridWithLowOrderX25519 replaces the last half of the given ciphertext
+// or public key by a 32-byte Curve25519 public key with a point of low order.
+func patchHybridWithLowOrderX25519(hybridKey []byte) {
+	// order 8
+	xPub := mustDecodeString("e0eb7a7c3b41b8ae1656e3faf19fc46ada098deb9c32b1fd866205165f49b800")
+	copy(hybridKey[len(hybridKey)-len(xPub):], xPub)
+}
+
+func patchHybridPublicKeyWithLowOrderX25519(pub kem.PublicKey) (kem.PublicKey, error) {
+	packed, err := pub.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	patchHybridWithLowOrderX25519(packed)
+	return pub.Scheme().UnmarshalBinaryPublicKey(packed)
+}
+
+func TestLowOrderX25519PointEncapsulate(t *testing.T) {
+	scheme := X25519MLKEM768()
+	pk, _, err := scheme.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("X25519MLKEM768 keygen: %s", err)
+	}
+	badPk, err := patchHybridPublicKeyWithLowOrderX25519(pk)
+	if err != nil {
+		t.Fatalf("patching X25519 key failed: %s", err)
+	}
+	_, _, err = scheme.Encapsulate(badPk)
+	want := kem.ErrPubKey
+	if err != want {
+		t.Fatalf("Encapsulate error: expected %v; got %v", want, err)
+	}
+}
+
+func TestLowOrderX25519PointDecapsulate(t *testing.T) {
+	scheme := X25519MLKEM768()
+	pk, sk, err := scheme.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("X25519MLKEM768 keygen: %s", err)
+	}
+	ct, _, err := scheme.Encapsulate(pk)
+	if err != nil {
+		t.Fatalf("Encapsulate failed: %s", err)
+	}
+	patchHybridWithLowOrderX25519(ct)
+	_, err = scheme.Decapsulate(sk, ct)
+	want := kem.ErrPubKey
+	if err != want {
+		t.Fatalf("Decapsulate error: expected %v; got %v", want, err)
+	}
+}

--- a/kem/xwing/xwing.go
+++ b/kem/xwing/xwing.go
@@ -252,6 +252,9 @@ func (pk *PublicKey) EncapsulateTo(ct, ss, seed []byte) {
 	copy(ekx[:], seed[32:])
 
 	x25519.KeyGen(&ctx, &ekx)
+	// A peer public key with low order points results in an all-zeroes
+	// shared secret. Ignored for now pending clarification in the spec,
+	// https://github.com/dconnolly/draft-connolly-cfrg-xwing-kem/issues/28
 	x25519.Shared(&ssx, &ekx, &pk.x)
 	pk.m.EncapsulateTo(ct[:mlkem768.CiphertextSize], ssm[:], seedm[:])
 
@@ -283,6 +286,9 @@ func (sk *PrivateKey) DecapsulateTo(ss, ct []byte) {
 	copy(ctx[:], ct[mlkem768.CiphertextSize:])
 
 	sk.m.DecapsulateTo(ssm[:], ctm)
+	// A peer public key with low order points results in an all-zeroes
+	// shared secret. Ignored for now pending clarification in the spec,
+	// https://github.com/dconnolly/draft-connolly-cfrg-xwing-kem/issues/28
 	x25519.Shared(&ssx, &sk.x, &ctx)
 	combiner(ss, &ssm, &ssx, &ctx, &sk.xpk)
 }


### PR DESCRIPTION
X25519 public keys with low order points result in an all-zeroes shared secret. Ensure that hybrids with X25519 and X448 fail during Encapsulate and Decapsulate when the peer provides such a garbage public key.
___
I discovered this while rebasing our Go fork on Go 1.24 which upgraded the BoGo test suite as part of implementing X25519MLKEM768: https://github.com/golang/go/commit/4b7f7cd87dfcbc17861c908b20a6101e5915ef59#diff-db7320adf5b82005863ef324a30e91235d0268afe79856722226022f3afc2611

That upgrade pulled in this change that adds extra tests for key shares: https://github.com/google/boringssl/commit/ed95627d2f074b6a8636fc8eaaa595903dbfcc9

Without this fix, these `crypto/tls` tests would fail as the TLS handshake continues instead of aborting:
```
TestBogoSuite/CurveTest-Invalid-LowOrderX25519Point-Server-MLKEM-TLS13
TestBogoSuite/CurveTest-Invalid-LowOrderX25519Point-Client-MLKEM-TLS13
```

I don't think this is a security issue, garbage in, garbage out. Nevertheless, it doesn't hurt to add the extra checks.