### PR TITLE
Make Unblind function public

### DIFF
--- a/oprf/client.go
+++ b/oprf/client.go
@@ -64,6 +64,17 @@ func (c client) blind(inputs [][]byte, blinds []Blind) (*FinalizeData, *Evaluati
 	return finData, evalReq, nil
 }
 
+func (c Client) Unblind(serUnblindeds [][]byte, blindeds []group.Element, blind []Blind) (err error) {
+	if len(serUnblindeds) == 0 {
+		return ErrInvalidInput
+	}
+	if len(serUnblindeds) != len(blindeds) || len(blindeds) != len(blind) {
+		return ErrInvalidInput
+	}
+
+	return c.unblind(serUnblindeds, blindeds, blind)
+}
+
 func (c client) unblind(serUnblindeds [][]byte, blindeds []group.Element, blind []Blind) (err error) {
 	invBlind := c.params.group.NewScalar()
 	U := c.params.group.NewElement()


### PR DESCRIPTION
Hi 👋 , 

Thanks for a the great work creating this library. I would like to request a small feature change to the OPRF client. 

Our usecase of the OPRF library is perhaps a bit different, so let me explain. There are three party parties involved:

- (A) a sender, which knows some secret ID number of a person. 
- (B) a receiver, which needs to process a message from the sender and needs a stable identifier of the person but is not allowed to see te secret ID number.
- (C) a service capable of generating pseudonyms. 

The OPRF client in this case is _both_ the sender and the receiver. However, from the `finalizeData` structure only the `blinds` are communicated between both. The original inputs are _not_ shared with the receiver because the are secret. 

The OPRF server in this case is the pseudonym generating service. We also don't want to share the secret ID with this service. That's why we are using OPRF. 

Of course, without the original inputs the receiver won't be able to reconstruct the final output using the `client.Finalize` function. However, we are capable of executing the `unblind` function on the receiver. This results in a stable identifier which the receiver can use. Luckily, for our use case that is enough.

Currently, the `unblind` function is private, this PR makes it public. 

For reference, I wrote some code tying these three services together and using the `unblind` function directly: 

https://github.com/henkerik/oprf-cloudflare/blob/master/main.go#L206

Feel free to ask me for any updates. 
 