### PR TITLE
blindsign/blindrsa: reject non-canonical signatures.

### DIFF
--- a/blindsign/blindrsa/brsa_test.go
+++ b/blindsign/blindrsa/brsa_test.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cloudflare/circl/blindsign/blindrsa/internal/common"
+	"github.com/cloudflare/circl/blindsign/blindrsa/internal/keys"
 	"github.com/cloudflare/circl/internal/test"
 )
 
@@ -368,6 +370,70 @@ func TestVectors(t *testing.T) {
 
 	for _, vector := range tvl {
 		t.Run(vector.Name, vector.verifyTestVector)
+	}
+}
+
+func TestNonCanonicalSignatureRejection(t *testing.T) {
+	message := []byte("hello world")
+	key, err := loadPrivateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, variant := range []Variant{
+		SHA384PSSDeterministic,
+		SHA384PSSZeroDeterministic,
+		SHA384PSSRandomized,
+		SHA384PSSZeroRandomized,
+	} {
+		t.Run(variant.String(), func(tt *testing.T) {
+			client, err := NewClient(variant, &key.PublicKey)
+			if err != nil {
+				t.Fatal(err)
+			}
+			signer := NewSigner(key)
+
+			inputMsg, err := client.Prepare(rand.Reader, message)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			blindedMsg, state, err := client.Blind(rand.Reader, inputMsg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			blindedSig, err := signer.BlindSign(blindedMsg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			sig, err := client.Finalize(state, blindedSig)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Compute a non-canonical signature representative: s + N
+			s := new(big.Int).SetBytes(sig)
+			s.Add(s, key.N)
+
+			kLen := (key.N.BitLen() + 7) / 8
+			if s.BitLen() > kLen*8 {
+				// s + N overflows the fixed-width encoding, skip this test
+				return
+			}
+
+			sigPlusN := make([]byte, kLen)
+			s.FillBytes(sigPlusN)
+
+			if client.Verify(inputMsg, sigPlusN) == nil {
+				t.Fatal("expected verification to fail for non-canonical signature s+N")
+			}
+
+			if common.VerifyBlindSignature(keys.NewBigPublicKey(client.v.pk), state.encodedMsg, sigPlusN) == nil {
+				t.Fatal("expected VerifyBlindSignature to fail for non-canonical signature s+N")
+			}
+		})
 	}
 }
 

--- a/blindsign/blindrsa/internal/common/common.go
+++ b/blindsign/blindrsa/internal/common/common.go
@@ -94,8 +94,14 @@ func DecryptAndCheck(random io.Reader, priv *keys.BigPrivateKey, c *big.Int) (m 
 
 // VerifyBlindSignature verifies the signature of the hashed and encoded message against the input public key.
 func VerifyBlindSignature(pub *keys.BigPublicKey, hashed, sig []byte) error {
+	if len(sig) != pub.Size() {
+		return rsa.ErrVerification
+	}
 	m := new(big.Int).SetBytes(hashed)
 	bigSig := new(big.Int).SetBytes(sig)
+	if bigSig.Cmp(pub.N) >= 0 {
+		return rsa.ErrVerification
+	}
 
 	c := encrypt(new(big.Int), pub.N, pub.E, bigSig)
 	if subtle.ConstantTimeCompare(m.Bytes(), c.Bytes()) == 1 {
@@ -117,6 +123,9 @@ func verifyPSS(pub *keys.BigPublicKey, hash crypto.Hash, digest []byte, sig []by
 		return rsa.ErrVerification
 	}
 	s := new(big.Int).SetBytes(sig)
+	if s.Cmp(pub.N) >= 0 {
+		return rsa.ErrVerification
+	}
 	m := encrypt(new(big.Int), pub.N, pub.E, s)
 	emBits := pub.N.BitLen() - 1
 	emLen := (emBits + 7) / 8

--- a/blindsign/blindrsa/partiallyblindrsa/pbrsa_test.go
+++ b/blindsign/blindrsa/partiallyblindrsa/pbrsa_test.go
@@ -306,6 +306,41 @@ func TestPBRSAGenerateTestVector(t *testing.T) {
 	}
 }
 
+func TestNonCanonicalSignatureRejection(t *testing.T) {
+	message := []byte("hello world")
+	metadata := []byte("metadata")
+	key := loadStrongRSAKey()
+
+	hash := crypto.SHA384
+	verifier := NewVerifier(&key.PublicKey, hash)
+	signer, err := NewSigner(key, hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sig, err := runPBRSA(signer, verifier, message, metadata, rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compute a non-canonical signature representative: s + N
+	s := new(big.Int).SetBytes(sig)
+	s.Add(s, key.N)
+
+	kLen := (key.N.BitLen() + 7) / 8
+	if s.BitLen() > kLen*8 {
+		// s + N overflows the fixed-width encoding, skip this test
+		return
+	}
+
+	sigPlusN := make([]byte, kLen)
+	s.FillBytes(sigPlusN)
+
+	if verifier.Verify(message, metadata, sigPlusN) == nil {
+		t.Fatal("expected verification to fail for non-canonical signature s+N")
+	}
+}
+
 func BenchmarkPBRSA(b *testing.B) {
 	message := []byte("hello world")
 	metadata := []byte("good doggo")


### PR DESCRIPTION
The blind RSA verifier accepts signatures that are larger than the modulus (but have the same length). In Privacy Pass, this could allow double spending if both the signature and nonce are used for double spend prevention. Using only the nonce is sufficient to prevent this.