### PR TITLE
ed448: reject non-canonical point encodings

### DIFF
--- a/ecc/goldilocks/point.go
+++ b/ecc/goldilocks/point.go
@@ -46,6 +46,9 @@ func FromBytes(in []byte) (*Point, error) {
 	}
 	err := errors.New("invalid decoding")
 	P := &Point{}
+	if in[fp.Size]&0x7F != 0 {
+		return nil, err
+	}
 	signX := in[fp.Size] >> 7
 	copy(P.y[:], in[:fp.Size])
 	p := fp.P()

--- a/ecc/goldilocks/point_test.go
+++ b/ecc/goldilocks/point_test.go
@@ -93,6 +93,34 @@ func TestPointMarshal(t *testing.T) {
 	}
 }
 
+func TestPointNonCanonical(t *testing.T) {
+	const testTimes = 1 << 8
+	for i := 0; i < testTimes; i++ {
+		P := randomPoint()
+		data, err := P.MarshalBinary()
+		test.CheckNoErr(t, err, "marshal failed")
+
+		// The canonical encoding must decode successfully.
+		if _, err := goldilocks.FromBytes(data); err != nil {
+			test.ReportError(t, err, nil, data)
+		}
+		// The last byte must only hold the sign bit; bits 448..454 are unused.
+		if data[len(data)-1]&0x7F != 0 {
+			test.ReportError(t, data[len(data)-1]&0x7F, 0, data)
+		}
+
+		// Setting any of the 7 unused high bits must make decoding fail.
+		for b := 0; b < 7; b++ {
+			bad := make([]byte, len(data))
+			copy(bad, data)
+			bad[len(bad)-1] |= 1 << uint(b)
+			if _, err := goldilocks.FromBytes(bad); err == nil {
+				test.ReportError(t, "decoded non-canonical encoding", "error", bad, b)
+			}
+		}
+	}
+}
+
 func BenchmarkPoint(b *testing.B) {
 	P := randomPoint()
 	Q := randomPoint()


### PR DESCRIPTION
FromBytes ignored bits 448-454 of the 456-bit encoding, letting 128
byte strings decode to the same point. Enforce the RFC 8032 canonical
y-coordinate check.