### PR TITLE
sign/{ed25519,ed448}: check if public key is identity.

### DIFF
--- a/sign/ed25519/ed25519.go
+++ b/sign/ed25519/ed25519.go
@@ -327,7 +327,7 @@ func verify(public PublicKey, message, signature, ctx []byte, preHash bool) bool
 	}
 
 	var P pointR1
-	if ok := P.FromBytes(public); !ok {
+	if ok := P.FromBytes(public); !ok || P.IsIdentity() {
 		return false
 	}
 

--- a/sign/ed25519/ed25519_test.go
+++ b/sign/ed25519/ed25519_test.go
@@ -3,6 +3,7 @@ package ed25519_test
 import (
 	"testing"
 
+	"github.com/cloudflare/circl/sign"
 	"github.com/cloudflare/circl/sign/ed25519"
 )
 
@@ -36,6 +37,34 @@ func TestMalleability(t *testing.T) {
 
 	if ed25519.Verify(publicKey, msg, sig) {
 		t.Fatal("non-canonical signature accepted")
+	}
+}
+
+func TestIdentityPublicKey(t *testing.T) {
+	// Identity public key encoding: y=1, x=0, sign bit of x is 0.
+	identityPub := make([]byte, ed25519.PublicKeySize)
+	identityPub[0] = 0x01
+
+	// Signature with R=identity, S=0.
+	identitySig := make([]byte, ed25519.SignatureSize)
+	identitySig[0] = 0x01
+
+	msg := []byte("any message")
+
+	if ed25519.Verify(identityPub, msg, identitySig) {
+		t.Error("identity public key accepted by Verify")
+	}
+	if ed25519.VerifyPh(identityPub, msg, identitySig, "") {
+		t.Error("identity public key accepted by VerifyPh")
+	}
+	if ed25519.VerifyWithCtx(identityPub, msg, identitySig, "ctx") {
+		t.Error("identity public key accepted by VerifyWithCtx")
+	}
+
+	scheme := ed25519.Scheme()
+	_, err := scheme.UnmarshalBinaryPublicKey(identityPub)
+	if err != sign.ErrInvalidPublicKey {
+		t.Errorf("UnmarshalBinaryPublicKey returned %v, want %v", err, sign.ErrInvalidPublicKey)
 	}
 }
 

--- a/sign/ed25519/point.go
+++ b/sign/ed25519/point.go
@@ -24,6 +24,10 @@ func (P *pointR1) SetIdentity() {
 	P.tb = fp.Elt{}
 }
 
+func (P *pointR1) IsIdentity() bool {
+	return fp.IsZero(&P.x) && !fp.IsZero(&P.y) && !fp.IsZero(&P.z) && P.y == P.z
+}
+
 func (P *pointR1) toAffine() {
 	fp.Inv(&P.z, &P.z)
 	fp.Mul(&P.x, &P.x, &P.z)

--- a/sign/ed25519/point_test.go
+++ b/sign/ed25519/point_test.go
@@ -29,6 +29,14 @@ func TestPoint(t *testing.T) {
 		test.CheckOk(!invalid.isEqual(&invalid), "invalid point shouldn't match anything", t)
 	})
 
+	t.Run("isIdentity", func(t *testing.T) {
+		var P pointR1
+		P.SetIdentity()
+		test.CheckOk(P.IsIdentity(), "SetIdentity should produce identity", t)
+		randomPoint(&P)
+		test.CheckOk(!P.IsIdentity(), "random point should not be identity", t)
+	})
+
 	t.Run("add", func(t *testing.T) {
 		var P pointR1
 		var Q pointR1

--- a/sign/ed25519/signapi.go
+++ b/sign/ed25519/signapi.go
@@ -74,6 +74,10 @@ func (*scheme) UnmarshalBinaryPublicKey(buf []byte) (sign.PublicKey, error) {
 	}
 	pub := make(PublicKey, PublicKeySize)
 	copy(pub, buf[:PublicKeySize])
+	var P pointR1
+	if ok := P.FromBytes(pub); !ok || P.IsIdentity() {
+		return nil, sign.ErrInvalidPublicKey
+	}
 	return pub, nil
 }
 

--- a/sign/ed448/ed448.go
+++ b/sign/ed448/ed448.go
@@ -300,7 +300,7 @@ func verify(public PublicKey, message, signature, ctx []byte, preHash bool) bool
 	}
 
 	P, err := goldilocks.FromBytes(public)
-	if err != nil {
+	if err != nil || P.IsIdentity() {
 		return false
 	}
 

--- a/sign/ed448/ed448_test.go
+++ b/sign/ed448/ed448_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cloudflare/circl/internal/test"
+	"github.com/cloudflare/circl/sign"
 	"github.com/cloudflare/circl/sign/ed448"
 )
 
@@ -40,6 +41,31 @@ func TestEqual(t *testing.T) {
 	}
 	if private.Equal(otherPriv) {
 		t.Errorf("different private keys are Equal")
+	}
+}
+
+func TestIdentityPublicKey(t *testing.T) {
+	// Identity public key encoding: y=1, x=0, sign bit of x is 0.
+	identityPub := make([]byte, ed448.PublicKeySize)
+	identityPub[0] = 0x01
+
+	// Signature with R=identity, S=0.
+	identitySig := make([]byte, ed448.SignatureSize)
+	identitySig[0] = 0x01
+
+	msg := []byte("any message")
+
+	if ed448.Verify(identityPub, msg, identitySig, "") {
+		t.Error("identity public key accepted by Verify")
+	}
+	if ed448.VerifyPh(identityPub, msg, identitySig, "") {
+		t.Error("identity public key accepted by VerifyPh")
+	}
+
+	scheme := ed448.Scheme()
+	_, err := scheme.UnmarshalBinaryPublicKey(identityPub)
+	if err != sign.ErrInvalidPublicKey {
+		t.Errorf("UnmarshalBinaryPublicKey returned %v, want %v", err, sign.ErrInvalidPublicKey)
 	}
 }
 

--- a/sign/ed448/signapi.go
+++ b/sign/ed448/signapi.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/asn1"
 
+	"github.com/cloudflare/circl/ecc/goldilocks"
 	"github.com/cloudflare/circl/sign"
 )
 
@@ -74,6 +75,10 @@ func (*scheme) UnmarshalBinaryPublicKey(buf []byte) (sign.PublicKey, error) {
 	}
 	pub := make(PublicKey, PublicKeySize)
 	copy(pub, buf[:PublicKeySize])
+	P, err := goldilocks.FromBytes(pub)
+	if err != nil || P.IsIdentity() {
+		return nil, sign.ErrInvalidPublicKey
+	}
 	return pub, nil
 }
 

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -110,6 +110,10 @@ var (
 	// the wrong size.
 	ErrPrivKeySize = errors.New("wrong size for private key")
 
+	// ErrInvalidPublicKey is the error used if the provided public key is
+	// invalid (e.g., it is the identity point).
+	ErrInvalidPublicKey = errors.New("invalid public key")
+
 	// ErrContextNotSupported is the error used if a context is not
 	// supported.
 	ErrContextNotSupported = errors.New("context not supported")


### PR DESCRIPTION
When parsing a public key or verifying a signature, check that the public key is not the identity element.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->