### PR TITLE
sign/dilithium: hold tr by value in pk returned from Public()

### DIFF
--- a/sign/dilithium/mode2/internal/dilithium.go
+++ b/sign/dilithium/mode2/internal/dilithium.go
@@ -236,8 +236,13 @@ func NewKeyFromSeed(seed *[common.SeedSize]byte) (*PublicKey, *PrivateKey) {
 	_, _ = h.Write(packedPk[:])
 	_, _ = h.Read(sk.tr[:])
 
-	// Finish cache of public key
-	pk.tr = &sk.tr
+	// Finish cache of public key. Copy the value rather than aliasing
+	// sk.tr so that later mutation of sk (for instance through a
+	// subsequent (*PrivateKey).Unpack on attacker-controlled bytes)
+	// does not silently propagate into a pk returned earlier from
+	// NewKeyFromSeed. See cloudflare/circl#600.
+	pk.tr = new([TRSize]byte)
+	*pk.tr = sk.tr
 
 	return &pk, &sk
 }
@@ -472,13 +477,18 @@ func SignTo(sk *PrivateKey, msg func(io.Writer), rnd [32]byte, signature []byte)
 }
 
 // Computes the public key corresponding to this private key.
+//
+// The returned pk holds its own copy of tr; later mutation of sk.tr
+// does not affect a pk previously returned from this method.
+// See cloudflare/circl#600.
 func (sk *PrivateKey) Public() *PublicKey {
 	var t0 VecK
 	pk := &PublicKey{
 		rho: sk.rho,
 		A:   &sk.A,
-		tr:  &sk.tr,
+		tr:  new([TRSize]byte),
 	}
+	*pk.tr = sk.tr
 	sk.computeT0andT1(&t0, &pk.t1)
 	pk.t1.PackT1(pk.t1p[:])
 	return pk

--- a/sign/dilithium/mode2/internal/dilithium_test.go
+++ b/sign/dilithium/mode2/internal/dilithium_test.go
@@ -140,6 +140,33 @@ func TestPublicFromPrivate(t *testing.T) {
 	}
 }
 
