### PR TITLE
sign/bls: rejects aggregated signatures built with duplicated messages.

### DIFF
--- a/sign/bls/bls.go
+++ b/sign/bls/bls.go
@@ -365,6 +365,18 @@ func VerifyAggregate[K KeyGroup](pubs []*PublicKey[K], msgs [][]byte, aggSig Sig
 		return false
 	}
 
+	// 1. If any two input messages are equal, return INVALID.
+	set := make(map[string]struct{}, len(msgs))
+	for _, m := range msgs {
+		k := string(m)
+		if _, found := set[k]; found {
+			return false
+		}
+		set[k] = struct{}{}
+	}
+
+	// 2. CoreAggregateVerify algorithm checks an aggregated signature over
+	// several (PK, message) pairs.
 	for _, p := range pubs {
 		if !p.Validate() {
 			return false

--- a/sign/bls/bls_test.go
+++ b/sign/bls/bls_test.go
@@ -21,6 +21,8 @@ func TestBls(t *testing.T) {
 	t.Run("G2/Errors", testErrors[bls.G2])
 	t.Run("G1/Aggregation", testAggregation[bls.G1])
 	t.Run("G2/Aggregation", testAggregation[bls.G2])
+	t.Run("G1/DuplicatedMsg", testDuplicatedMsgs[bls.G1])
+	t.Run("G2/DuplicatedMsg", testDuplicatedMsgs[bls.G2])
 }
 
 func testBls[K bls.KeyGroup](t *testing.T) {
@@ -150,6 +152,34 @@ func testAggregation[K bls.KeyGroup](t *testing.T) {
 
 	ok := bls.VerifyAggregate(pubKeys, msgs, aggSig)
 	test.CheckOk(ok, "failed to verify aggregated signature", t)
+}
+
+func testDuplicatedMsgs[K bls.KeyGroup](t *testing.T) {
+	const N = 3
+
+	ikm := [32]byte{}
+	_, _ = rand.Reader.Read(ikm[:])
+
+	duplicated_msg := []byte("signing the same messsage")
+	msgs := make([][]byte, N)
+	sigs := make([]bls.Signature, N)
+	pubKeys := make([]*bls.PublicKey[K], N)
+
+	for i := range sigs {
+		priv, err := bls.KeyGen[K](ikm[:], nil, nil)
+		test.CheckNoErr(t, err, "failed to keygen")
+		pubKeys[i] = priv.PublicKey()
+
+		msgs[i] = duplicated_msg
+		sigs[i] = bls.Sign(priv, msgs[i])
+	}
+
+	aggSig, err := bls.Aggregate(*new(K), sigs)
+	test.CheckNoErr(t, err, "failed to aggregate")
+
+	test.CheckOk(
+		bls.VerifyAggregate(pubKeys, msgs, aggSig) == false,
+		"failed to reject aggregated signature with duplicated messages", t)
 }
 
 func BenchmarkBls(b *testing.B) {


### PR DESCRIPTION
[AggregateVerify](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-05#section-3.1.1) must reject attempts to verify aggregated signatures with duplicated messages.