### PR TITLE
oprf: reject identity element as public key.

### DIFF
--- a/oprf/keys.go
+++ b/oprf/keys.go
@@ -29,7 +29,18 @@ func (k *PrivateKey) UnmarshalBinary(s Suite, data []byte) error {
 	k.p = p
 	k.k = k.p.group.NewScalar()
 
-	return k.k.UnmarshalBinary(data)
+	if err := k.k.UnmarshalBinary(data); err != nil {
+		return err
+	}
+
+	// RFC 9497 requires private keys (scalars) to be non-zero. A zero
+	// private key produces an identity public key, which collapses the
+	// (V)OPRF/POPRF relation to a publicly computable function.
+	if k.k.IsZero() {
+		return ErrInvalidPrivateKey
+	}
+
+	return nil
 }
 
 func (k *PublicKey) UnmarshalBinary(s Suite, data []byte) error {
@@ -40,7 +51,19 @@ func (k *PublicKey) UnmarshalBinary(s Suite, data []byte) error {
 	k.p = p
 	k.e = k.p.group.NewElement()
 
-	return k.e.UnmarshalBinary(data)
+	if err := k.e.UnmarshalBinary(data); err != nil {
+		return err
+	}
+
+	// RFC 9497 requires DeserializeElement to reject the group identity.
+	// Accepting the identity public key would let a server prove a valid
+	// DLEQ relation with the public witness 0, collapsing the VOPRF/POPRF
+	// output to a publicly computable function of (input, info).
+	if k.e.IsIdentity() {
+		return ErrInvalidPublicKey
+	}
+
+	return nil
 }
 
 func (k *PrivateKey) Public() *PublicKey {
@@ -61,7 +84,14 @@ func GenerateKey(s Suite, rnd io.Reader) (*PrivateKey, error) {
 	if !ok {
 		return nil, ErrInvalidSuite
 	}
+
+	// RFC 9497 requires private keys to be non-zero. Retry in the
+	// negligible-probability case that a zero scalar is sampled.
+	zero := p.group.NewScalar()
 	privateKey := p.group.RandomScalar(rnd)
+	for privateKey.IsEqual(zero) {
+		privateKey = p.group.RandomScalar(rnd)
+	}
 
 	return &PrivateKey{p, privateKey, nil}, nil
 }

--- a/oprf/oprf.go
+++ b/oprf/oprf.go
@@ -115,7 +115,7 @@ func NewClient(s Suite) Client {
 
 func NewVerifiableClient(s Suite, server *PublicKey) VerifiableClient {
 	p, ok := s.(params)
-	if !ok || server == nil {
+	if !ok || server == nil || server.e == nil || server.e.IsIdentity() {
 		panic(ErrNoKey)
 	}
 	p.m = VerifiableMode
@@ -125,7 +125,7 @@ func NewVerifiableClient(s Suite, server *PublicKey) VerifiableClient {
 
 func NewPartialObliviousClient(s Suite, server *PublicKey) PartialObliviousClient {
 	p, ok := s.(params)
-	if !ok || server == nil {
+	if !ok || server == nil || server.e == nil || server.e.IsIdentity() {
 		panic(ErrNoKey)
 	}
 	p.m = PartialObliviousMode
@@ -251,6 +251,8 @@ var (
 	ErrInvalidProof       = errors.New("oprf: proof verification failed")
 	ErrInverseZero        = errors.New("oprf: inverting a zero value")
 	ErrNoKey              = errors.New("oprf: must provide a key")
+	ErrInvalidPublicKey   = errors.New("oprf: invalid public key")
+	ErrInvalidPrivateKey  = errors.New("oprf: invalid private key")
 )
 
 type (

--- a/oprf/oprf_test.go
+++ b/oprf/oprf_test.go
@@ -248,6 +248,56 @@ func TestErrors(t *testing.T) {
 	})
 }
 
+// TestIdentityKeyRejection ensures the OPRF parsing boundary rejects the
+// identity public key and the zero private key, as required by RFC 9497.
+// Accepting them would let an attacker impersonate a verifiable OPRF server
+// without a secret key (see ZK-dfh985d3).
+func TestIdentityKeyRejection(t *testing.T) {
+	suites := []Suite{SuiteRistretto255, SuiteP256, SuiteP384, SuiteP521}
+	for _, suite := range suites {
+		t.Run(suite.Identifier(), func(t *testing.T) {
+			g := suite.Group()
+
+			// Serialized identity element must be rejected as a public key.
+			identity, err := g.Identity().MarshalBinaryCompress()
+			test.CheckNoErr(t, err, "failed to marshal identity")
+			err = new(PublicKey).UnmarshalBinary(suite, identity)
+			test.CheckIsErr(t, err, "must reject identity public key")
+			if err != ErrInvalidPublicKey {
+				t.Fatalf("expected ErrInvalidPublicKey, got %v", err)
+			}
+
+			// Serialized zero scalar must be rejected as a private key.
+			zero, err := g.NewScalar().MarshalBinary()
+			test.CheckNoErr(t, err, "failed to marshal zero scalar")
+			err = new(PrivateKey).UnmarshalBinary(suite, zero)
+			test.CheckIsErr(t, err, "must reject zero private key")
+			if err != ErrInvalidPrivateKey {
+				t.Fatalf("expected ErrInvalidPrivateKey, got %v", err)
+			}
+
+			// Constructors must reject an identity public key defensively.
+			idKey := &PublicKey{suite.(params), g.Identity()}
+			err = test.CheckPanic(func() { NewVerifiableClient(suite, idKey) })
+			test.CheckNoErr(t, err, "verifiable client must reject identity key")
+			err = test.CheckPanic(func() { NewPartialObliviousClient(suite, idKey) })
+			test.CheckNoErr(t, err, "partial oblivious client must reject identity key")
+
+			// A valid key must still round-trip and be accepted.
+			priv, err := GenerateKey(suite, rand.Reader)
+			test.CheckNoErr(t, err, "failed to generate key")
+			pubBytes, err := priv.Public().MarshalBinary()
+			test.CheckNoErr(t, err, "failed to marshal public key")
+			err = new(PublicKey).UnmarshalBinary(suite, pubBytes)
+			test.CheckNoErr(t, err, "valid public key must be accepted")
+			privBytes, err := priv.MarshalBinary()
+			test.CheckNoErr(t, err, "failed to marshal private key")
+			err = new(PrivateKey).UnmarshalBinary(suite, privBytes)
+			test.CheckNoErr(t, err, "valid private key must be accepted")
+		})
+	}
+}
+
 func Example_oprf() {
 	suite := SuiteP256
 	//                                  Server(sk, pk, info*)


### PR DESCRIPTION
RFC 9497 requires rejecting the identity element as a public key during deserialization.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->