### PR TITLE
Add AGENTS.md and REVIEW.md for contributor and AI agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# CIRCL Agent Instructions
+
+CIRCL is an **experimental, externally visible** Go cryptographic library.
+Consumers include Cloudflare's Go fork, downstream modules, and external
+researchers. Every change is security-sensitive. The README disclaims API
+stability — the bar is **"correct and justified,"** not "frozen."
+
+**When in doubt, stop and ask a human maintainer.**
+
+## Ground truth (read before acting)
+
+- `README.md`, `go.mod`, `.golangci.yaml`, `.github/workflows/ci-actions.yml`,
+  `Makefile`.
+
+## Security
+
+- **No new side channels.** Crypto on secret data must avoid secret-dependent
+  branches, memory accesses, table indices, and loop bounds. Use
+  `crypto/subtle` for comparisons and selection. Call out any deviation in
+  the commit message.
+- **`unsafe` is permitted but scrutinized.** Already used in
+  `simd/keccakf1600`, `internal/sha3`, `dh/csidh`, `ecc/fourq`. New uses
+  require written justification (perf number or interop reason) and should
+  stay inside `internal/`.
+- **Dependencies are allowlisted by `depguard`:** stdlib, `golang.org/x/*`,
+  `github.com/bwesterb/go-ristretto`, `github.com/cloudflare/circl`. New
+  entries require human approval and a `depguard` update in the same PR.
+- **Randomness:** `crypto/rand` or an injected `io.Reader`. Never
+  `math/rand` in crypto paths.
+- **Validate inputs at API boundaries.** Recent precedents: `sign/bls`
+  identity check, `ecc/bls12381` affinize identity handling, `pki` nil
+  block check, `zk/qndleq` zero-challenge check.
+
+## Testing
+
+- **`go test ./...` must pass on amd64.** CI also runs Go 1.25/1.26 on
+  arm64, WASM (`GOOS=js GOARCH=wasm`), macOS, and Windows. If you touch
+  assembly or `unsafe`, also try `NOASM=1` (purego).
+- **KATs:** the repo uses Known Answer Tests extensively (e.g.
+  `kem/kyber/kat_test.go`, `dh/x25519/testdata/wycheproof_kat.json.gz`).
+  Only regenerate a KAT with a written reason citing the upstream spec
+  (see commit `91088f2` as the model).
+- **Regression test every bug fix.** Recent `zk/qndleq`, `sign/bls`,
+  `ecc/bls12381`, `pki` commits all follow this pattern.
+
+## Code generation and assembly
+
+- Several packages are **generated** (`sign/dilithium`, `sign/mldsa`,
+  `kem/kyber`, `simd/keccakf1600`, `pke/kyber`). CI runs `go generate -v
+  ./...` and fails if the working tree changes. Edit the `templates/` or
+  `internal/.../asm/` source, then `make generate`.
+- 22 `.s` files exist, generated from `avo`-style Go programs. Any new
+  assembly path needs a matching pure-Go fallback for the `purego` build.
+
+## API and compatibility
+
+- The README says API changes are expected. Within a minor series, prefer
+  **additive** changes. Breaking changes are allowed at minor-version
+  boundaries; pair with `// Deprecated:` on the old API where feasible
+  (see `dh/sidh`, `kem/sike`).
+- **Never silently change a serialized wire format.** If you must,
+  regenerate KATs and call it out loudly.
+- Exported identifiers need godoc; match the surrounding package style.
+
+## Style
+
+- `make lint` (golangci-lint v2) enforces `gofmt`, `gofumpt`, `goimports`,
+  plus `gosec`, `govet` (`enable-all` minus `fieldalignment`),
+  `staticcheck`, `errcheck`, `funlen` (120/80), `unused`, `unparam`,
+  `ineffassign`, `misspell`, `depguard`, and others. Run it before pushing.
+- Variable shadowing is checked separately via `go vet -vettool=shadow`
+  (see commit `6223887`).
+- Implementation details belong in `internal/` packages. Keep the exported
+  surface minimal.
+
+## Stop and escalate immediately if you
+
+- Suspect a **vulnerability in existing code.** Do not commit a public fix
+  silently. Report via HackerOne or `security@cloudflare.com` (see README
+  Security Disclaimer). Coordinated disclosure, not a normal PR.
+- Are about to introduce **new `unsafe`, new `reflect`, new assembly, or a
+  new external dependency.**
+- Find an **ambiguity in the spec/RFC/paper** you're implementing — cite
+  it and ask.
+- Are about to **change a wire format, a KAT, or a public API signature.**
+- Are about to **touch a secret-handling path** and are not certain the
+  change preserves constant-time behavior.
+
+This code may be deployed in TLS stacks, signing infrastructure, and
+post-quantum experiments. Treat every diff as if a cryptographer will read
+it on Monday.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,83 @@
+# CIRCL Code Review Checklist
+
+What CI enforces, plus what a human reviewer should add. See `AGENTS.md`
+for rationale.
+
+## CI must be green
+
+- [ ] `go build ./...` and `go test -count=1 ./...` pass on amd64 for Go
+      1.25 and 1.26.
+- [ ] `golangci-lint run` is clean (config: `.golangci.yaml`).
+- [ ] `go vet ./...` and `go vet -vettool=shadow ./...` are clean.
+- [ ] `go generate -v ./...` leaves the working tree unchanged.
+- [ ] arm64, WASM (`GOOS=js GOARCH=wasm`), macOS, and Windows builds pass.
+- [ ] `make circl_static` and `make circl_plugin` still work if package
+      layout changed.
+- [ ] CodeQL and Semgrep workflows have no new findings.
+
+## Security
+
+- [ ] No new secret-dependent branches, memory accesses, table indices, or
+      loop bounds. `crypto/subtle` used for comparisons/selection on secrets.
+- [ ] No new `unsafe` — or written justification in the commit message and
+      confinement to `internal/`.
+- [ ] `crypto/rand` (or an injected `io.Reader`) for randomness. No
+      `math/rand` in crypto paths.
+- [ ] Parsers reject malformed encodings; identity elements, zero scalars,
+      zero challenges are handled explicitly (precedents: `sign/bls`,
+      `ecc/bls12381`, `zk/qndleq`, `pki`).
+- [ ] No new `require` entries unless already permitted by `depguard`; new
+      ones include a `depguard` update.
+- [ ] `gosec` findings are addressed or explicitly justified (G115 is
+      pre-excluded).
+
+## Correctness
+
+- [ ] Implementation cites its spec — RFC, FIPS, IETF draft, or paper
+      (`ia.cr/...`) — in code comments or commit message.
+- [ ] Edge cases exercised: zero / one / identity / max-value inputs,
+      empty slices, oversized inputs, malformed encodings.
+- [ ] KATs still pass. Regenerated golden values include a written reason
+      and an upstream reference (see commit `91088f2`).
+- [ ] Errors are returned, not swallowed. No `panic` on
+      attacker-controlled input.
+
+## Testing
+
+- [ ] Every bug fix has a regression test that fails without the fix.
+- [ ] New crypto code has unit tests covering the documented contract.
+
+## API and compatibility
+
+- [ ] Exported names have godoc.
+- [ ] Additive changes are preferred. Breaking changes are called out in
+      the PR description and paired with `// Deprecated:` where feasible
+      (see `dh/sidh`).
+- [ ] No silent wire-format changes. If a serialized representation
+      changes, KATs are regenerated and the change is documented.
+
+## Code generation and assembly
+
+- [ ] Generated packages: the **template** was edited (not the generated
+      file), and `make generate` was run.
+- [ ] Changed `.s` files were produced by rerunning their generator under
+      `*/internal/asm/`; the diff is reproducible.
+- [ ] Any new assembly path has a pure-Go fallback
+      (`make NOASM=1 test` passes).
+
+## Documentation
+
+- [ ] Package-level godoc explains what primitive is implemented and from
+      which spec.
+- [ ] Non-obvious parameter choices (security level, hash, domain
+      separation tag) are documented.
+- [ ] New top-level packages are listed in `README.md` under the relevant
+      "List of Algorithms" subsection.
+
+---
+
+The README disclaims API stability — "changes in the code, repository, and
+API occur in the future." The bar is **"correct, justified, and
+reproducible,"** not "frozen." When a change looks risky on security or
+correctness grounds, request a second review from someone with
+cryptographic background before merging.


