### PR TITLE
ecc/bls12381: check input length for infinity encoding in SetBytes.

### DIFF
--- a/ecc/bls12381/g1.go
+++ b/ecc/bls12381/g1.go
@@ -49,6 +49,9 @@ func (g *G1) SetBytes(b []byte) error {
 		if isCompressed == 1 {
 			l = G1SizeCompressed
 		}
+		if len(b) < l {
+			return errInputLength
+		}
 		zeros := make([]byte, l-1)
 		if (b[0]&0x1F) != 0 || subtle.ConstantTimeCompare(b[1:l], zeros) != 1 {
 			return errEncoding

--- a/ecc/bls12381/g2.go
+++ b/ecc/bls12381/g2.go
@@ -47,6 +47,9 @@ func (g *G2) SetBytes(b []byte) error {
 		if isCompressed == 1 {
 			l = G2SizeCompressed
 		}
+		if len(b) < l {
+			return errInputLength
+		}
 		zeros := make([]byte, l-1)
 		if (b[0]&0x1F) != 0 || subtle.ConstantTimeCompare(b[1:l], zeros) != 1 {
 			return errEncoding


### PR DESCRIPTION
The initial length check only guarantees the compressed size, so an uncompressed-infinity prefix could cause SetBytes to slice b[1:l] beyond the buffer and panic. Validate len(b) >= l before slicing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->