### PR TITLE
Perform final reduction of Horner poly evaluation

### DIFF
--- a/tss/rsa/rsa_threshold.go
+++ b/tss/rsa/rsa_threshold.go
@@ -175,8 +175,9 @@ func computePolynomial(a []*big.Int, x uint, m *big.Int) *big.Int {
 		sum.Set(a[len(a)-1])
 		for i := len(a) - 2; i >= 0; i-- {
 			sum.Mul(sum, xBig).Mod(sum, m)
-			sum.Add(sum, a[i]).Mod(sum, m)
+			sum.Add(sum, a[i])
 		}
+		sum.Mod(sum, m)
 	}
 
 	return sum


### PR DESCRIPTION
Amendment to #590

Gets rid of modular arithmetic in additions, which stays within the bounds of the ring modulus, saving a few CPU cycles. The operations are const time on a best-effort basis... Switching from `math/big` to a library with Montgomery reductions is actually the better approach here.