### PR TITLE
abe/cpabe/tkn20: reject ciphertexts with trailing data.

### DIFF
--- a/abe/cpabe/tkn20/format_test.go
+++ b/abe/cpabe/tkn20/format_test.go
@@ -97,3 +97,66 @@ func testCiphertext(t *testing.T, ctName string) {
 		t.Fatal("message incorrect")
 	}
 }
+
+func TestCiphertextRejectsTrailingData(t *testing.T) {
+	for _, ctName := range []string{"testdata/ciphertext", "testdata/ciphertext_v137"} {
+		ciphertext, err := os.ReadFile(filepath.Clean(ctName))
+		if err != nil {
+			t.Fatalf("%s: unable to read ciphertext", ctName)
+		}
+		attributeKey, err := os.ReadFile("testdata/attributeKey")
+		if err != nil {
+			t.Fatal("unable to read attribute key")
+		}
+		sk := AttributeKey{}
+		if err = sk.UnmarshalBinary(attributeKey); err != nil {
+			t.Fatal("unable to parse attribute key")
+		}
+		attrs := Attributes{}
+		attrs.FromMap(map[string]string{"country": "NL", "EU": "true"})
+
+		// Baseline: the canonical ciphertext is accepted by all parsers.
+		if _, err := sk.Decrypt(ciphertext); err != nil {
+			t.Fatalf("%s: baseline Decrypt failed: %v", ctName, err)
+		}
+		if !attrs.CouldDecrypt(ciphertext) {
+			t.Fatalf("%s: baseline CouldDecrypt failed", ctName)
+		}
+		if err := (&Policy{}).ExtractFromCiphertext(ciphertext); err != nil {
+			t.Fatalf("%s: baseline ExtractFromCiphertext failed: %v", ctName, err)
+		}
+
+		// ct || suffix must be rejected by every parser (canonical encoding).
+		for _, suffix := range [][]byte{{0x00}, {0xff}, {0xff, 0xff, 0xff, 0xff}, []byte("extra")} {
+			mutated := append(append([]byte{}, ciphertext...), suffix...)
+			if _, err := sk.Decrypt(mutated); err == nil {
+				t.Errorf("%s: Decrypt accepted %d trailing byte(s)", ctName, len(suffix))
+			}
+			if attrs.CouldDecrypt(mutated) {
+				t.Errorf("%s: CouldDecrypt accepted %d trailing byte(s)", ctName, len(suffix))
+			}
+			if err := (&Policy{}).ExtractFromCiphertext(mutated); err == nil {
+				t.Errorf("%s: ExtractFromCiphertext accepted %d trailing byte(s)", ctName, len(suffix))
+			}
+		}
+	}
+}
+
+func TestShortCiphertextNoPanic(t *testing.T) {
+	attributeKey, err := os.ReadFile("testdata/attributeKey")
+	if err != nil {
+		t.Fatal("unable to read attribute key")
+	}
+	sk := AttributeKey{}
+	if err = sk.UnmarshalBinary(attributeKey); err != nil {
+		t.Fatal("unable to parse attribute key")
+	}
+	attrs := Attributes{}
+	attrs.FromMap(map[string]string{"country": "NL", "EU": "true"})
+	for i := 0; i <= len("v1.3.8")+2; i++ { // shorter than the version prefix must not panic
+		in := make([]byte, i)
+		_, _ = sk.Decrypt(in)
+		_ = attrs.CouldDecrypt(in)
+		_ = (&Policy{}).ExtractFromCiphertext(in)
+	}
+}

--- a/abe/cpabe/tkn20/internal/tkn/bk.go
+++ b/abe/cpabe/tkn20/internal/tkn/bk.go
@@ -141,7 +141,7 @@ type rmLenPref = func([]byte) ([]byte, []byte, error)
 
 func checkCiphertextFormat(ciphertext []byte) (ct []byte, fn rmLenPref) {
 	const N = len(CiphertextVersion)
-	if bytes.Equal(ciphertext[0:N], []byte(CiphertextVersion)) {
+	if len(ciphertext) >= N && bytes.Equal(ciphertext[0:N], []byte(CiphertextVersion)) {
 		return ciphertext[N:], removeLen32Prefixed
 	}
 	return ciphertext, removeLenPrefixed
@@ -157,9 +157,12 @@ func DecryptCCA(ciphertext []byte, key *AttributesKey) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	tag, _, err := removeLenPrefixed(rest)
+	tag, rest, err := removeLenPrefixed(rest)
 	if err != nil {
 		return nil, err
+	}
+	if len(rest) != 0 {
+		return nil, fmt.Errorf("malformed ciphertext: %d trailing byte(s)", len(rest))
 	}
 	C1, envRaw, err := removeLenPrefixedVar(macData)
 	if err != nil {
@@ -229,8 +232,15 @@ func CouldDecrypt(ciphertext []byte, a *Attributes) bool {
 	if err != nil {
 		return false
 	}
-	macData, _, err := removeLenPrefixedVar(rest)
+	macData, rest, err := removeLenPrefixedVar(rest)
 	if err != nil {
+		return false
+	}
+	// Enforce one canonical encoding: tag must follow, with nothing after it.
+	if _, rest, err = removeLenPrefixed(rest); err != nil {
+		return false
+	}
+	if len(rest) != 0 {
 		return false
 	}
 	C1, _, err := removeLenPrefixedVar(macData)
@@ -259,8 +269,14 @@ func (p *Policy) ExtractFromCiphertext(ct []byte) error {
 	if err != nil {
 		return fmt.Errorf("invalid ciphertext")
 	}
-	macData, _, err := removeLenPrefixedVar(rest)
+	macData, rest, err := removeLenPrefixedVar(rest)
 	if err != nil {
+		return fmt.Errorf("invalid ciphertext")
+	}
+	if _, rest, err = removeLenPrefixed(rest); err != nil {
+		return fmt.Errorf("invalid ciphertext")
+	}
+	if len(rest) != 0 {
 		return fmt.Errorf("invalid ciphertext")
 	}
 	C1, _, err := removeLenPrefixedVar(macData)


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->