### PR TITLE
Fix HPKE/KEM exact-length key unmarshaling

### DIFF
--- a/hpke/kem_test.go
+++ b/hpke/kem_test.go
@@ -1,0 +1,60 @@
+package hpke_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cloudflare/circl/hpke"
+	"github.com/cloudflare/circl/internal/test"
+)
+
+func TestKemKeysExactLength(t *testing.T) {
+	for _, kemID := range []hpke.KEM{
+		hpke.KEM_P256_HKDF_SHA256,
+		hpke.KEM_P384_HKDF_SHA384,
+		hpke.KEM_P521_HKDF_SHA512,
+		hpke.KEM_X25519_HKDF_SHA256,
+		hpke.KEM_X448_HKDF_SHA512,
+		hpke.KEM_X25519_KYBER768_DRAFT00,
+	} {
+		checkExactLengthUnmarshal(t, kemID)
+	}
+}
+
+func checkExactLengthUnmarshal(t *testing.T, kemID hpke.KEM) {
+	scheme := kemID.Scheme()
+	pk, sk, err := scheme.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	skBytes, err := sk.MarshalBinary()
+	test.CheckNoErr(t, err, "marshal private key")
+	pkBytes, err := pk.MarshalBinary()
+	test.CheckNoErr(t, err, "marshal public key")
+
+	t.Run(fmt.Sprintf("%v/PrivateKey", scheme.Name()), func(t *testing.T) {
+		n := scheme.PrivateKeySize()
+		buffer := make([]byte, n+1)
+		copy(buffer, skBytes)
+
+		_, err := scheme.UnmarshalBinaryPrivateKey(buffer[:n+1])
+		test.CheckIsErr(t, err, "oversized private key must fail")
+
+		gotSk, err := scheme.UnmarshalBinaryPrivateKey(buffer[:n])
+		test.CheckNoErr(t, err, "exact-size private key must succeed")
+		test.CheckOk(sk.Equal(gotSk), "private keys must match", t)
+	})
+
+	t.Run(fmt.Sprintf("%v/PublicKey", scheme.Name()), func(t *testing.T) {
+		n := scheme.PublicKeySize()
+		buffer := make([]byte, n+1)
+		copy(buffer, pkBytes)
+
+		_, err := scheme.UnmarshalBinaryPublicKey(buffer[:n+1])
+		test.CheckIsErr(t, err, "oversized public key must fail")
+
+		gotPk, err := scheme.UnmarshalBinaryPublicKey(buffer[:n])
+		test.CheckNoErr(t, err, "exact-size public key must succeed")
+		test.CheckOk(pk.Equal(gotPk), "public keys must match", t)
+	})
+}

--- a/hpke/shortkem.go
+++ b/hpke/shortkem.go
@@ -101,6 +101,9 @@ func (s shortKEM) GenerateKeyPair() (kem.PublicKey, kem.PrivateKey, error) {
 }
 
 func (s shortKEM) UnmarshalBinaryPrivateKey(data []byte) (kem.PrivateKey, error) {
+	if len(data) != s.PrivateKeySize() {
+		return nil, kem.ErrPrivKeySize
+	}
 	key, err := s.Curve.NewPrivateKey(data)
 	if err != nil {
 		return nil, ErrInvalidKEMPrivateKey
@@ -110,6 +113,9 @@ func (s shortKEM) UnmarshalBinaryPrivateKey(data []byte) (kem.PrivateKey, error)
 }
 
 func (s shortKEM) UnmarshalBinaryPublicKey(data []byte) (kem.PublicKey, error) {
+	if len(data) != s.PublicKeySize() {
+		return nil, kem.ErrPubKeySize
+	}
 	key, err := s.Curve.NewPublicKey(data)
 	if err != nil {
 		return nil, ErrInvalidKEMPublicKey

--- a/hpke/xkem.go
+++ b/hpke/xkem.go
@@ -81,8 +81,8 @@ func (x xKEM) GenerateKeyPair() (kem.PublicKey, kem.PrivateKey, error) {
 
 func (x xKEM) UnmarshalBinaryPrivateKey(data []byte) (kem.PrivateKey, error) {
 	l := x.PrivateKeySize()
-	if len(data) < l {
-		return nil, ErrInvalidKEMPrivateKey
+	if len(data) != l {
+		return nil, kem.ErrPrivKeySize
 	}
 	sk := &xKEMPrivKey{x, make([]byte, l), nil}
 	copy(sk.priv, data[:l])
@@ -94,8 +94,8 @@ func (x xKEM) UnmarshalBinaryPrivateKey(data []byte) (kem.PrivateKey, error) {
 
 func (x xKEM) UnmarshalBinaryPublicKey(data []byte) (kem.PublicKey, error) {
 	l := x.PublicKeySize()
-	if len(data) < l {
-		return nil, ErrInvalidKEMPublicKey
+	if len(data) != l {
+		return nil, kem.ErrPubKeySize
 	}
 	pk := &xKEMPubKey{x, make([]byte, l)}
 	copy(pk.pub, data[:l])

--- a/kem/schemes/schemes_test.go
+++ b/kem/schemes/schemes_test.go
@@ -135,6 +135,37 @@ func TestApi(t *testing.T) {
 	}
 }
 
+func TestExactLengthUnmarshal(t *testing.T) {
+	allSchemes := schemes.All()
+	for _, scheme := range allSchemes {
+		t.Run(scheme.Name(), func(t *testing.T) {
+			pk, sk, err := scheme.GenerateKeyPair()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			packedPk, err := pk.MarshalBinary()
+			if err != nil {
+				t.Fatal(err)
+			}
+			packedSk, err := sk.MarshalBinary()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			oversizedPk := append(packedPk, 0x00)
+			if _, err := scheme.UnmarshalBinaryPublicKey(oversizedPk); err == nil {
+				t.Fatal("expected error for oversized public key")
+			}
+
+			oversizedSk := append(packedSk, 0x00)
+			if _, err := scheme.UnmarshalBinaryPrivateKey(oversizedSk); err == nil {
+				t.Fatal("expected error for oversized private key")
+			}
+		})
+	}
+}
+
 func Example_schemes() {
 	// import "github.com/cloudflare/circl/kem/schemes"
 


### PR DESCRIPTION
## Summary
- Require exact-length buffers in HPKE `shortKEM` and `xKEM` `UnmarshalBinaryPublicKey` / `UnmarshalBinaryPrivateKey` instead of accepting oversized inputs that were silently truncated
- Return standard `kem.ErrPubKeySize` / `kem.ErrPrivKeySize` on length mismatch
- Add `hpke/kem_test.go` and extend `kem/schemes/schemes_test.go` with `TestExactLengthUnmarshal` across all registered KEM schemes

## Test plan
- [x] `go test ./hpke/... ./kem/schemes/...`

Fixes #488
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->