### PR TITLE
ARM64 implementation for poly.PackLe16

### DIFF
--- a/sign/internal/dilithium/arm64.go
+++ b/sign/internal/dilithium/arm64.go
@@ -1,5 +1,5 @@
-//go:build (!amd64 && !arm64) || purego
-// +build !amd64,!arm64 purego
+//go:build arm64 && !purego
+// +build arm64,!purego
 
 package dilithium
 
@@ -32,7 +32,7 @@ func (p *Poly) MulHat(a, b *Poly) {
 
 // Sets p to a + b.  Does not normalize polynomials.
 func (p *Poly) Add(a, b *Poly) {
-	p.addGeneric(a, b)
+	polyAdd(p, a, b)
 }
 
 // Sets p to a - b.
@@ -79,3 +79,6 @@ func (p *Poly) Exceeds(bound uint32) bool {
 func (p *Poly) MulBy2toD(q *Poly) {
 	p.mulBy2toDGeneric(q)
 }
+
+//go:noescape
+func polyAdd(p, a, b *Poly)

--- a/sign/internal/dilithium/arm64.go
+++ b/sign/internal/dilithium/arm64.go
@@ -46,7 +46,11 @@ func (p *Poly) Sub(a, b *Poly) {
 // Writes p whose coefficients are in [0, 16) to buf, which must be of
 // length N/2.
 func (p *Poly) PackLe16(buf []byte) {
-	p.packLe16Generic(buf)
+	// early bounds so we don't have to in assembly code
+	// compiler may inline this func, so it may remove the bounds check
+	_ = buf[PolyLe16Size-1]
+
+	polyPackLe16(p, buf)
 }
 
 // Reduces each of the coefficients to <2q.
@@ -82,3 +86,6 @@ func (p *Poly) MulBy2toD(q *Poly) {
 
 //go:noescape
 func polyAdd(p, a, b *Poly)
+
+//go:noescape
+func polyPackLe16(p *Poly, buf []byte)

--- a/sign/internal/dilithium/arm64.s
+++ b/sign/internal/dilithium/arm64.s
@@ -8,7 +8,7 @@ TEXT ·polyAdd(SB), NOSPLIT|NOFRAME, $0-24
     MOVD    a+8(FP), R1
     MOVD    b+16(FP), R2
 
-    // loop counter (each iterations processes 16 elements so 16 * 16 = 256 = N)
+    // loop counter (each iteration processes 16 elements so 16 * 16 = 256 = N)
     // manually unrolling could also be done, for now skipped
     MOVW    $16, R3
 

--- a/sign/internal/dilithium/arm64.s
+++ b/sign/internal/dilithium/arm64.s
@@ -1,0 +1,29 @@
+//go:build arm64 && !purego
+
+#include "textflag.h"
+
+// func polyAdd(p, a, b *Poly)
+TEXT ·polyAdd(SB), NOSPLIT|NOFRAME, $0-24
+    MOVD    p+0(FP), R0
+    MOVD    a+8(FP), R1
+    MOVD    b+16(FP), R2
+
+    // loop counter (each iterations processes 16 elements so 16 * 16 = 256 = N)
+    // manually unrolling could also be done, for now skipped
+    MOVW    $16, R3
+
+add:
+    VLD1.P  (64)(R1), [V0.S4, V1.S4, V2.S4, V3.S4]
+    VLD1.P  (64)(R2), [V4.S4, V5.S4, V6.S4, V7.S4]
+
+    VADD    V4.S4, V0.S4, V8.S4
+    VADD    V5.S4, V1.S4, V9.S4
+    VADD    V6.S4, V2.S4, V10.S4
+    VADD    V7.S4, V3.S4, V11.S4
+
+    VST1.P  [V8.S4, V9.S4, V10.S4, V11.S4], (64)(R0)
+
+    SUBS    $1, R3, R3
+    BGT     add
+
+    RET

--- a/sign/internal/dilithium/arm64.s
+++ b/sign/internal/dilithium/arm64.s
@@ -12,7 +12,7 @@ TEXT ·polyAdd(SB), NOSPLIT|NOFRAME, $0-24
     // manually unrolling could also be done, for now skipped
     MOVW    $16, R3
 
-add:
+loop:
     VLD1.P  (64)(R1), [V0.S4, V1.S4, V2.S4, V3.S4]
     VLD1.P  (64)(R2), [V4.S4, V5.S4, V6.S4, V7.S4]
 
@@ -24,6 +24,38 @@ add:
     VST1.P  [V8.S4, V9.S4, V10.S4, V11.S4], (64)(R0)
 
     SUBS    $1, R3, R3
-    BGT     add
+    BGT     loop
+
+    RET
+
+
+// func polyPackLe16(p *Poly, buf []byte)
+TEXT ·polyPackLe16(SB), NOSPLIT|NOFRAME, $0-32
+    MOVD    p+0(FP), R0
+    MOVD    buf+8(FP), R1
+
+    MOVW    $8, R3 // loop counter
+    VMOVQ   $0x1c0c180814041000, $0x3c2c382834243020, V15 // lookup table index
+
+loop:
+    VLD4.P  (64)(R0), [V0.S4, V1.S4, V2.S4, V3.S4]
+    VLD4.P  (64)(R0), [V4.S4, V5.S4, V6.S4, V7.S4]
+
+    VSHL    $4, V1.S4, V1.S4
+    VSHL    $4, V3.S4, V3.S4
+    VSHL    $4, V5.S4, V5.S4
+    VSHL    $4, V7.S4, V7.S4
+
+    VORR    V1.B16, V0.B16, V10.B16
+    VORR    V3.B16, V2.B16, V11.B16
+    VORR    V5.B16, V4.B16, V12.B16
+    VORR    V7.B16, V6.B16, V13.B16
+
+    VTBL    V15.B16, [V10.B16, V11.B16, V12.B16, V13.B16], V16.B16
+
+    VST1.P  [V16.B16], (16)(R1)
+
+    SUBS    $1, R3, R3
+    BGT     loop
 
     RET

--- a/sign/internal/dilithium/arm64_test.go
+++ b/sign/internal/dilithium/arm64_test.go
@@ -1,3 +1,6 @@
+//go:build arm64 && !purego
+// +build arm64,!purego
+
 package dilithium
 
 import (

--- a/sign/internal/dilithium/arm64_test.go
+++ b/sign/internal/dilithium/arm64_test.go
@@ -1,0 +1,18 @@
+package dilithium
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestAssemblyImplementationAssumptions(t *testing.T) {
+	var p Poly
+
+	if len(p) != 256 {
+		t.Fatal("length of p must be 256. (assumption of the arm64 implementations)")
+	}
+
+	if unsafe.Sizeof(p) != 1024 {
+		t.Fatal("sizeof p be must be 1024 bytes. (assumption of the arm64 implementations)")
+	}
+}


### PR DESCRIPTION
To test performance difference on arm64 chips: "go test -benchmem -run=^$ ./sign/internal/dilithium -bench=Le16"

On my machine (Apple M1 Max) on average:

```
BenchmarkPackLe16-10            69454038                17.62 ns/op            0 B/op          0 allocs/op
BenchmarkPackLe16Generic-10     18178948                66.44 ns/op            0 B/op          0 allocs/op
```

Also consider this are microbenchmarks!