### PR TITLE
hpke: don't panic when parsing on hybrid keys/ciphertexts.

### DIFF
--- a/hpke/hpke_test.go
+++ b/hpke/hpke_test.go
@@ -63,6 +63,40 @@ func Example() {
 	// Output: true
 }
 
+func TestHybridKEMMalformedInputs(t *testing.T) {
+	scheme := hpke.KEM_X25519_KYBER768_DRAFT00.Scheme()
+	pk, sk, err := scheme.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = scheme.Decapsulate(sk, []byte{})
+	if err == nil {
+		t.Error("Decapsulate with short ciphertext should fail")
+	}
+
+	_, err = scheme.UnmarshalBinaryPrivateKey([]byte{})
+	if err == nil {
+		t.Error("UnmarshalBinaryPrivateKey with short data should fail")
+	}
+
+	_, err = scheme.UnmarshalBinaryPublicKey([]byte{})
+	if err == nil {
+		t.Error("UnmarshalBinaryPublicKey with short data should fail")
+	}
+
+	seed := make([]byte, scheme.EncapsulationSeedSize())
+	_, _, err = scheme.EncapsulateDeterministically(pk, []byte{})
+	if err == nil {
+		t.Error("EncapsulateDeterministically with short seed should fail")
+	}
+
+	_, _, err = scheme.EncapsulateDeterministically(pk, seed)
+	if err != nil {
+		t.Errorf("EncapsulateDeterministically with correct seed failed: %v", err)
+	}
+}
+
 func runHpkeBenchmark(b *testing.B, kem hpke.KEM, kdf hpke.KDF, aead hpke.AEAD) {
 	suite := hpke.NewSuite(kem, kdf, aead)
 

--- a/hpke/hybridkem.go
+++ b/hpke/hybridkem.go
@@ -53,7 +53,13 @@ func (h hybridKEM) Encapsulate(pkr kem.PublicKey) (
 }
 
 func (h hybridKEM) Decapsulate(skr kem.PrivateKey, ct []byte) ([]byte, error) {
-	hybridSk := skr.(*hybridKEMPrivKey)
+	if len(ct) != h.CiphertextSize() {
+		return nil, kem.ErrCiphertextSize
+	}
+	hybridSk, ok := skr.(*hybridKEMPrivKey)
+	if !ok {
+		return nil, kem.ErrTypeMismatch
+	}
 	ssA, err := h.kemA.Decapsulate(hybridSk.privA, ct[0:h.kemA.CiphertextSize()])
 	if err != nil {
 		return nil, err
@@ -71,7 +77,13 @@ func (h hybridKEM) Decapsulate(skr kem.PrivateKey, ct []byte) ([]byte, error) {
 func (h hybridKEM) EncapsulateDeterministically(
 	pkr kem.PublicKey, seed []byte,
 ) (ct, ss []byte, err error) {
-	hybridPk := pkr.(*hybridKEMPubKey)
+	if len(seed) != h.EncapsulationSeedSize() {
+		return nil, nil, kem.ErrSeedSize
+	}
+	hybridPk, ok := pkr.(*hybridKEMPubKey)
+	if !ok {
+		return nil, nil, kem.ErrTypeMismatch
+	}
 	encA, ssA, err := h.kemA.EncapsulateDeterministically(hybridPk.pubA, seed[0:h.kemA.EncapsulationSeedSize()])
 	if err != nil {
 		return nil, nil, err
@@ -200,6 +212,9 @@ func (h hybridKEM) GenerateKeyPair() (kem.PublicKey, kem.PrivateKey, error) {
 }
 
 func (h hybridKEM) UnmarshalBinaryPrivateKey(data []byte) (kem.PrivateKey, error) {
+	if len(data) != h.PrivateKeySize() {
+		return nil, kem.ErrPrivKeySize
+	}
 	skA, err := h.kemA.UnmarshalBinaryPrivateKey(data[0:h.kemA.PrivateKeySize()])
 	if err != nil {
 		return nil, err
@@ -216,6 +231,9 @@ func (h hybridKEM) UnmarshalBinaryPrivateKey(data []byte) (kem.PrivateKey, error
 }
 
 func (h hybridKEM) UnmarshalBinaryPublicKey(data []byte) (kem.PublicKey, error) {
+	if len(data) != h.PublicKeySize() {
+		return nil, kem.ErrPubKeySize
+	}
 	pkA, err := h.kemA.UnmarshalBinaryPublicKey(data[0:h.kemA.PublicKeySize()])
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The `hybridKEM` implementation of the HPKE doesn't check that the marshaled quantities, like the private key, public key, and ciphertext, have the expected length. If short quantities are given, then the implementation will panic instead of handling these as errors.