### PR TITLE
add arm64 version of polySub

### DIFF
--- a/sign/internal/dilithium/arm64.go
+++ b/sign/internal/dilithium/arm64.go
@@ -40,7 +40,7 @@ func (p *Poly) Add(a, b *Poly) {
 // Warning: assumes coefficients of b are less than 2q.
 // Sets p to a + b.  Does not normalize polynomials.
 func (p *Poly) Sub(a, b *Poly) {
-	p.subGeneric(a, b)
+	polySubARM64(p, a, b)
 }
 
 // Writes p whose coefficients are in [0, 16) to buf, which must be of
@@ -101,3 +101,6 @@ func polyPackLe16ARM64(p *Poly, buf *byte)
 
 //go:noescape
 func polyMulBy2toDARM64(p, q *Poly)
+
+//go:noescape
+func polySubARM64(p, a, b *Poly)

--- a/sign/internal/dilithium/arm64.s
+++ b/sign/internal/dilithium/arm64.s
@@ -91,3 +91,35 @@ loop:
     BGT     loop
 
     RET
+
+// func polySubARM64(p, a, b *Poly)
+TEXT ·polySubARM64(SB), NOSPLIT|NOFRAME, $0-24
+    MOVD    p+0(FP), R0
+    MOVD    a+8(FP), R1
+    MOVD    b+16(FP), R2
+
+    MOVW    $(const_N / 16), R3
+    MOVW    $(const_Q << 1), R4
+
+    VDUP    R4, V8.S4
+
+loop:
+    VLD1.P  (64)(R1), [V0.S4, V1.S4, V2.S4, V3.S4]
+    VLD1.P  (64)(R2), [V4.S4, V5.S4, V6.S4, V7.S4]
+
+    VSUB    V4.S4, V8.S4, V4.S4
+    VSUB    V5.S4, V8.S4, V5.S4
+    VSUB    V6.S4, V8.S4, V6.S4
+    VSUB    V7.S4, V8.S4, V7.S4
+
+    VADD    V4.S4, V0.S4, V0.S4
+    VADD    V5.S4, V1.S4, V1.S4
+    VADD    V6.S4, V2.S4, V2.S4
+    VADD    V7.S4, V3.S4, V3.S4
+
+    VST1.P  [V0.S4, V1.S4, V2.S4, V3.S4], (64)(R0)
+
+    SUBS    $1, R3, R3
+    BGT     loop
+
+    RET

--- a/sign/internal/dilithium/arm64.s
+++ b/sign/internal/dilithium/arm64.s
@@ -103,6 +103,7 @@ TEXT ·polySubARM64(SB), NOSPLIT|NOFRAME, $0-24
 
     VDUP    R4, V8.S4
 
+    // p = a + (2q - b)
 loop:
     VLD1.P  (64)(R1), [V0.S4, V1.S4, V2.S4, V3.S4]
     VLD1.P  (64)(R2), [V4.S4, V5.S4, V6.S4, V7.S4]


### PR DESCRIPTION
To test performance difference on arm64 chips: "go test -benchmem -run=^$ ./sign/internal/dilithium -bench=Sub"

On my machine (Apple M1 Max) on average:

```
BenchmarkSubGeneric-10          12127086                89.72 ns/op            0 B/op          0 allocs/op
BenchmarkSub-10                 56654660                20.93 ns/op            0 B/op          0 allocs/op
```

Also consider this are microbenchmarks!