### PR TITLE
Dilithium: don't accept signatures with trailing data

### DIFF
--- a/sign/dilithium/mode2/internal/dilithium.go
+++ b/sign/dilithium/mode2/internal/dilithium.go
@@ -88,10 +88,9 @@ func (sig *unpackedSignature) Pack(buf []byte) {
 //
 // Returns whether buf contains a properly packed signature.
 func (sig *unpackedSignature) Unpack(buf []byte) bool {
-	if len(buf) < SignatureSize {
-		return false
-	}
-	if NIST && len(buf) != SignatureSize {
+	// NOTE: Previously the Dilithium (but not ML-DSA) implementation accepted
+	// signatures with trailing data.
+	if len(buf) != SignatureSize {
 		return false
 	}
 	copy(sig.c[:], buf[:])

--- a/sign/dilithium/mode3/internal/dilithium.go
+++ b/sign/dilithium/mode3/internal/dilithium.go
@@ -86,10 +86,9 @@ func (sig *unpackedSignature) Pack(buf []byte) {
 //
 // Returns whether buf contains a properly packed signature.
 func (sig *unpackedSignature) Unpack(buf []byte) bool {
-	if len(buf) < SignatureSize {
-		return false
-	}
-	if NIST && len(buf) != SignatureSize {
+	// NOTE: Previously the Dilithium (but not ML-DSA) implementation accepted
+	// signatures with trailing data.
+	if len(buf) != SignatureSize {
 		return false
 	}
 	copy(sig.c[:], buf[:])

--- a/sign/dilithium/mode5/internal/dilithium.go
+++ b/sign/dilithium/mode5/internal/dilithium.go
@@ -88,10 +88,9 @@ func (sig *unpackedSignature) Pack(buf []byte) {
 //
 // Returns whether buf contains a properly packed signature.
 func (sig *unpackedSignature) Unpack(buf []byte) bool {
-	if len(buf) < SignatureSize {
-		return false
-	}
-	if NIST && len(buf) != SignatureSize {
+	// NOTE: Previously the Dilithium (but not ML-DSA) implementation accepted
+	// signatures with trailing data.
+	if len(buf) != SignatureSize {
 		return false
 	}
 	copy(sig.c[:], buf[:])

--- a/sign/mldsa/mldsa44/internal/dilithium.go
+++ b/sign/mldsa/mldsa44/internal/dilithium.go
@@ -88,10 +88,9 @@ func (sig *unpackedSignature) Pack(buf []byte) {
 //
 // Returns whether buf contains a properly packed signature.
 func (sig *unpackedSignature) Unpack(buf []byte) bool {
-	if len(buf) < SignatureSize {
-		return false
-	}
-	if NIST && len(buf) != SignatureSize {
+	// NOTE: Previously the Dilithium (but not ML-DSA) implementation accepted
+	// signatures with trailing data.
+	if len(buf) != SignatureSize {
 		return false
 	}
 	copy(sig.c[:], buf[:])

--- a/sign/mldsa/mldsa65/internal/dilithium.go
+++ b/sign/mldsa/mldsa65/internal/dilithium.go
@@ -88,10 +88,9 @@ func (sig *unpackedSignature) Pack(buf []byte) {
 //
 // Returns whether buf contains a properly packed signature.
 func (sig *unpackedSignature) Unpack(buf []byte) bool {
-	if len(buf) < SignatureSize {
-		return false
-	}
-	if NIST && len(buf) != SignatureSize {
+	// NOTE: Previously the Dilithium (but not ML-DSA) implementation accepted
+	// signatures with trailing data.
+	if len(buf) != SignatureSize {
 		return false
 	}
 	copy(sig.c[:], buf[:])

--- a/sign/mldsa/mldsa87/internal/dilithium.go
+++ b/sign/mldsa/mldsa87/internal/dilithium.go
@@ -88,10 +88,9 @@ func (sig *unpackedSignature) Pack(buf []byte) {
 //
 // Returns whether buf contains a properly packed signature.
 func (sig *unpackedSignature) Unpack(buf []byte) bool {
-	if len(buf) < SignatureSize {
-		return false
-	}
-	if NIST && len(buf) != SignatureSize {
+	// NOTE: Previously the Dilithium (but not ML-DSA) implementation accepted
+	// signatures with trailing data.
+	if len(buf) != SignatureSize {
 		return false
 	}
 	copy(sig.c[:], buf[:])


### PR DESCRIPTION
It was a somewhat misguided but intentional decision to accept signatures with trailing data, leaving the check to the caller. This was not documented and caused (mostly AI) confusion. Be more strict.

ML-DSA was never affected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->