### PR TITLE
Add ExportRaw() and ImportRaw() serialization helpers for Prio3 share…

### DIFF
--- a/vdaf/prio3/internal/prio3/types.go
+++ b/vdaf/prio3/internal/prio3/types.go
@@ -1,6 +1,7 @@
 package prio3
 
 import (
+	"errors"
 	"github.com/cloudflare/circl/internal/conv"
 	"github.com/cloudflare/circl/vdaf/prio3/arith"
 	"golang.org/x/crypto/cryptobyte"
@@ -358,6 +359,32 @@ func (s *OutShare[V, E]) Marshal(b *cryptobyte.Builder) error {
 
 func (s *OutShare[V, E]) Unmarshal(str *cryptobyte.String) bool {
 	return s.share.Unmarshal(str)
+}
+
+// ExportBytes returns the portable binary encoding of the OutShare.
+func (s *OutShare[V, E]) ExportBytes() ([]byte, error) {
+	return s.MarshalBinary()
+}
+
+// ImportBytes sets the OutShare from a portable binary encoding.
+func (s *OutShare[V, E]) ImportBytes(data []byte) error {
+	return s.UnmarshalBinary(data)
+}
+
+// ExportRaw returns the underlying vector as a byte slice.
+func (s *OutShare[V, E]) ExportRaw() ([]byte, error) {
+	if b, ok := any(s.share).(interface{ ExportRaw() ([]byte, error) }); ok {
+		return b.ExportRaw()
+	}
+	return nil, errors.New("ExportRaw: underlying vector does not support ExportRaw")
+}
+
+// ImportRaw sets the underlying vector from a byte slice.
+func (s *OutShare[V, E]) ImportRaw(data []byte) error {
+	if b, ok := any(&s.share).(interface{ ImportRaw([]byte) error }); ok {
+		return b.ImportRaw(data)
+	}
+	return errors.New("ImportRaw: underlying vector does not support ImportRaw")
 }
 
 // AggShare represents the following structure.


### PR DESCRIPTION
### Summary
This PR adds minimal, backward-compatible serialization helpers for CIRCL’s Prio3 types to support **cross-process and distributed deployments** of Verifiable Distributed Aggregation Functions (VDAFs).

### Background
The current CIRCL VDAF implementation assumes that all aggregators and the collector operate within a single process.  
Serialization helpers (e.g., for `InputShare`, `PrepShare`, `OutShare`) are defined under `vdaf/prio3/internal/prio3`, which cannot be accessed externally due to Go’s `internal/` package visibility rules.  

This makes distributed deployments — where aggregators and the collector run on distinct hosts — infeasible without modifying CIRCL.  
Our patch exposes a minimal public serialization interface to enable share transmission between processes while preserving CIRCL’s internal cryptographic semantics.

### Changes Introduced
- Added public methods for raw export/import of Prio3 share types:
  ```go
  func (s *OutShare[V,E]) ExportRaw() ([]byte, error)
  func (s *OutShare[V,E]) ImportRaw([]byte) error