### PR DESCRIPTION
Adds two contributor-facing documents:

- **`AGENTS.md`** — guidance for AI coding agents (and new human contributors) working in this repo. Covers security expectations, testing conventions, the `unsafe`/dependency policy, code generation and assembly rules, API/compatibility expectations, lint contract, and the escalation paths.
- **`REVIEW.md`** — a code review checklist mirroring what CI already enforces plus the human-judgement items reviewers should add on top.

## Approach

Every rule is grounded in something already in the tree — `.golangci.yaml`, `go.mod`, `.github/workflows/ci-actions.yml`, the `Makefile`, or specific recent commits. The goal was to encode the tacit conventions a maintainer already follows so that a new contributor (or AI agent) starts from the same baseline, without inventing aspirational policy.

Notable choices:

- Frames the bar as **"correct and justified,"** not "frozen" — matches the README's experimental-library disclaimer.
- Cites concrete precedent commits for input-validation patterns (`sign/bls`, `ecc/bls12381`, `zk/qndleq`, `pki`), KAT regeneration (`91088f2`), and shadow checks (`6223887`).
- Treats `unsafe` as permitted-but-scrutinized, reflecting actual usage in `simd/keccakf1600`, `internal/sha3`, `dh/csidh`, `ecc/fourq`.
- Reproduces the `depguard` allowlist verbatim from `.golangci.yaml`.
- Points to the existing security policy (HackerOne / `security@cloudflare.com`) for vulnerability disclosure rather than inventing a new flow.

Happy to iterate on any specifics — these are intended as a living baseline the maintainers own going forward, not a finished policy document.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/620" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->