### PR TITLE
tss/rsa: avoiding overflow in lambda calculation with big.Int

### DIFF
--- a/tss/rsa/rsa_threshold.go
+++ b/tss/rsa/rsa_threshold.go
@@ -218,7 +218,7 @@ func CombineSignShares(pub *rsa.PublicKey, shares []SignShare, msg []byte) (Sign
 	// i_1 ... i_k
 	for _, share := range shares {
 		// λ(S, 0, i)
-		lambda, err := computeLambda(delta, shares, 0, int64(share.Index))
+		lambda, err := computeLambda(delta, shares, 0, int64(share.Index), int64(players))
 		if err != nil {
 			return nil, err
 		}
@@ -280,55 +280,60 @@ func CombineSignShares(pub *rsa.PublicKey, shares []SignShare, msg []byte) (Sign
 	return sig, nil
 }
 
-// computes lagrange Interpolation for the shares
-// i must be an id 0..l but not in S
-// j must be in S
-func computeLambda(delta *big.Int, S []SignShare, i, j int64) (*big.Int, error) {
-	if i == j {
-		return nil, errors.New("rsa_threshold: i and j can't be equal by precondition")
+func checkIndices(i, j, l int64, S []SignShare) bool {
+	var isIinS, isJinS bool
+	for k := range S {
+		sk := int64(S[k].Index)
+		if sk == i {
+			isIinS = true
+		}
+		if sk == j {
+			isJinS = true
+		}
 	}
-	// these are just to check preconditions
-	foundi := false
-	foundj := false
+
+	// j must be in S
+	// i must be in {0..l} but not in S
+	return isJinS && (0 <= i && i <= l && !isIinS)
+}
+
+// computes Lagrange Interpolation for the shares
+// i must be in {0..l} but not in S
+// j must be in S
+func computeLambda(delta *big.Int, S []SignShare, i, j, l int64) (*big.Int, error) {
+	// Equation (2) of https://www.iacr.org/archive/eurocrypt2000/1807/18070209-new.pdf
+	if !checkIndices(i, j, l, S) {
+		return nil, ErrInvalidCalc
+	}
 
 	// λ(s, i, j) = ∆( (  π{j'∈S\{j}} (i - j')  ) /  (  π{j'∈S\{j}} (j - j') ) )
-
-	num := int64(1)
-	den := int64(1)
+	num := big.NewInt(1)
+	den := big.NewInt(1)
+	tmp := big.NewInt(0)
 
 	// ∈ S
 	for _, s := range S {
-		// j'
-		jprime := int64(s.Index)
-		// S\{j}
-		if jprime == j {
-			foundj = true
-			continue
+		jprime := int64(s.Index) // j'
+		if jprime != j {
+			num.Mul(num, tmp.SetInt64(i-jprime)) // (i - j')  for j' ∈ S \ {j}
+			den.Mul(den, tmp.SetInt64(j-jprime)) // (j - j')  for j' ∈ S \ {j}
 		}
-		if jprime == i {
-			foundi = false
-			break
-		}
-		//  (i - j')
-		num *= i - jprime
-		// (j - j')
-		den *= j - jprime
 	}
 
-	// ∆ * (num/den)
-	var lambda big.Int
-	// (num/den)
-	lambda.Div(big.NewInt(num), big.NewInt(den))
-	// ∆ * (num/den)
-	lambda.Mul(delta, &lambda)
-
-	if foundi {
-		return nil, fmt.Errorf("rsa_threshold: i: %d should not be in S", i)
+	// den must be different of zero.
+	if den.Sign() == 0 {
+		return nil, ErrInvalidCalc
 	}
 
-	if !foundj {
-		return nil, fmt.Errorf("rsa_threshold: j: %d should be in S", j)
+	// lambda = (delta * num) / den, and lambda must an integer.
+	var lambda, rem big.Int
+	lambda.Mul(delta, num)
+	lambda.QuoRem(&lambda, den, &rem)
+	if rem.Sign() != 0 {
+		return nil, ErrInvalidCalc
 	}
 
 	return &lambda, nil
 }
+
+var ErrInvalidCalc = errors.New("tss/rsa: invalid calculation")

--- a/tss/rsa/rsa_threshold_test.go
+++ b/tss/rsa/rsa_threshold_test.go
@@ -95,26 +95,101 @@ func TestComputePolynomialLarge(t *testing.T) {
 
 func TestComputeLambda(t *testing.T) {
 	// shares = {1, 2, 3, 4, 5}
+	// l = 5
 	// i = 0
 	// ∆ = 5! = 120
 	// j = 3
 	//
 	// num = (0 - 1) * (0 - 2) * (0 - 4) * (0 - 5) = 40
-	// dem = (3 - 1) * (3 - 2) * (3 - 4) * (3 - 5) = 4
-	// num/dev = 40/4 = 10
+	// den = (3 - 1) * (3 - 2) * (3 - 4) * (3 - 5) = 4
+	// num/den = 40/4 = 10
 	// ∆ * 10 = 120 * 10 = 1200
-	shares := make([]SignShare, 5)
-	for i := uint(1); i <= 5; i++ {
+	const l = 5
+	shares := make([]SignShare, l)
+	for i := uint(1); i <= l; i++ {
 		shares[i-1].Index = i
 	}
 	i := int64(0)
-	delta := int64(120)
+	delta := calculateDelta(l)
 	j := int64(3)
 
-	lambda, err := computeLambda(big.NewInt(delta), shares, i, j)
-
+	lambda, err := computeLambda(delta, shares, i, j, l)
 	if err != nil || lambda.Cmp(big.NewInt(1200)) != 0 {
 		t.Fatal("computeLambda failed")
+	}
+}
+
+func TestCheckIndices(t *testing.T) {
+	type pairs []struct {
+		i int64 // i must be in {0..l} but not in S
+		j int64 // j must be in S
+	}
+
+	testCases := []struct {
+		want bool
+		pairs
+	}{
+		{true, pairs{{0, 1}, {0, 4}, {2, 1}, {2, 4}, {3, 1}, {3, 4}, {5, 1}, {5, 4}, {6, 1}, {6, 4}, {8, 1}, {8, 4}}},
+		{false, pairs{{1, 1}, {1, 4}, {4, 1}, {4, 4}, {9, 1}, {9, 4}, {-1, 1}, {-1, 4}, {0, 0}, {0, 2}, {0, 3}}},
+	}
+
+	// S = {1,4}
+	var shares [2]SignShare
+	shares[0].Index = 1
+	shares[1].Index = 4
+	const l = 8
+
+	for _, tc := range testCases {
+		for _, p := range tc.pairs {
+			got := checkIndices(p.i, p.j, l, shares[:])
+			test.CheckOk(got == tc.want, fmt.Sprintf("i: %v j: %v", p.i, p.j), t)
+		}
+	}
+}
+
+func TestComputeLambdaLarge(t *testing.T) {
+	/* Python3
+	from math import prod, factorial
+	S = [7,14,21]
+	j = 7
+	l = 32
+	computeLambda = lambda i,j,l,S : (\
+		factorial(l) * prod( i-jp for jp in S if jp!=j ) \
+		) // prod( j-jp for jp in S if jp!=j )
+	i= 0; computeLambda(i,j,l,S)
+	i=12; computeLambda(i,j,l,S)
+	i=19; computeLambda(i,j,l,S)
+	i=32; computeLambda(i,j,l,S)
+	*/
+
+	// S = {7,14,21}
+	var shares [3]SignShare
+	shares[0].Index = 7
+	shares[1].Index = 14
+	shares[2].Index = 21
+
+	const players = 32
+	const j = 7
+	delta := calculateDelta(players)
+	testCases := []struct {
+		i    int64
+		want string
+	}{
+		{0, "789392510801080590501654036480000000"},
+		{12, "48330153722515138193978818560000000"},
+		{19, "-26850085401397298996654899200000000"},
+		{32, "531631690947666520133767004160000000"},
+	}
+
+	var want big.Int
+	for _, tc := range testCases {
+		got, err := computeLambda(delta, shares[:], tc.i, j, players)
+		test.CheckNoErr(t, err, "computeLambda failed")
+		want.SetString(tc.want, 10)
+
+		if got.Cmp(&want) != 0 {
+			test.ReportError(t, got.String(), want.String(), tc.i)
+		}
 	}
 }
 


### PR DESCRIPTION
avoiding overflow in lambda calculation with big.Int
Previously, uses int64 arithmetic and was overflowing for larger number of parties.