### PR TITLE
Optimize pairing product computation by moving exponentiations to G1.

### DIFF
--- a/ecc/bls12381/pair.go
+++ b/ecc/bls12381/pair.go
@@ -72,7 +72,13 @@ func finalExp(g *Gt, f *ff.Fp12) {
 	ff.HardExponentiation(&g.i, c)
 }
 
-// ProdPair calculates the product of pairings, i.e., \Prod_i pair(ni*Pi,Qi).
+// ProdPair calculates the product of pairings:
+//
+//	e = \Prod_i pair(Pi, Qi)^ni
+//	  = \Prod_i pair(ni*Pi, Qi)
+//	  = \Prod_i pair(Pi, ni*Qi)
+//
+// For efficiency, it performs operations in G1.
 func ProdPair(P []*G1, Q []*G2, n []*Scalar) *Gt {
 	if len(P) != len(Q) || len(P) != len(n) {
 		panic("mismatch length of inputs")

--- a/ecc/bls12381/pair.go
+++ b/ecc/bls12381/pair.go
@@ -72,28 +72,32 @@ func finalExp(g *Gt, f *ff.Fp12) {
 	ff.HardExponentiation(&g.i, c)
 }
 
-// ProdPair calculates the product of pairings, i.e., \Prod_i pair(Pi,Qi)^ni.
+// ProdPair calculates the product of pairings, i.e., \Prod_i pair(ni*Pi,Qi).
 func ProdPair(P []*G1, Q []*G2, n []*Scalar) *Gt {
-	if len(P) != len(Q) || len(P) != len(n) {
-		panic("mismatch length of inputs")
-	}
+    if len(P) != len(Q) || len(P) != len(n) {
+        panic("mismatch length of inputs")
+    }
 
-	ei := new(ff.Fp12)
-	mi := new(ff.Fp12)
-	out := new(ff.Fp12)
-	out.SetOne()
+    scaled := make([]*G1, len(P))
+    for i := range P {
+        scaled[i] = new(G1)
+        scaled[i].ScalarMult(n[i], P[i])
+    }
 
-	affineP := affinize(P)
-	for i := range affineP {
-		miller(mi, &affineP[i], Q[i])
-		nb, _ := n[i].MarshalBinary()
-		ei.Exp(mi, nb)
-		out.Mul(out, ei)
-	}
+    affineP := affinize(scaled)
 
-	e := &Gt{}
-	finalExp(e, out)
-	return e
+    mi := new(ff.Fp12)
+    out := new(ff.Fp12)
+    out.SetOne()
+
+    for i := range affineP {
+        miller(mi, &affineP[i], Q[i])
+        out.Mul(out, mi)
+    }
+
+    e := &Gt{}
+    finalExp(e, out)
+    return e
 }
 
 // ProdPairFrac computes the product e(P, Q)^sign where sign is 1 or -1

--- a/ecc/bls12381/pair.go
+++ b/ecc/bls12381/pair.go
@@ -74,30 +74,30 @@ func finalExp(g *Gt, f *ff.Fp12) {
 
 // ProdPair calculates the product of pairings, i.e., \Prod_i pair(ni*Pi,Qi).
 func ProdPair(P []*G1, Q []*G2, n []*Scalar) *Gt {
-    if len(P) != len(Q) || len(P) != len(n) {
-        panic("mismatch length of inputs")
-    }
+	if len(P) != len(Q) || len(P) != len(n) {
+		panic("mismatch length of inputs")
+	}
 
-    scaled := make([]*G1, len(P))
-    for i := range P {
-        scaled[i] = new(G1)
-        scaled[i].ScalarMult(n[i], P[i])
-    }
+	scaled := make([]*G1, len(P))
+	for i := range P {
+		scaled[i] = new(G1)
+		scaled[i].ScalarMult(n[i], P[i])
+	}
 
-    affineP := affinize(scaled)
+	affineP := affinize(scaled)
 
-    mi := new(ff.Fp12)
-    out := new(ff.Fp12)
-    out.SetOne()
+	mi := new(ff.Fp12)
+	out := new(ff.Fp12)
+	out.SetOne()
 
-    for i := range affineP {
-        miller(mi, &affineP[i], Q[i])
-        out.Mul(out, mi)
-    }
+	for i := range affineP {
+		miller(mi, &affineP[i], Q[i])
+		out.Mul(out, mi)
+	}
 
-    e := &Gt{}
-    finalExp(e, out)
-    return e
+	e := &Gt{}
+	finalExp(e, out)
+	return e
 }
 
 // ProdPairFrac computes the product e(P, Q)^sign where sign is 1 or -1


### PR DESCRIPTION
What the title says. :) This version passes all tests and is approximately 2x faster in the benchmarks.
A shorter but slightly slower alternative can be found below. This is joint work with @aniagut.

```
// ProdPair calculates the product of pairings, i.e., \Prod_i pair(ni*Pi,Qi).
func ProdPair(P []*G1, Q []*G2, n []*Scalar) *Gt {
        if len(P) != len(Q) || len(P) != len(n) {
                panic("mismatch length of inputs")
        }

        mi := new(ff.Fp12)
        out := new(ff.Fp12)
        out.SetOne()

        affineP := affinize(P)
        for i := range affineP {
                affineP[i].ScalarMult(n[i], &affineP[i]);
                affineP[i].toAffine();
                miller(mi, &affineP[i], Q[i])
                out.Mul(out, mi)
        }

        e := &Gt{}
        finalExp(e, out)
        return e
}
```