### PR TITLE
ascon: don't output plaintext if authentication fails

### DIFF
--- a/cipher/ascon/ascon.go
+++ b/cipher/ascon/ascon.go
@@ -157,6 +157,7 @@ func (a *Cipher) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, er
 	a.finalize(tag1, &s)
 
 	if subtle.ConstantTimeCompare(tag0, tag1) == 0 {
+		clear(plaintext)
 		return nil, ErrDecryption
 	}
 

--- a/cipher/ascon/ascon_test.go
+++ b/cipher/ascon/ascon_test.go
@@ -107,6 +107,28 @@ func TestBadInputs(t *testing.T) {
 	test.CheckIsErr(t, err, "should panic due to bad ciphertext")
 }
 
+func TestOpenClearsOnFailure(t *testing.T) {
+	key, _ := hex.DecodeString("000102030405060708090A0B0C0D0E0F")
+	nonce, _ := hex.DecodeString("000102030405060708090A0B0C0D0E0F")
+	c, _ := ascon.New(key, ascon.Ascon128)
+
+	pt := []byte("helloworld")
+	ct := c.Seal(nil, nonce, pt, nil)
+	ct[len(ct)-1] ^= 0xFF // tamper the tag so authentication fails
+
+	dst := make([]byte, 0, len(pt))
+	out, err := c.Open(dst, nonce, ct, nil)
+	test.CheckIsErr(t, err, "should fail due to bad tag")
+	if out != nil {
+		test.ReportError(t, out, nil)
+	}
+
+	buf := dst[:len(pt)]
+	if !bytes.Equal(buf, make([]byte, len(pt))) {
+		test.ReportError(t, buf, make([]byte, len(pt)))
+	}
+}
+
 func TestAPI(t *testing.T) {
 	key, _ := hex.DecodeString("000102030405060708090A0B0C0D0E0F")
 	nonce, _ := hex.DecodeString("000102030405060708090A0B0C0D0E0F")


### PR DESCRIPTION
This isn't a vulnerability on its own: if a caller uses the plaintext after authentication fails, they're already in trouble.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->