### PR TITLE
Fixes several errors on twisted Edwards curves.

### DIFF
--- a/dh/curve4q/curve4Q.go
+++ b/dh/curve4q/curve4Q.go
@@ -20,8 +20,10 @@ func KeyGen(public, secret *Key) {
 func Shared(shared, secret, public *Key) bool {
 	var P, Q fourq.Point
 	ok := P.Unmarshal((*[Size]byte)(public))
+	if !ok {
+		return false
+	}
 	Q.ScalarMult((*[Size]byte)(secret), &P)
 	Q.Marshal((*[Size]byte)(shared))
-	ok = ok && Q.IsOnCurve()
-	return ok
+	return !Q.IsIdentity() && Q.IsOnCurve()
 }

--- a/dh/curve4q/curve4Q_test.go
+++ b/dh/curve4q/curve4Q_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/cloudflare/circl/ecc/fourq"
 	"github.com/cloudflare/circl/internal/test"
 )
 
@@ -35,6 +36,60 @@ func TestDH(t *testing.T) {
 			test.ReportError(t, got, want, secretAlice, secretBob)
 		}
 	}
+}
+
+func TestDHLowOrder(t *testing.T) {
+	var secretAlice, validPublicAlice, invalidPublicAlice, sharedAlice Key
+	var secretBob, publicBob, sharedBob Key
+
+	t.Run("zeroPoint", func(t *testing.T) {
+		testTimes := 1 << 10
+
+		for i := 0; i < testTimes; i++ {
+			_, _ = rand.Read(secretAlice[:])
+			_, _ = rand.Read(secretBob[:])
+
+			KeyGen(&validPublicAlice, &secretAlice)
+			KeyGen(&publicBob, &secretBob)
+
+			zeroPoint := fourq.Point{}
+			zeroPoint.SetIdentity()
+			zeroPoint.Marshal((*[Size]byte)(&invalidPublicAlice))
+
+			ok := Shared(&sharedAlice, &secretAlice, &publicBob)
+			test.CheckOk(ok, "shared must not fail", t)
+
+			ok = Shared(&sharedBob, &secretBob, &validPublicAlice)
+			test.CheckOk(ok, "shared must not fail", t)
+
+			invalid := Shared(&sharedBob, &secretBob, &invalidPublicAlice)
+			test.CheckOk(!invalid, "shared must fail", t)
+		}
+	})
+
+	t.Run("lowOrderPoint", func(t *testing.T) {
+		KeyGen(&validPublicAlice, &secretAlice)
+		KeyGen(&publicBob, &secretBob)
+
+		// Point of order 56
+		lowOrderPoint := fourq.Point{
+			X: fourq.Fq{
+				fourq.Fp{0xc0, 0xe5, 0x21, 0x04, 0xaa, 0xe1, 0x93, 0xd8, 0x9b, 0x50, 0x42, 0x54, 0xd6, 0x46, 0x86, 0x74},
+				fourq.Fp{0x21, 0x25, 0x4d, 0x9a, 0xda, 0x8f, 0xad, 0x28, 0xa2, 0x3d, 0xfd, 0x02, 0x13, 0xea, 0xd2, 0x56},
+			},
+			Y: fourq.Fq{
+				fourq.Fp{0xaf, 0x71, 0xe4, 0x3b, 0x22, 0x21, 0x41, 0xef, 0x12, 0xba, 0x67, 0x02, 0x57, 0x1, 0xe5, 0x58},
+				fourq.Fp{0x0e, 0x1a, 0xf5, 0xe5, 0xb8, 0x24, 0x9c, 0xe0, 0xed, 0xc3, 0xc4, 0x69, 0x7, 0x32, 0x8e, 0x2c},
+			},
+		}
+
+		ok := lowOrderPoint.IsOnCurve()
+		test.CheckOk(ok, "point is on curve", t)
+
+		lowOrderPoint.Marshal((*[Size]byte)(&invalidPublicAlice))
+		invalid := Shared(&sharedBob, &secretBob, &invalidPublicAlice)
+		test.CheckOk(!invalid, "shared must fail", t)
+	})
 }
 
 func BenchmarkDH(b *testing.B) {

--- a/ecc/fourq/curve.go
+++ b/ecc/fourq/curve.go
@@ -12,6 +12,8 @@ const Size = 32
 // Point represents an affine point of the curve. The identity is (0,1).
 type Point struct{ X, Y Fq }
 
+func (P Point) String() string { return "(x: " + P.X.String() + ", y: " + P.Y.String() + ")" }
+
 // CurveParams contains the parameters of the elliptic curve.
 type CurveParams struct {
 	Name string   // The canonical name of the curve.

--- a/ecc/fourq/point_test.go
+++ b/ecc/fourq/point_test.go
@@ -189,6 +189,23 @@ func TestScalarMult(t *testing.T) {
 			}
 		}
 	})