+// Regression test for cloudflare/circl#600: the pk returned by
+// NewKeyFromSeed and (*PrivateKey).Public must hold its own copy of tr,
+// not a pointer aliasing sk.tr. Otherwise a later mutation of sk -- for
+// instance through (*PrivateKey).Unpack on attacker-controlled bytes --
+// silently propagates into a pk that was returned earlier.
+func TestPublicTrIsIndependentOfPrivate(t *testing.T) {
+	var seed [common.SeedSize]byte
+	pkSeed, sk := NewKeyFromSeed(&seed)
+	pkPub := sk.Public()
+
+	pkSeedTr := *pkSeed.tr
+	pkPubTr := *pkPub.tr
+
+	for i := range sk.tr {
+		sk.tr[i] ^= 0xff
+	}
+
+	if *pkSeed.tr != pkSeedTr {
+		t.Fatalf("pk from NewKeyFromSeed aliased sk.tr (got %x want %x)",
+			*pkSeed.tr, pkSeedTr)
+	}
+	if *pkPub.tr != pkPubTr {
+		t.Fatalf("pk from sk.Public() aliased sk.tr (got %x want %x)",
+			*pkPub.tr, pkPubTr)
+	}
+}
+
 func TestGamma1Size(t *testing.T) {
 	var expected int
 	switch Gamma1Bits {

--- a/sign/dilithium/mode3/internal/dilithium.go
+++ b/sign/dilithium/mode3/internal/dilithium.go
@@ -234,8 +234,13 @@ func NewKeyFromSeed(seed *[common.SeedSize]byte) (*PublicKey, *PrivateKey) {
 	_, _ = h.Write(packedPk[:])
 	_, _ = h.Read(sk.tr[:])
 
-	// Finish cache of public key
-	pk.tr = &sk.tr
+	// Finish cache of public key. Copy the value rather than aliasing
+	// sk.tr so that later mutation of sk (for instance through a
+	// subsequent (*PrivateKey).Unpack on attacker-controlled bytes)
+	// does not silently propagate into a pk returned earlier from
+	// NewKeyFromSeed. See cloudflare/circl#600.
+	pk.tr = new([TRSize]byte)
+	*pk.tr = sk.tr
 
 	return &pk, &sk
 }
@@ -470,13 +475,18 @@ func SignTo(sk *PrivateKey, msg func(io.Writer), rnd [32]byte, signature []byte)
 }
 
 // Computes the public key corresponding to this private key.
+//
+// The returned pk holds its own copy of tr; later mutation of sk.tr
+// does not affect a pk previously returned from this method.
+// See cloudflare/circl#600.
 func (sk *PrivateKey) Public() *PublicKey {
 	var t0 VecK
 	pk := &PublicKey{
 		rho: sk.rho,
 		A:   &sk.A,
-		tr:  &sk.tr,
+		tr:  new([TRSize]byte),
 	}
+	*pk.tr = sk.tr
 	sk.computeT0andT1(&t0, &pk.t1)
 	pk.t1.PackT1(pk.t1p[:])
 	return pk

--- a/sign/dilithium/mode3/internal/dilithium_test.go
+++ b/sign/dilithium/mode3/internal/dilithium_test.go
@@ -138,6 +138,33 @@ func TestPublicFromPrivate(t *testing.T) {
 	}
 }
 
+// Regression test for cloudflare/circl#600: the pk returned by
+// NewKeyFromSeed and (*PrivateKey).Public must hold its own copy of tr,
+// not a pointer aliasing sk.tr. Otherwise a later mutation of sk -- for
+// instance through (*PrivateKey).Unpack on attacker-controlled bytes --
+// silently propagates into a pk that was returned earlier.
+func TestPublicTrIsIndependentOfPrivate(t *testing.T) {
+	var seed [common.SeedSize]byte
+	pkSeed, sk := NewKeyFromSeed(&seed)
+	pkPub := sk.Public()
+
+	pkSeedTr := *pkSeed.tr
+	pkPubTr := *pkPub.tr
+
+	for i := range sk.tr {
+		sk.tr[i] ^= 0xff
+	}
+
+	if *pkSeed.tr != pkSeedTr {
+		t.Fatalf("pk from NewKeyFromSeed aliased sk.tr (got %x want %x)",
+			*pkSeed.tr, pkSeedTr)
+	}
+	if *pkPub.tr != pkPubTr {
+		t.Fatalf("pk from sk.Public() aliased sk.tr (got %x want %x)",
+			*pkPub.tr, pkPubTr)
+	}
+}
+
 func TestGamma1Size(t *testing.T) {
 	var expected int
 	switch Gamma1Bits {

--- a/sign/dilithium/mode5/internal/dilithium.go
+++ b/sign/dilithium/mode5/internal/dilithium.go
@@ -236,8 +236,13 @@ func NewKeyFromSeed(seed *[common.SeedSize]byte) (*PublicKey, *PrivateKey) {
 	_, _ = h.Write(packedPk[:])
 	_, _ = h.Read(sk.tr[:])
 
-	// Finish cache of public key
-	pk.tr = &sk.tr
+	// Finish cache of public key. Copy the value rather than aliasing
+	// sk.tr so that later mutation of sk (for instance through a
+	// subsequent (*PrivateKey).Unpack on attacker-controlled bytes)
+	// does not silently propagate into a pk returned earlier from
+	// NewKeyFromSeed. See cloudflare/circl#600.
+	pk.tr = new([TRSize]byte)
+	*pk.tr = sk.tr
 
 	return &pk, &sk
 }
@@ -472,13 +477,18 @@ func SignTo(sk *PrivateKey, msg func(io.Writer), rnd [32]byte, signature []byte)
 }
 
 // Computes the public key corresponding to this private key.
+//
+// The returned pk holds its own copy of tr; later mutation of sk.tr
+// does not affect a pk previously returned from this method.
+// See cloudflare/circl#600.
 func (sk *PrivateKey) Public() *PublicKey {
 	var t0 VecK
 	pk := &PublicKey{
 		rho: sk.rho,
 		A:   &sk.A,
-		tr:  &sk.tr,
+		tr:  new([TRSize]byte),
 	}
+	*pk.tr = sk.tr
 	sk.computeT0andT1(&t0, &pk.t1)
 	pk.t1.PackT1(pk.t1p[:])
 	return pk

--- a/sign/dilithium/mode5/internal/dilithium_test.go
+++ b/sign/dilithium/mode5/internal/dilithium_test.go
@@ -140,6 +140,33 @@ func TestPublicFromPrivate(t *testing.T) {
 	}
 }
 
+// Regression test for cloudflare/circl#600: the pk returned by
+// NewKeyFromSeed and (*PrivateKey).Public must hold its own copy of tr,
+// not a pointer aliasing sk.tr. Otherwise a later mutation of sk -- for
+// instance through (*PrivateKey).Unpack on attacker-controlled bytes --
+// silently propagates into a pk that was returned earlier.
+func TestPublicTrIsIndependentOfPrivate(t *testing.T) {
+	var seed [common.SeedSize]byte
+	pkSeed, sk := NewKeyFromSeed(&seed)
+	pkPub := sk.Public()
+
+	pkSeedTr := *pkSeed.tr
+	pkPubTr := *pkPub.tr
+
+	for i := range sk.tr {
+		sk.tr[i] ^= 0xff
+	}
+
+	if *pkSeed.tr != pkSeedTr {
+		t.Fatalf("pk from NewKeyFromSeed aliased sk.tr (got %x want %x)",
+			*pkSeed.tr, pkSeedTr)
+	}
+	if *pkPub.tr != pkPubTr {
+		t.Fatalf("pk from sk.Public() aliased sk.tr (got %x want %x)",
+			*pkPub.tr, pkPubTr)
+	}
+}
+
 func TestGamma1Size(t *testing.T) {
 	var expected int
 	switch Gamma1Bits {

--- a/sign/mldsa/mldsa44/internal/dilithium.go
+++ b/sign/mldsa/mldsa44/internal/dilithium.go
@@ -236,8 +236,13 @@ func NewKeyFromSeed(seed *[common.SeedSize]byte) (*PublicKey, *PrivateKey) {
 	_, _ = h.Write(packedPk[:])
 	_, _ = h.Read(sk.tr[:])
 
-	// Finish cache of public key
-	pk.tr = &sk.tr
+	// Finish cache of public key. Copy the value rather than aliasing
+	// sk.tr so that later mutation of sk (for instance through a
+	// subsequent (*PrivateKey).Unpack on attacker-controlled bytes)
+	// does not silently propagate into a pk returned earlier from
+	// NewKeyFromSeed. See cloudflare/circl#600.
+	pk.tr = new([TRSize]byte)
+	*pk.tr = sk.tr
 
 	return &pk, &sk
 }
@@ -472,13 +477,18 @@ func SignTo(sk *PrivateKey, msg func(io.Writer), rnd [32]byte, signature []byte)
 }
 
 // Computes the public key corresponding to this private key.
+//
+// The returned pk holds its own copy of tr; later mutation of sk.tr
+// does not affect a pk previously returned from this method.
+// See cloudflare/circl#600.
 func (sk *PrivateKey) Public() *PublicKey {
 	var t0 VecK
 	pk := &PublicKey{
 		rho: sk.rho,
 		A:   &sk.A,
-		tr:  &sk.tr,
+		tr:  new([TRSize]byte),
 	}
+	*pk.tr = sk.tr
 	sk.computeT0andT1(&t0, &pk.t1)
 	pk.t1.PackT1(pk.t1p[:])
 	return pk

--- a/sign/mldsa/mldsa44/internal/dilithium_test.go
+++ b/sign/mldsa/mldsa44/internal/dilithium_test.go
@@ -140,6 +140,33 @@ func TestPublicFromPrivate(t *testing.T) {
 	}
 }
 
+// Regression test for cloudflare/circl#600: the pk returned by
+// NewKeyFromSeed and (*PrivateKey).Public must hold its own copy of tr,
+// not a pointer aliasing sk.tr. Otherwise a later mutation of sk -- for
+// instance through (*PrivateKey).Unpack on attacker-controlled bytes --
+// silently propagates into a pk that was returned earlier.
+func TestPublicTrIsIndependentOfPrivate(t *testing.T) {
+	var seed [common.SeedSize]byte
+	pkSeed, sk := NewKeyFromSeed(&seed)
+	pkPub := sk.Public()
+
+	pkSeedTr := *pkSeed.tr
+	pkPubTr := *pkPub.tr
+
+	for i := range sk.tr {
+		sk.tr[i] ^= 0xff
+	}
+
+	if *pkSeed.tr != pkSeedTr {
+		t.Fatalf("pk from NewKeyFromSeed aliased sk.tr (got %x want %x)",
+			*pkSeed.tr, pkSeedTr)
+	}
+	if *pkPub.tr != pkPubTr {
+		t.Fatalf("pk from sk.Public() aliased sk.tr (got %x want %x)",
+			*pkPub.tr, pkPubTr)
+	}
+}
+
 func TestGamma1Size(t *testing.T) {
 	var expected int
 	switch Gamma1Bits {

--- a/sign/mldsa/mldsa65/internal/dilithium.go
+++ b/sign/mldsa/mldsa65/internal/dilithium.go
@@ -236,8 +236,13 @@ func NewKeyFromSeed(seed *[common.SeedSize]byte) (*PublicKey, *PrivateKey) {
 	_, _ = h.Write(packedPk[:])
 	_, _ = h.Read(sk.tr[:])
 
-	// Finish cache of public key
-	pk.tr = &sk.tr
+	// Finish cache of public key. Copy the value rather than aliasing
+	// sk.tr so that later mutation of sk (for instance through a
+	// subsequent (*PrivateKey).Unpack on attacker-controlled bytes)
+	// does not silently propagate into a pk returned earlier from
+	// NewKeyFromSeed. See cloudflare/circl#600.
+	pk.tr = new([TRSize]byte)
+	*pk.tr = sk.tr
 
 	return &pk, &sk
 }
@@ -472,13 +477,18 @@ func SignTo(sk *PrivateKey, msg func(io.Writer), rnd [32]byte, signature []byte)
 }
 
 // Computes the public key corresponding to this private key.
+//
+// The returned pk holds its own copy of tr; later mutation of sk.tr
+// does not affect a pk previously returned from this method.
+// See cloudflare/circl#600.
 func (sk *PrivateKey) Public() *PublicKey {
 	var t0 VecK
 	pk := &PublicKey{
 		rho: sk.rho,
 		A:   &sk.A,
-		tr:  &sk.tr,
+		tr:  new([TRSize]byte),
 	}
+	*pk.tr = sk.tr
 	sk.computeT0andT1(&t0, &pk.t1)
 	pk.t1.PackT1(pk.t1p[:])
 	return pk

--- a/sign/mldsa/mldsa65/internal/dilithium_test.go
+++ b/sign/mldsa/mldsa65/internal/dilithium_test.go
@@ -140,6 +140,33 @@ func TestPublicFromPrivate(t *testing.T) {
 	}
 }
 
+// Regression test for cloudflare/circl#600: the pk returned by
+// NewKeyFromSeed and (*PrivateKey).Public must hold its own copy of tr,
+// not a pointer aliasing sk.tr. Otherwise a later mutation of sk -- for
+// instance through (*PrivateKey).Unpack on attacker-controlled bytes --
+// silently propagates into a pk that was returned earlier.
+func TestPublicTrIsIndependentOfPrivate(t *testing.T) {
+	var seed [common.SeedSize]byte
+	pkSeed, sk := NewKeyFromSeed(&seed)
+	pkPub := sk.Public()
+
+	pkSeedTr := *pkSeed.tr
+	pkPubTr := *pkPub.tr
+
+	for i := range sk.tr {
+		sk.tr[i] ^= 0xff
+	}
+
+	if *pkSeed.tr != pkSeedTr {
+		t.Fatalf("pk from NewKeyFromSeed aliased sk.tr (got %x want %x)",
+			*pkSeed.tr, pkSeedTr)
+	}
+	if *pkPub.tr != pkPubTr {
+		t.Fatalf("pk from sk.Public() aliased sk.tr (got %x want %x)",
+			*pkPub.tr, pkPubTr)
+	}
+}
+
 func TestGamma1Size(t *testing.T) {
 	var expected int
 	switch Gamma1Bits {

--- a/sign/mldsa/mldsa87/internal/dilithium.go
+++ b/sign/mldsa/mldsa87/internal/dilithium.go
@@ -236,8 +236,13 @@ func NewKeyFromSeed(seed *[common.SeedSize]byte) (*PublicKey, *PrivateKey) {
 	_, _ = h.Write(packedPk[:])
 	_, _ = h.Read(sk.tr[:])
 
-	// Finish cache of public key
-	pk.tr = &sk.tr
+	// Finish cache of public key. Copy the value rather than aliasing
+	// sk.tr so that later mutation of sk (for instance through a
+	// subsequent (*PrivateKey).Unpack on attacker-controlled bytes)
+	// does not silently propagate into a pk returned earlier from
+	// NewKeyFromSeed. See cloudflare/circl#600.
+	pk.tr = new([TRSize]byte)
+	*pk.tr = sk.tr
 
 	return &pk, &sk
 }
@@ -472,13 +477,18 @@ func SignTo(sk *PrivateKey, msg func(io.Writer), rnd [32]byte, signature []byte)
 }
 
 // Computes the public key corresponding to this private key.
+//
+// The returned pk holds its own copy of tr; later mutation of sk.tr
+// does not affect a pk previously returned from this method.
+// See cloudflare/circl#600.
 func (sk *PrivateKey) Public() *PublicKey {
 	var t0 VecK
 	pk := &PublicKey{
 		rho: sk.rho,
 		A:   &sk.A,
-		tr:  &sk.tr,
+		tr:  new([TRSize]byte),
 	}
+	*pk.tr = sk.tr
 	sk.computeT0andT1(&t0, &pk.t1)
 	pk.t1.PackT1(pk.t1p[:])
 	return pk

--- a/sign/mldsa/mldsa87/internal/dilithium_test.go
+++ b/sign/mldsa/mldsa87/internal/dilithium_test.go
@@ -140,6 +140,33 @@ func TestPublicFromPrivate(t *testing.T) {
 	}
 }
 
+// Regression test for cloudflare/circl#600: the pk returned by
+// NewKeyFromSeed and (*PrivateKey).Public must hold its own copy of tr,
+// not a pointer aliasing sk.tr. Otherwise a later mutation of sk -- for
+// instance through (*PrivateKey).Unpack on attacker-controlled bytes --
+// silently propagates into a pk that was returned earlier.
+func TestPublicTrIsIndependentOfPrivate(t *testing.T) {
+	var seed [common.SeedSize]byte
+	pkSeed, sk := NewKeyFromSeed(&seed)
+	pkPub := sk.Public()
+
+	pkSeedTr := *pkSeed.tr
+	pkPubTr := *pkPub.tr
+
+	for i := range sk.tr {
+		sk.tr[i] ^= 0xff
+	}
+
+	if *pkSeed.tr != pkSeedTr {
+		t.Fatalf("pk from NewKeyFromSeed aliased sk.tr (got %x want %x)",
+			*pkSeed.tr, pkSeedTr)
+	}
+	if *pkPub.tr != pkPubTr {
+		t.Fatalf("pk from sk.Public() aliased sk.tr (got %x want %x)",
+			*pkPub.tr, pkPubTr)
+	}
+}
+
 func TestGamma1Size(t *testing.T) {
 	var expected int
 	switch Gamma1Bits {


### PR DESCRIPTION
## Summary

Resolves cloudflare/circl#600.

`(*PrivateKey).Public()` and `NewKeyFromSeed` previously cached `tr`
on the returned `*PublicKey` as a pointer aliasing `sk.tr`. As a
result, any later mutation of `sk.tr` -- e.g. through a subsequent
`(*PrivateKey).Unpack` on attacker-controlled bytes -- silently
propagated into a `pk` that had already been handed back to the
caller.

This PR switches both sites to a value copy. The returned `pk` now
holds its own `[TRSize]byte` and is independent of subsequent changes
to `sk`.

The change matches the direction in @bwesterb's [reply on #600](https://github.com/cloudflare/circl/issues/600) ("not use a pointer, but rather store a copy").

## Implementation

Edited in `sign/dilithium/mode3/internal/dilithium.go` (the master).
Regenerated to `mode2`, `mode5`, and `sign/mldsa/{mldsa44,mldsa65,mldsa87}`
via `go generate ./sign/dilithium/`.

A regression test `TestPublicTrIsIndependentOfPrivate` is added in
the same master and propagates to all six internal packages. It
asserts that mutating `sk.tr` after `NewKeyFromSeed` and after
`sk.Public()` does not change the `tr` byte values stored in the
returned `pk`.

## Test plan

- [x] ` + "`go generate -v ./...`" + ` clean (no drift outside the 12 intended files)
- [x] ` + "`go vet ./sign/dilithium/... ./sign/mldsa/...`" + `
- [x] ` + "`go build ./sign/dilithium/... ./sign/mldsa/...`" + `
- [x] ` + "`go test -count=1 ./sign/dilithium/... ./sign/mldsa/...`" + ` — 12/12 packages pass, including the new regression test in all six internal packages
- [x] ` + "`go vet -vettool=$(which shadow) ./sign/dilithium/... ./sign/mldsa/...`" + ` clean