### PR TITLE
abe/cpabe/tkn20: bound recursion depth when parsing policies.

### DIFF
--- a/abe/cpabe/tkn20/internal/dsl/dsl_test.go
+++ b/abe/cpabe/tkn20/internal/dsl/dsl_test.go
@@ -2,6 +2,7 @@ package dsl_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/cloudflare/circl/abe/cpabe/tkn20/internal/dsl"
@@ -140,5 +141,31 @@ func TestDsl(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestParserDepthLimit(t *testing.T) {
+	// Inputs nested far beyond maxParseDepth (64) must return the depth-limit
+	// error rather than recursing until the goroutine stack overflows. Both
+	// recursion drivers are exercised: nested groups and chained "not".
+	want := "policy exceeds maximum nesting depth of 64"
+	for _, in := range []string{
+		strings.Repeat("(", 1000),    // nested groups
+		strings.Repeat("not ", 1000), // chained "not"
+	} {
+		_, err := dsl.Run(in)
+		if err == nil {
+			t.Errorf("expected a depth-limit error for input of length %d, got nil", len(in))
+			continue
+		}
+		if err.Error() != want {
+			t.Errorf("expected error %q, received %q", want, err.Error())
+		}
+	}
+
+	// A policy nested well within the limit must still parse successfully.
+	valid := strings.Repeat("(", 16) + "region: US" + strings.Repeat(")", 16)
+	if _, err := dsl.Run(valid); err != nil {
+		t.Errorf("valid nested policy was rejected: %v", err)
 	}
 }

--- a/abe/cpabe/tkn20/internal/dsl/parser.go
+++ b/abe/cpabe/tkn20/internal/dsl/parser.go
@@ -4,9 +4,15 @@ import (
 	"fmt"
 )
 
+// maxParseDepth bounds the recursion depth of the recursive-descent parser.
+const maxParseDepth = 64
+
+var errMaxDepth = fmt.Errorf("policy exceeds maximum nesting depth of %d", maxParseDepth)
+
 type Parser struct {
 	tokens   []Token
 	curr     int
+	depth    int
 	wires    map[attr]attrValue
 	gates    []gate
 	negative bool
@@ -16,6 +22,7 @@ func newParser(tokens []Token) Parser {
 	return Parser{
 		tokens:   tokens,
 		curr:     0,
+		depth:    0,
 		wires:    make(map[attr]attrValue),
 		gates:    make([]gate, 0),
 		negative: false,
@@ -34,6 +41,13 @@ func (p *Parser) parse() (Ast, error) {
 }
 
 func (p *Parser) expression() (Expr, error) {
+	// expression is entered once per level of parenthesis nesting (via
+	// primary), so guarding it bounds the depth of grouped sub-expressions.
+	p.depth++
+	defer func() { p.depth-- }()
+	if p.depth > maxParseDepth {
+		return nil, errMaxDepth
+	}
 	return p.or()
 }
 
@@ -117,6 +131,13 @@ func (p *Parser) and() (Expr, error) {
 
 func (p *Parser) not() (Expr, error) {
 	if p.tokens[p.curr].Type == Not {
+		// not recurses into itself for each chained "not", which bypasses
+		// expression, so it needs its own depth guard.
+		p.depth++
+		defer func() { p.depth-- }()
+		if p.depth > maxParseDepth {
+			return nil, errMaxDepth
+		}
 		p.curr++
 		currWires := make(map[attr]int)
 		for wire := range p.wires {

--- a/abe/cpabe/tkn20/tkn20_test.go
+++ b/abe/cpabe/tkn20/tkn20_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -231,5 +232,17 @@ func TestPolicyMethods(t *testing.T) {
 				t.Fatalf("expected and received values differ")
 			}
 		}
+	}
+}
+
+func TestPolicyFromStringStackOverflow(t *testing.T) {
+	// Regression test: 4 MB of '(' used to drive ~4,000,000 levels of
+	// expression->or->and->not->primary recursion, exhausting the goroutine
+	// stack and aborting the process with a fatal "stack overflow" error that
+	// no recover() can catch. The parser now bounds its recursion depth and
+	// returns an error instead.
+	var p Policy
+	if err := p.FromString(strings.Repeat("(", 4_000_000)); err == nil {
+		t.Fatal("expected an error for an excessively nested policy, got nil")
 	}
 }


### PR DESCRIPTION
The parser doesn't track the depth it's parsing, which means it'll eventually overflow the stack. Limit the depth to 64 so that the parser fails before getting anywhere close to this limit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/622" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->