+	t.Run("unmarshal-faulty-point", func(t *testing.T) {
+		// This test demonstrates that it is possible to find points which are unmarshalled
+		// successfully, but are not on the curve.
+		var marshalledPoint [Size]byte
+		for i := 0; i < testTimes; i++ {
+			_, _ = rand.Read(marshalledPoint[:])
+			unmarshalledP := Point{}
+			ok := unmarshalledP.Unmarshal(&marshalledPoint)
+			isOnCurve := unmarshalledP.IsOnCurve()
+			switch true {
+			case ok && !isOnCurve:
+				t.Fatalf("unmarshal ok, but not on curve: %v\n", unmarshalledP)
+			case !ok && isOnCurve:
+				t.Fatalf("unmarshal failed with a point on curve: %v\n", unmarshalledP)
+			}
+		}
+	})
 }
 
 func TestScalar(t *testing.T) {

--- a/ecc/fourq/point_test.go
+++ b/ecc/fourq/point_test.go
@@ -110,6 +110,7 @@ func TestOddMultiples(t *testing.T) {
 			Q.add(&Tab[j])
 		}
 		// R = (2^6)P == 64P
+		R = P
 		for j := 0; j < 6; j++ {
 			R.double()
 		}
@@ -123,7 +124,7 @@ func TestOddMultiples(t *testing.T) {
 
 func TestScalarMult(t *testing.T) {
 	const testTimes = 1 << 10
-	var P, Q, G pointR1
+	var P, Q pointR1
 	var k [Size]byte
 
 	t.Run("0P=0", func(t *testing.T) {
@@ -163,11 +164,13 @@ func TestScalarMult(t *testing.T) {
 		}
 	})
 	t.Run("mult", func(t *testing.T) {
-		G.X = genX
-		G.Y = genY
+		var G Point
+		G.SetGenerator()
+		var gen pointR1
+		G.toR1(&gen)
 		for i := 0; i < testTimes; i++ {
 			_, _ = rand.Read(k[:])
-			P.ScalarMult(&k, &G)
+			P.ScalarMult(&k, &gen)
 			Q.ScalarBaseMult(&k)
 			got := Q.isEqual(&P)
 			want := true

--- a/ecc/goldilocks/curve.go
+++ b/ecc/goldilocks/curve.go
@@ -18,6 +18,9 @@ func (Curve) Identity() *Point {
 func (Curve) IsOnCurve(P *Point) bool {
 	x2, y2, t, t2, z2 := &fp.Elt{}, &fp.Elt{}, &fp.Elt{}, &fp.Elt{}, &fp.Elt{}
 	rhs, lhs := &fp.Elt{}, &fp.Elt{}
+	// Check z != 0
+	eq0 := !fp.IsZero(&P.z)
+
 	fp.Mul(t, &P.ta, &P.tb)  // t = ta*tb
 	fp.Sqr(x2, &P.x)         // x^2
 	fp.Sqr(y2, &P.y)         // y^2
@@ -27,13 +30,14 @@ func (Curve) IsOnCurve(P *Point) bool {
 	fp.Mul(rhs, t2, &paramD) // dt^2
 	fp.Add(rhs, rhs, z2)     // z^2 + dt^2
 	fp.Sub(lhs, lhs, rhs)    // x^2 + y^2 - (z^2 + dt^2)
-	eq0 := fp.IsZero(lhs)
+	eq1 := fp.IsZero(lhs)
 
 	fp.Mul(lhs, &P.x, &P.y) // xy
 	fp.Mul(rhs, t, &P.z)    // tz
 	fp.Sub(lhs, lhs, rhs)   // xy - tz
-	eq1 := fp.IsZero(lhs)
-	return eq0 && eq1
+	eq2 := fp.IsZero(lhs)
+
+	return eq0 && eq1 && eq2
 }
 
 // Generator returns the generator point.

--- a/ecc/goldilocks/point_test.go
+++ b/ecc/goldilocks/point_test.go
@@ -15,6 +15,19 @@ func randomPoint() *goldilocks.Point {
 	return goldilocks.Curve{}.ScalarBaseMult(&k)
 }
 
+func TestPoint(t *testing.T) {
+	c := goldilocks.Curve{}
+	t.Run("IsOnCurve(ok)", func(t *testing.T) {
+		goodGen := c.Generator()
+		test.CheckOk(c.IsOnCurve(goodGen), "valid point should pass", t)
+	})
+
+	t.Run("IsOnCurve(zero)", func(t *testing.T) {
+		var allZeros goldilocks.Point
+		test.CheckOk(!c.IsOnCurve(&allZeros), "invalid point should be detected", t)
+	})
+}
+
 func TestPointAdd(t *testing.T) {
 	const testTimes = 1 << 10
 	var e goldilocks.Curve

--- a/sign/ed25519/point.go
+++ b/sign/ed25519/point.go
@@ -164,7 +164,7 @@ func (P *pointR1) isEqual(Q *pointR1) bool {
 	fp.Mul(r, r, &P.z)
 	fp.Sub(l, l, r)
 	b = b && fp.IsZero(l)
-	return b
+	return b && !fp.IsZero(&P.z) && !fp.IsZero(&Q.z)
 }
 
 func (P *pointR3) neg() {

--- a/sign/ed25519/point_test.go
+++ b/sign/ed25519/point_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cloudflare/circl/internal/test"
+	"github.com/cloudflare/circl/math/fp25519"
 )
 
 func randomPoint(P *pointR1) {
@@ -16,6 +17,17 @@ func randomPoint(P *pointR1) {
 
 func TestPoint(t *testing.T) {
 	const testTimes = 1 << 10
+
+	t.Run("isEqual", func(t *testing.T) {
+		var valid, invalid pointR1
+		randomPoint(&valid)
+		randomPoint(&invalid)
+		invalid.z = fp25519.Elt{}
+		test.CheckOk(!valid.isEqual(&invalid), "valid point shouldn't match invalid point", t)
+		test.CheckOk(!invalid.isEqual(&valid), "invalid point shouldn't match valid point", t)
+		test.CheckOk(valid.isEqual(&valid), "valid point should match valid point", t)
+		test.CheckOk(!invalid.isEqual(&invalid), "invalid point shouldn't match anything", t)
+	})
 
 	t.Run("add", func(t *testing.T) {
 		var P pointR1


### PR DESCRIPTION
Changes: 
- Fixes validation of points (`IsOnCurve` and `IsEqual` methods) over a twisted Edwards curve. It applies to FourQ, Ed25519 and goldilocks curves.
- Detection of Low Order points for Curve4q DH. 
- Fixes Unmarshalling of FourQ points.


Each pair of commits is 1 test and 1 fix.