### PR TITLE
expander: panic on Expand n > 65535 to honor documented limit.

### DIFF
--- a/expander/expander.go
+++ b/expander/expander.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"math"
 
 	"github.com/cloudflare/circl/xof"
 )
@@ -95,8 +96,11 @@ func NewExpanderXOF(id xof.ID, kSecLevel uint, dst []byte) *expanderXOF {
 	return &expanderXOF{id, kSecLevel, dst}
 }
 
-// Expand panics if output's length is longer than 2^16 bytes.
+// Expand panics if output's length is longer than 2^16-1 bytes.
 func (e *expanderXOF) Expand(in []byte, n uint) []byte {
+	if n > math.MaxUint16 {
+		panic(errorLongOutput)
+	}
 	bLen := []byte{0, 0}
 	binary.BigEndian.PutUint16(bLen, uint16(n))
 	pseudo := make([]byte, n)

--- a/expander/expander_test.go
+++ b/expander/expander_test.go
@@ -7,6 +7,7 @@ import (
 	_ "crypto/sha512"
 	"encoding/json"
 	"fmt"
+	"math"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -15,6 +16,16 @@ import (
 	"github.com/cloudflare/circl/internal/test"
 	"github.com/cloudflare/circl/xof"
 )
+
+func TestExpanderXOFPanicsOnLongOutput(t *testing.T) {
+	exp := expander.NewExpanderXOF(xof.SHAKE128, 0, []byte("test-dst"))
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Expand expected to panic for n > 2^16-1, got no panic")
+		}
+	}()
+	exp.Expand([]byte("input"), uint(math.MaxUint16)+1)
+}
 
 func TestExpander(t *testing.T) {
 	fileNames, err := filepath.Glob("./testdata/*.json.gz")


### PR DESCRIPTION
expanderXOF.Expand documents that it panics if the requested output is longer than 2^16 bytes, but the code silently truncated via uint16(n) instead. For n >= 65536 this corrupts the length encoding in the XOF stream, breaking RFC compliance for large outputs.
Add a bounds check that panics with the existing errorLongOutput sentinel.