### PR TITLE
.github: Use native ARM64 builders instead of QEMU

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -41,27 +41,23 @@ jobs:
         run: go build -v ./...
       - name: Testing
         run: go test -v -count=1 ./...
-  exotic_job:
-    name: Go-${{matrix.CFG[2]}}/${{matrix.CFG[0]}}
+  arm64_job:
+    name: Go-${{matrix.GOVER}}/arm64
     needs: [amd64_job]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
-        CFG: [[arm64, arm64v8, '1.22']]
+        GOVER: ['1.23', '1.22']
     steps:
       - uses: actions/checkout@v4
-      - name: Enabling Docker Experimental
-        run: |
-          echo $'{\n    "experimental": true\n}' | sudo tee /etc/docker/daemon.json
-          sudo service docker restart
-      - name: Pulling Images
-        run: |
-          docker pull -q multiarch/qemu-user-static
-          docker pull -q --platform linux/${{matrix.CFG[0]}} ${{matrix.CFG[1]}}/golang:${{matrix.CFG[2]}}
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - name: Setup Go-${{ matrix.GOVER }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.GOVER }}
+      - name: Building
+        run: go build -v ./...
       - name: Testing
-        run: |
-          docker run --rm --platform linux/${{matrix.CFG[0]}} -v `pwd`:`pwd` -w `pwd` ${{matrix.CFG[1]}}/golang:${{matrix.CFG[2]}} go test -v ./...
+        run: go test -v -count=1 ./...
   build_modes:
     needs: [amd64_job]
     runs-on: ubuntu-22.04


### PR DESCRIPTION
The QEMU builder sporadically crashes in gcc. Since there are now native ARM64 build agents available, use that instead. Re-enable Go 1.23 for ARM64, the original Go 1.23 incompatibility with QEMU got resolved.
___
This should prevent flaky builds such as:
- https://github.com/cloudflare/circl/actions/runs/13960263989/job/39080251377 (#540)
- https://github.com/cloudflare/circl/actions/runs/13989058956/job/39168905189 (#541)