### PR TITLE
Revert to using package-declared HPKE errors for shortkem instead of standard library errors

### DIFF
--- a/hpke/shortkem.go
+++ b/hpke/shortkem.go
@@ -103,7 +103,7 @@ func (s shortKEM) GenerateKeyPair() (kem.PublicKey, kem.PrivateKey, error) {
 func (s shortKEM) UnmarshalBinaryPrivateKey(data []byte) (kem.PrivateKey, error) {
 	key, err := s.Curve.NewPrivateKey(data)
 	if err != nil {
-		return nil, err
+		return nil, ErrInvalidKEMPrivateKey
 	}
 
 	return &shortKEMPrivKey{s, key}, nil
@@ -112,7 +112,7 @@ func (s shortKEM) UnmarshalBinaryPrivateKey(data []byte) (kem.PrivateKey, error)
 func (s shortKEM) UnmarshalBinaryPublicKey(data []byte) (kem.PublicKey, error) {
 	key, err := s.Curve.NewPublicKey(data)
 	if err != nil {
-		return nil, err
+		return nil, ErrInvalidKEMPublicKey
 	}
 
 	return &shortKEMPubKey{s, *key}, nil


### PR DESCRIPTION
A commit to update HPKE code to use ecdh stdlib package: https://github.com/cloudflare/circl/commit/342ad81204fc580bd54aec19f09cb55b214b7d39 - changed the error returned from the Unmarshal functions from `shortkem` to return the underlying error (which returns the standard library errors). Considering `xkem` still returns the package defined errors and if the project doesn't need the underlying error for some reasons, it would make sense to keep the error returned consistent and also helps projects handle errors better.