### PR TITLE
eddilithium: fail verification if signature is wrong length

### DIFF
--- a/sign/eddilithium2/eddilithium.go
+++ b/sign/eddilithium2/eddilithium.go
@@ -94,6 +94,9 @@ func SignTo(sk *PrivateKey, msg []byte, signature []byte) {
 
 // Verify checks whether the given signature by pk on msg is valid.
 func Verify(pk *PublicKey, msg []byte, signature []byte) bool {
+	if len(signature) != SignatureSize {
+		return false
+	}
 	if !mode2.Verify(
 		&pk.d,
 		msg,

--- a/sign/eddilithium3/eddilithium.go
+++ b/sign/eddilithium3/eddilithium.go
@@ -88,6 +88,9 @@ func SignTo(sk *PrivateKey, msg []byte, signature []byte) {
 
 // Verify checks whether the given signature by pk on msg is valid.
 func Verify(pk *PublicKey, msg []byte, signature []byte) bool {
+	if len(signature) != SignatureSize {
+		return false
+	}
 	if !mode3.Verify(
 		&pk.d,
 		msg,


### PR DESCRIPTION
Earlier a short signature would cause a panic, and padded data would be ignored on a long signature. This was intentional, but perhaps surprising.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->