### PR TITLE
internal/test/acvp: unify ACVP prompt/results loading. Closes #533.

### DIFF
--- a/internal/test/acvp/acvp.go
+++ b/internal/test/acvp/acvp.go
@@ -1,0 +1,65 @@
+// Package acvp provides shared helpers for ACVP test vector parsing.
+package acvp
+
+import (
+	"encoding/json"
+	"path"
+	"testing"
+
+	"github.com/cloudflare/circl/internal/test"
+)
+
+// LoadVectors loads ACVP prompt and expectedResults files from the given
+// directory (containing prompt.json.gz and expectedResults.json.gz).
+//
+// It returns the prompt's raw test groups and a map keyed by tcId mapping
+// to the raw test JSON from expectedResults.
+func LoadVectors(t *testing.T, dir string) (groups []json.RawMessage, results map[int]json.RawMessage) {
+	t.Helper()
+
+	buf, err := test.ReadGzip(path.Join(dir, "prompt.json.gz"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var prompt struct {
+		TestGroups []json.RawMessage `json:"testGroups"`
+	}
+	if err := json.Unmarshal(buf, &prompt); err != nil {
+		t.Fatal(err)
+	}
+
+	buf, err = test.ReadGzip(path.Join(dir, "expectedResults.json.gz"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var expected struct {
+		TestGroups []json.RawMessage `json:"testGroups"`
+	}
+	if err := json.Unmarshal(buf, &expected); err != nil {
+		t.Fatal(err)
+	}
+
+	results = make(map[int]json.RawMessage)
+	for _, rawGroup := range expected.TestGroups {
+		var group struct {
+			Tests []json.RawMessage `json:"tests"`
+		}
+		if err := json.Unmarshal(rawGroup, &group); err != nil {
+			t.Fatal(err)
+		}
+		for _, rawTest := range group.Tests {
+			var tst struct {
+				TcID int `json:"tcId"`
+			}
+			if err := json.Unmarshal(rawTest, &tst); err != nil {
+				t.Fatal(err)
+			}
+			if _, exists := results[tst.TcID]; exists {
+				t.Fatalf("duplicate test id: %d", tst.TcID)
+			}
+			results[tst.TcID] = rawTest
+		}
+	}
+
+	return prompt.TestGroups, results
+}

--- a/kem/mlkem/acvp_test.go
+++ b/kem/mlkem/acvp_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cloudflare/circl/internal/test"
+	"github.com/cloudflare/circl/internal/test/acvp"
 	"github.com/cloudflare/circl/kem/schemes"
 )
 
@@ -22,56 +23,9 @@ func TestACVP(t *testing.T) {
 
 // nolint:funlen,gocyclo
 func testACVP(t *testing.T, sub string) {
-	buf, err := test.ReadGzip("testdata/ML-KEM-" + sub + "-FIPS203/prompt.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
+	groups, rawResults := acvp.LoadVectors(t, "testdata/ML-KEM-"+sub+"-FIPS203")
 
-	var prompt struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err = json.Unmarshal(buf, &prompt); err != nil {
-		t.Fatal(err)
-	}
-
-	buf, err = test.ReadGzip("testdata/ML-KEM-" + sub + "-FIPS203/expectedResults.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var results struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err := json.Unmarshal(buf, &results); err != nil {
-		t.Fatal(err)
-	}
-
-	rawResults := make(map[int]json.RawMessage)
-
-	for _, rawGroup := range results.TestGroups {
-		var abstractGroup struct {
-			Tests []json.RawMessage `json:"tests"`
-		}
-		if err := json.Unmarshal(rawGroup, &abstractGroup); err != nil {
-			t.Fatal(err)
-		}
-		for _, rawTest := range abstractGroup.Tests {
-			var abstractTest struct {
-				TcID int `json:"tcId"`
-			}
-			if err := json.Unmarshal(rawTest, &abstractTest); err != nil {
-				t.Fatal(err)
-			}
-			if _, exists := rawResults[abstractTest.TcID]; exists {
-				t.Fatalf("Duplicate test id: %d", abstractTest.TcID)
-			}
-			rawResults[abstractTest.TcID] = rawTest
-		}
-	}
-
-	for _, rawGroup := range prompt.TestGroups {
+	for _, rawGroup := range groups {
 		var abstractGroup struct {
 			TestType string `json:"testType"`
 		}

--- a/sign/dilithium/templates/acvp.templ.go
+++ b/sign/dilithium/templates/acvp.templ.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/cloudflare/circl/internal/test"
+	"github.com/cloudflare/circl/internal/test/acvp"
 )
 
 func TestACVP(t *testing.T) {
@@ -28,58 +29,11 @@ func TestACVP(t *testing.T) {
 
 // nolint:funlen,gocyclo
 func testACVP(t *testing.T, sub string) {
-	buf, err := test.ReadGzip("../testdata/ML-DSA-" + sub + "-FIPS204/prompt.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var prompt struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err = json.Unmarshal(buf, &prompt); err != nil {
-		t.Fatal(err)
-	}
-
-	buf, err = test.ReadGzip("../testdata/ML-DSA-" + sub + "-FIPS204/expectedResults.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var results struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err := json.Unmarshal(buf, &results); err != nil {
-		t.Fatal(err)
-	}
-
-	rawResults := make(map[int]json.RawMessage)
-
-	for _, rawGroup := range results.TestGroups {
-		var abstractGroup struct {
-			Tests []json.RawMessage `json:"tests"`
-		}
-		if err := json.Unmarshal(rawGroup, &abstractGroup); err != nil {
-			t.Fatal(err)
-		}
-		for _, rawTest := range abstractGroup.Tests {
-			var abstractTest struct {
-				TcID int `json:"tcId"`
-			}
-			if err := json.Unmarshal(rawTest, &abstractTest); err != nil {
-				t.Fatal(err)
-			}
-			if _, exists := rawResults[abstractTest.TcID]; exists {
-				t.Fatalf("Duplicate test id: %d", abstractTest.TcID)
-			}
-			rawResults[abstractTest.TcID] = rawTest
-		}
-	}
+	groups, rawResults := acvp.LoadVectors(t, "../testdata/ML-DSA-"+sub+"-FIPS204")
 
 	scheme := Scheme()
 
-	for _, rawGroup := range prompt.TestGroups {
+	for _, rawGroup := range groups {
 		var abstractGroup struct {
 			TestType string `json:"testType"`
 		}

--- a/sign/mldsa/mldsa44/acvp_test.go
+++ b/sign/mldsa/mldsa44/acvp_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/cloudflare/circl/internal/test"
+	"github.com/cloudflare/circl/internal/test/acvp"
 )
 
 func TestACVP(t *testing.T) {
@@ -24,58 +25,11 @@ func TestACVP(t *testing.T) {
 
 // nolint:funlen,gocyclo
 func testACVP(t *testing.T, sub string) {
-	buf, err := test.ReadGzip("../testdata/ML-DSA-" + sub + "-FIPS204/prompt.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var prompt struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err = json.Unmarshal(buf, &prompt); err != nil {
-		t.Fatal(err)
-	}
-
-	buf, err = test.ReadGzip("../testdata/ML-DSA-" + sub + "-FIPS204/expectedResults.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var results struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err := json.Unmarshal(buf, &results); err != nil {
-		t.Fatal(err)
-	}
-
-	rawResults := make(map[int]json.RawMessage)
-
-	for _, rawGroup := range results.TestGroups {
-		var abstractGroup struct {
-			Tests []json.RawMessage `json:"tests"`
-		}
-		if err := json.Unmarshal(rawGroup, &abstractGroup); err != nil {
-			t.Fatal(err)
-		}
-		for _, rawTest := range abstractGroup.Tests {
-			var abstractTest struct {
-				TcID int `json:"tcId"`
-			}
-			if err := json.Unmarshal(rawTest, &abstractTest); err != nil {
-				t.Fatal(err)
-			}
-			if _, exists := rawResults[abstractTest.TcID]; exists {
-				t.Fatalf("Duplicate test id: %d", abstractTest.TcID)
-			}
-			rawResults[abstractTest.TcID] = rawTest
-		}
-	}
+	groups, rawResults := acvp.LoadVectors(t, "../testdata/ML-DSA-"+sub+"-FIPS204")
 
 	scheme := Scheme()
 
-	for _, rawGroup := range prompt.TestGroups {
+	for _, rawGroup := range groups {
 		var abstractGroup struct {
 			TestType string `json:"testType"`
 		}

--- a/sign/mldsa/mldsa65/acvp_test.go
+++ b/sign/mldsa/mldsa65/acvp_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/cloudflare/circl/internal/test"
+	"github.com/cloudflare/circl/internal/test/acvp"
 )
 
 func TestACVP(t *testing.T) {
@@ -24,58 +25,11 @@ func TestACVP(t *testing.T) {
 
 // nolint:funlen,gocyclo
 func testACVP(t *testing.T, sub string) {
-	buf, err := test.ReadGzip("../testdata/ML-DSA-" + sub + "-FIPS204/prompt.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var prompt struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err = json.Unmarshal(buf, &prompt); err != nil {
-		t.Fatal(err)
-	}
-
-	buf, err = test.ReadGzip("../testdata/ML-DSA-" + sub + "-FIPS204/expectedResults.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var results struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err := json.Unmarshal(buf, &results); err != nil {
-		t.Fatal(err)
-	}
-
-	rawResults := make(map[int]json.RawMessage)
-
-	for _, rawGroup := range results.TestGroups {
-		var abstractGroup struct {
-			Tests []json.RawMessage `json:"tests"`
-		}
-		if err := json.Unmarshal(rawGroup, &abstractGroup); err != nil {
-			t.Fatal(err)
-		}
-		for _, rawTest := range abstractGroup.Tests {
-			var abstractTest struct {
-				TcID int `json:"tcId"`
-			}
-			if err := json.Unmarshal(rawTest, &abstractTest); err != nil {
-				t.Fatal(err)
-			}
-			if _, exists := rawResults[abstractTest.TcID]; exists {
-				t.Fatalf("Duplicate test id: %d", abstractTest.TcID)
-			}
-			rawResults[abstractTest.TcID] = rawTest
-		}
-	}
+	groups, rawResults := acvp.LoadVectors(t, "../testdata/ML-DSA-"+sub+"-FIPS204")
 
 	scheme := Scheme()
 
-	for _, rawGroup := range prompt.TestGroups {
+	for _, rawGroup := range groups {
 		var abstractGroup struct {
 			TestType string `json:"testType"`
 		}

--- a/sign/mldsa/mldsa87/acvp_test.go
+++ b/sign/mldsa/mldsa87/acvp_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/cloudflare/circl/internal/test"
+	"github.com/cloudflare/circl/internal/test/acvp"
 )
 
 func TestACVP(t *testing.T) {
@@ -24,58 +25,11 @@ func TestACVP(t *testing.T) {
 
 // nolint:funlen,gocyclo
 func testACVP(t *testing.T, sub string) {
-	buf, err := test.ReadGzip("../testdata/ML-DSA-" + sub + "-FIPS204/prompt.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var prompt struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err = json.Unmarshal(buf, &prompt); err != nil {
-		t.Fatal(err)
-	}
-
-	buf, err = test.ReadGzip("../testdata/ML-DSA-" + sub + "-FIPS204/expectedResults.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var results struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err := json.Unmarshal(buf, &results); err != nil {
-		t.Fatal(err)
-	}
-
-	rawResults := make(map[int]json.RawMessage)
-
-	for _, rawGroup := range results.TestGroups {
-		var abstractGroup struct {
-			Tests []json.RawMessage `json:"tests"`
-		}
-		if err := json.Unmarshal(rawGroup, &abstractGroup); err != nil {
-			t.Fatal(err)
-		}
-		for _, rawTest := range abstractGroup.Tests {
-			var abstractTest struct {
-				TcID int `json:"tcId"`
-			}
-			if err := json.Unmarshal(rawTest, &abstractTest); err != nil {
-				t.Fatal(err)
-			}
-			if _, exists := rawResults[abstractTest.TcID]; exists {
-				t.Fatalf("Duplicate test id: %d", abstractTest.TcID)
-			}
-			rawResults[abstractTest.TcID] = rawTest
-		}
-	}
+	groups, rawResults := acvp.LoadVectors(t, "../testdata/ML-DSA-"+sub+"-FIPS204")
 
 	scheme := Scheme()
 
-	for _, rawGroup := range prompt.TestGroups {
+	for _, rawGroup := range groups {
 		var abstractGroup struct {
 			TestType string `json:"testType"`
 		}


### PR DESCRIPTION
he boilerplate to load ACVP prompt/results and build a tcId-keyed result map was duplicated. Extracted into internal/test/acvp.LoadVectors.
slhdsa uses a different style and is not touched.
Closes #533