### PR TITLE
abe/cpabe/tkn20: handle short ciphertexts as errors.

### DIFF
--- a/abe/cpabe/tkn20/internal/tkn/bk.go
+++ b/abe/cpabe/tkn20/internal/tkn/bk.go
@@ -141,7 +141,7 @@ type rmLenPref = func([]byte) ([]byte, []byte, error)
 
 func checkCiphertextFormat(ciphertext []byte) (ct []byte, fn rmLenPref) {
 	const N = len(CiphertextVersion)
-	if bytes.Equal(ciphertext[0:N], []byte(CiphertextVersion)) {
+	if len(ciphertext) >= N && bytes.Equal(ciphertext[0:N], []byte(CiphertextVersion)) {
 		return ciphertext[N:], removeLen32Prefixed
 	}
 	return ciphertext, removeLenPrefixed

--- a/abe/cpabe/tkn20/internal/tkn/bk_test.go
+++ b/abe/cpabe/tkn20/internal/tkn/bk_test.go
@@ -2,6 +2,7 @@ package tkn
 
 import (
 	"crypto/rand"
+	"encoding/binary"
 	"testing"
 )
 
@@ -287,6 +288,90 @@ var benchAttrs = &Attributes{
 		wild:  false,
 		Value: ToScalar(1),
 	},
+}
+
+func TestMalformedCiphertextInternal(t *testing.T) {
+	public, secret, err := GenerateParams(rand.Reader)
+	if err != nil {
+		t.Fatalf("error generating parameters: %s", err)
+	}
+	policy := &Policy{
+		Inputs: []Wire{
+			{"a", "", ToScalar(1), true},
+		},
+		F: Formula{
+			Gates: []Gate{},
+		},
+	}
+	attrs := &Attributes{
+		"a": {
+			wild:  false,
+			Value: ToScalar(1),
+		},
+	}
+	userKey, err := DeriveAttributeKeysCCA(rand.Reader, secret, attrs)
+	if err != nil {
+		t.Fatalf("error generating Attribute keys: %s", err)
+	}
+
+	msg := []byte("drink your ovaltine")
+	ciphertext, err := EncryptCCA(rand.Reader, public, policy, msg)
+	if err != nil {
+		t.Fatalf("error encrypting: %s", err)
+	}
+
+	// Empty ciphertext must not panic.
+	if CouldDecrypt([]byte{}, attrs) {
+		t.Fatal("empty ciphertext should not be decryptable")
+	}
+	if _, err := DecryptCCA([]byte{}, userKey); err == nil {
+		t.Fatal("empty ciphertext should fail to decrypt")
+	}
+	badPolicy := &Policy{}
+	if err := badPolicy.ExtractFromCiphertext([]byte{}); err == nil {
+		t.Fatal("empty ciphertext should fail extraction")
+	}
+
+	// Truncated ciphertexts must not panic.
+	// DecryptCCA must return an error for any truncation because it needs
+	// the authentication tag, but CouldDecrypt and ExtractFromCiphertext
+	// only need the header and may succeed if the truncation is in the
+	// trailing tag/mac region.
+	for i := 1; i < len(ciphertext); i++ {
+		truncated := ciphertext[:i]
+		_ = CouldDecrypt(truncated, attrs)
+		if _, err := DecryptCCA(truncated, userKey); err == nil {
+			t.Fatalf("truncated ciphertext (len=%d) should fail to decrypt", i)
+		}
+		badPolicy := &Policy{}
+		_ = badPolicy.ExtractFromCiphertext(truncated)
+	}
+
+	// Manipulated lengths to create inconsistent data.
+	// Corrupt the macData length field in a v1.3.8 ciphertext.
+	if len(ciphertext) > len(CiphertextVersion)+4 {
+		corrupted := make([]byte, len(ciphertext))
+		copy(corrupted, ciphertext)
+		// The layout is: version | id (len-prefixed) | macData (len32-prefixed) | tag (len-prefixed)
+		// Corrupt the 32-bit length prefix of macData to claim a huge size.
+		idx := len(CiphertextVersion)
+		// Skip id length-prefixed field
+		_, rem, err := removeLenPrefixed(corrupted[idx:])
+		if err == nil {
+			// rem now starts with the 32-bit length prefix for macData
+			binary.LittleEndian.PutUint32(rem, 0xFFFFFFFF)
+			if CouldDecrypt(corrupted, attrs) {
+				t.Fatal("corrupted-length ciphertext should not be decryptable")
+			}
+			if _, err := DecryptCCA(corrupted, userKey); err == nil {
+				t.Fatal("corrupted-length ciphertext should fail to decrypt")
+			}
+			badPolicy := &Policy{}
+			if err := badPolicy.ExtractFromCiphertext(corrupted); err == nil {
+				t.Fatal("corrupted-length ciphertext should fail extraction")
+			}
+		}
+	}
 }
 
 func BenchmarkTkDecryption(b *testing.B) {

--- a/abe/cpabe/tkn20/internal/tkn/formula.go
+++ b/abe/cpabe/tkn20/internal/tkn/formula.go
@@ -76,6 +76,9 @@ func (f *Formula) UnmarshalBinary(data []byte) error {
 		return fmt.Errorf("too short data")
 	}
 	n := int(binary.LittleEndian.Uint16(data[0:2]))
+	if len(data) < 2+7*n {
+		return fmt.Errorf("too short data")
+	}
 	f.Gates = make([]Gate, n)
 	for i := 0; i < n; i++ {
 		f.Gates[i].Class = int(data[7*i+2])

--- a/abe/cpabe/tkn20/internal/tkn/policy.go
+++ b/abe/cpabe/tkn20/internal/tkn/policy.go
@@ -234,7 +234,10 @@ func (p *Policy) UnmarshalBinary(data []byte) error {
 	}
 	fLen := uint(binary.LittleEndian.Uint16(data))
 	data = data[2:]
-	err := p.F.UnmarshalBinary(data)
+	if uint(len(data)) < fLen {
+		return fmt.Errorf("data not long enough")
+	}
+	err := p.F.UnmarshalBinary(data[:fLen])
 	if err != nil {
 		return err
 	}
@@ -247,13 +250,19 @@ func (p *Policy) UnmarshalBinary(data []byte) error {
 	data = data[2:]
 	p.Inputs = make([]Wire, nWires)
 	for i := 0; i < nWires; i++ {
+		if len(data) < 2 {
+			return fmt.Errorf("data not long enough")
+		}
 		wireLen := uint(binary.LittleEndian.Uint16(data))
 		data = data[2:]
-		err = p.Inputs[i].UnmarshalBinary(data)
-		data = data[wireLen:]
+		if uint(len(data)) < wireLen {
+			return fmt.Errorf("data not long enough")
+		}
+		err = p.Inputs[i].UnmarshalBinary(data[:wireLen])
 		if err != nil {
 			return fmt.Errorf("data not long enough")
 		}
+		data = data[wireLen:]
 	}
 	return nil
 }

--- a/abe/cpabe/tkn20/internal/tkn/tk.go
+++ b/abe/cpabe/tkn20/internal/tkn/tk.go
@@ -410,6 +410,9 @@ func (hdr *ciphertextHeader) unmarshalBinary(data []byte) error {
 	if err != nil {
 		return err
 	}
+	if len(data) < 2 {
+		return fmt.Errorf("ciphertext header too short")
+	}
 	c2Len := int(binary.LittleEndian.Uint16(data))
 	hdr.c2 = make([]*matrixG2, c2Len)
 	data = data[2:]
@@ -429,6 +432,9 @@ func (hdr *ciphertextHeader) unmarshalBinary(data []byte) error {
 		}
 	}
 
+	if len(data) < 2 {
+		return fmt.Errorf("ciphertext header too short")
+	}
 	c3Len := int(binary.LittleEndian.Uint16(data))
 	hdr.c3 = make([]*matrixG1, c3Len)
 	hdr.c3neg = make([]*matrixG1, c3Len)

--- a/abe/cpabe/tkn20/tkn20_test.go
+++ b/abe/cpabe/tkn20/tkn20_test.go
@@ -195,6 +195,79 @@ func TestMarshal(t *testing.T) {
 	}
 }
 
+func TestMalformedCiphertext(t *testing.T) {
+	pk, msk, err := Setup(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := Policy{}
+	err = policy.FromString("a:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	attrs := Attributes{}
+	attrs.FromMap(map[string]string{"a": "1"})
+	sk, err := msk.KeyGen(rand.Reader, attrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := []byte("test")
+	validCT, err := pk.Encrypt(rand.Reader, policy, msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty ciphertext must not panic.
+	emptyAttrs := Attributes{}
+	emptyAttrs.FromMap(map[string]string{})
+	_ = emptyAttrs.CouldDecrypt([]byte{})
+	if _, err := sk.Decrypt([]byte{}); err == nil {
+		t.Fatal("empty ciphertext should fail to decrypt")
+	}
+	badPolicy := &Policy{}
+	if err := badPolicy.ExtractFromCiphertext([]byte{}); err == nil {
+		t.Fatal("empty ciphertext should fail extraction")
+	}
+
+	// Truncate the valid ciphertext at every byte and ensure no panic.
+	// DecryptCCA must return an error for any truncation because it needs
+	// the authentication tag, but CouldDecrypt and ExtractFromCiphertext
+	// only need the header and may succeed if the truncation is in the
+	// trailing tag/mac region.
+	for i := 1; i < len(validCT); i++ {
+		truncated := validCT[:i]
+		_ = attrs.CouldDecrypt(truncated)
+		if _, err := sk.Decrypt(truncated); err == nil {
+			t.Fatalf("truncated ciphertext (len=%d) should fail to decrypt", i)
+		}
+		badPolicy = &Policy{}
+		_ = badPolicy.ExtractFromCiphertext(truncated)
+	}
+
+	// Legacy format (no version prefix) with minimal data.
+	legacyTruncated := []byte{0x00, 0x00}
+	_ = attrs.CouldDecrypt(legacyTruncated)
+	if _, err := sk.Decrypt(legacyTruncated); err == nil {
+		t.Fatal("legacy truncated ciphertext should fail to decrypt")
+	}
+	badPolicy = &Policy{}
+	if err := badPolicy.ExtractFromCiphertext(legacyTruncated); err == nil {
+		t.Fatal("legacy truncated ciphertext should fail extraction")
+	}
+
+	// Version prefix with truncated remainder.
+	versionPrefixed := append([]byte("v1.3.8"), []byte{0x00, 0x00}...)
+	_ = attrs.CouldDecrypt(versionPrefixed)
+	if _, err := sk.Decrypt(versionPrefixed); err == nil {
+		t.Fatal("version-prefixed truncated ciphertext should fail to decrypt")
+	}
+	badPolicy = &Policy{}
+	if err := badPolicy.ExtractFromCiphertext(versionPrefixed); err == nil {
+		t.Fatal("version-prefixed truncated ciphertext should fail extraction")
+	}
+}
+
 func TestPolicyMethods(t *testing.T) {
 	policyStr := "(season: fall or season: winter) or (region: alaska and season: summer)"
 	policy := Policy{}


### PR DESCRIPTION
In a few places, decryption neglects to check the length of the buffer before slicing, causing decryption to panic instead of returning an error.