### PR TITLE
sign/bls: Check that signature cannot be the identity point

### DIFF
--- a/sign/bls/bls.go
+++ b/sign/bls/bls.go
@@ -41,6 +41,7 @@ import (
 var (
 	ErrInvalid    = errors.New("bls: invalid BLS instance")
 	ErrInvalidKey = errors.New("bls: invalid key")
+	ErrInvalidSig = errors.New("bls: invalid signature")
 	ErrKeyGen     = errors.New("bls: too many unsuccessful key generation tries")
 	ErrShortIKM   = errors.New("bls: IKM material shorter than 32 bytes")
 	ErrAggregate  = errors.New("bls: error while aggregating signatures")
@@ -64,8 +65,31 @@ type (
 	KeyG2SigG1 = G2
 )
 
-func (f *G1) setBytes(b []byte) error { return f.g.SetBytes(b) }
-func (f *G2) setBytes(b []byte) error { return f.g.SetBytes(b) }
+func (f *G1) setBytes(b []byte) error {
+	err := f.g.SetBytes(b)
+	if err != nil {
+		return err
+	}
+
+	if f.g.IsIdentity() {
+		return ErrInvalidSig
+	}
+
+	return nil
+}
+
+func (f *G2) setBytes(b []byte) error {
+	err := f.g.SetBytes(b)
+	if err != nil {
+		return err
+	}
+
+	if f.g.IsIdentity() {
+		return ErrInvalidSig
+	}
+
+	return nil
+}
 
 func (f *G1) hash(msg []byte) { f.g.Hash(msg, []byte(dstG1)) }
 func (f *G2) hash(msg []byte) { f.g.Hash(msg, []byte(dstG2)) }
@@ -331,24 +355,26 @@ func Aggregate[K KeyGroup](k K, sigs []Signature) (Signature, error) {
 
 	switch any(k).(type) {
 	case G1:
-		var P, Q GG.G2
+		var P GG.G2
+		var Q G2
 		P.SetIdentity()
 		for _, sig := range sigs {
-			if err := Q.SetBytes(sig); err != nil {
+			if err := Q.setBytes(sig); err != nil {
 				return nil, err
 			}
-			P.Add(&P, &Q)
+			P.Add(&P, &Q.g)
 		}
 		return P.BytesCompressed(), nil
 
 	case G2:
-		var P, Q GG.G1
+		var P GG.G1
+		var Q G1
 		P.SetIdentity()
 		for _, sig := range sigs {
-			if err := Q.SetBytes(sig); err != nil {
+			if err := Q.setBytes(sig); err != nil {
 				return nil, err
 			}
-			P.Add(&P, &Q)
+			P.Add(&P, &Q.g)
 		}
 		return P.BytesCompressed(), nil
 
@@ -404,7 +430,7 @@ func VerifyAggregate[K KeyGroup](pubs []*PublicKey[K], msgs [][]byte, aggSig Sig
 		}
 
 		err := listG2[n].SetBytes(aggSig)
-		if err != nil {
+		if err != nil || listG2[n].IsIdentity() {
 			return false
 		}
 
@@ -419,7 +445,7 @@ func VerifyAggregate[K KeyGroup](pubs []*PublicKey[K], msgs [][]byte, aggSig Sig
 		}
 
 		err := listG1[n].SetBytes(aggSig)
-		if err != nil {
+		if err != nil || listG1[n].IsIdentity() {
 			return false
 		}
 

--- a/sign/bls/bls_test.go
+++ b/sign/bls/bls_test.go
@@ -103,9 +103,14 @@ func testErrors[K bls.KeyGroup](t *testing.T) {
 	// Bad public key
 	msg := []byte("hello")
 	sig := bls.Sign[K](priv, msg)
-	pub = new(bls.PublicKey[K])
-	test.CheckOk(pub.Validate() == false, "should fail: bad public key", t)
-	test.CheckOk(bls.Verify(pub, msg, sig) == false, "should fail: bad signature", t)
+	badPub := new(bls.PublicKey[K])
+	test.CheckOk(badPub.Validate() == false, "should fail: bad public key", t)
+	test.CheckOk(bls.Verify(badPub, msg, sig) == false, "should fail: bad public key", t)
+
+	// Bad Signature equal to G.Identity
+	badSig := make(bls.Signature, len(sig))
+	badSig[0] = 0xC0
+	test.CheckOk(bls.Verify(pub, msg, badSig) == false, "should fail: bad signature", t)
 
 	// Bad private key
 	priv = new(bls.PrivateKey[K])
@@ -121,11 +126,18 @@ func testErrors[K bls.KeyGroup](t *testing.T) {
 	_, err = bls.Aggregate[K](*new(K), nil)
 	test.CheckIsErr(t, err, "should fail: empty signatures")
 
+	// Aggregate badSig
+	_, err = bls.Aggregate[K](*new(K), []bls.Signature{sig, badSig})
+	test.CheckIsErr(t, err, "should fail: bad signature")
+
 	// VerifyAggregate nil
 	test.CheckOk(bls.VerifyAggregate([]*bls.PublicKey[K]{}, nil, nil) == false, "should fail: empty keys", t)
 
 	// VerifyAggregate empty signature
 	test.CheckOk(bls.VerifyAggregate([]*bls.PublicKey[K]{pub}, [][]byte{msg}, nil) == false, "should fail: empty signature", t)
+
+	// VerifyAggregate bad aggregate signature
+	test.CheckOk(bls.VerifyAggregate([]*bls.PublicKey[K]{pub}, [][]byte{msg}, badSig) == false, "should fail: bad signature", t)
 }
 
 func testAggregation[K bls.KeyGroup](t *testing.T) {


### PR DESCRIPTION
[BLS](https://www.iacr.org/archive/asiacrypt2001/22480516.pdf) paper specifies that signature cannot be the identity element of the group.

