### PR TITLE
ecc/bls12381: reject trailing data in G1/G2 SetBytes

### DIFF
--- a/ecc/bls12381/g1.go
+++ b/ecc/bls12381/g1.go
@@ -44,16 +44,18 @@ func (g *G1) SetBytes(b []byte) error {
 	isInfinity := int((b[0] >> 6) & 0x1)
 	isBigYCoord := int((b[0] >> 5) & 0x1)
 
+	wantLen := G1Size
+	if isCompressed == 1 {
+		wantLen = G1SizeCompressed
+	}
+	// NOTE Previous versions accepted trailing data.
+	if len(b) != wantLen {
+		return errInputLength
+	}
+
 	if isInfinity == 1 {
-		l := G1Size
-		if isCompressed == 1 {
-			l = G1SizeCompressed
-		}
-		if len(b) < l {
-			return errInputLength
-		}
-		zeros := make([]byte, l-1)
-		if (b[0]&0x1F) != 0 || subtle.ConstantTimeCompare(b[1:l], zeros) != 1 {
+		zeros := make([]byte, wantLen-1)
+		if (b[0]&0x1F) != 0 || subtle.ConstantTimeCompare(b[1:wantLen], zeros) != 1 {
 			return errEncoding
 		}
 		g.SetIdentity()
@@ -79,9 +81,6 @@ func (g *G1) SetBytes(b []byte) error {
 			g.y.Neg()
 		}
 	} else {
-		if len(b) < G1Size {
-			return errInputLength
-		}
 		if err := g.y.UnmarshalBinary(b[ff.FpSize:G1Size]); err != nil {
 			return err
 		}

--- a/ecc/bls12381/g1_test.go
+++ b/ecc/bls12381/g1_test.go
@@ -159,13 +159,13 @@ func TestG1Serial(t *testing.T) {
 		test.CheckIsErr(t, q.SetBytes(b[:G1Size-1]), mustErr)
 		test.CheckIsErr(t, q.SetBytes(b[:G1SizeCompressed]), mustErr)
 		test.CheckNoErr(t, q.SetBytes(b), mustOk)
-		test.CheckNoErr(t, q.SetBytes(append(b, 0)), mustOk)
+		test.CheckIsErr(t, q.SetBytes(append(b, 0)), mustErr)
 		b = p.BytesCompressed()
 		test.CheckIsErr(t, q.SetBytes(b[:0]), mustErr)
 		test.CheckIsErr(t, q.SetBytes(b[:1]), mustErr)
 		test.CheckIsErr(t, q.SetBytes(b[:G1SizeCompressed-1]), mustErr)
 		test.CheckNoErr(t, q.SetBytes(b), mustOk)
-		test.CheckNoErr(t, q.SetBytes(append(b, 0)), mustOk)
+		test.CheckIsErr(t, q.SetBytes(append(b, 0)), mustErr)
 	})
 	t.Run("badInfinity", func(t *testing.T) {
 		var badInf, p G1

--- a/ecc/bls12381/g2.go
+++ b/ecc/bls12381/g2.go
@@ -42,16 +42,18 @@ func (g *G2) SetBytes(b []byte) error {
 	isInfinity := int((b[0] >> 6) & 0x1)
 	isBigYCoord := int((b[0] >> 5) & 0x1)
 
+	wantLen := G2Size
+	if isCompressed == 1 {
+		wantLen = G2SizeCompressed
+	}
+	// NOTE Previous versions accepted trailing data.
+	if len(b) != wantLen {
+		return errInputLength
+	}
+
 	if isInfinity == 1 {
-		l := G2Size
-		if isCompressed == 1 {
-			l = G2SizeCompressed
-		}
-		if len(b) < l {
-			return errInputLength
-		}
-		zeros := make([]byte, l-1)
-		if (b[0]&0x1F) != 0 || subtle.ConstantTimeCompare(b[1:l], zeros) != 1 {
+		zeros := make([]byte, wantLen-1)
+		if (b[0]&0x1F) != 0 || subtle.ConstantTimeCompare(b[1:wantLen], zeros) != 1 {
 			return errEncoding
 		}
 		g.SetIdentity()
@@ -77,9 +79,6 @@ func (g *G2) SetBytes(b []byte) error {
 			g.y.Neg()
 		}
 	} else {
-		if len(b) < G2Size {
-			return errInputLength
-		}
 		if err := g.y.UnmarshalBinary(b[ff.Fp2Size:G2Size]); err != nil {
 			return err
 		}

--- a/ecc/bls12381/g2_test.go
+++ b/ecc/bls12381/g2_test.go
@@ -118,13 +118,13 @@ func TestG2Serial(t *testing.T) {
 		test.CheckIsErr(t, q.SetBytes(b[:G2Size-1]), mustErr)
 		test.CheckIsErr(t, q.SetBytes(b[:G2SizeCompressed]), mustErr)
 		test.CheckNoErr(t, q.SetBytes(b), mustOk)
-		test.CheckNoErr(t, q.SetBytes(append(b, 0)), mustOk)
+		test.CheckIsErr(t, q.SetBytes(append(b, 0)), mustErr)
 		b = p.BytesCompressed()
 		test.CheckIsErr(t, q.SetBytes(b[:0]), mustErr)
 		test.CheckIsErr(t, q.SetBytes(b[:1]), mustErr)
 		test.CheckIsErr(t, q.SetBytes(b[:G2SizeCompressed-1]), mustErr)
 		test.CheckNoErr(t, q.SetBytes(b), mustOk)
-		test.CheckNoErr(t, q.SetBytes(append(b, 0)), mustOk)
+		test.CheckIsErr(t, q.SetBytes(append(b, 0)), mustErr)
 	})
 	t.Run("badInfinity", func(t *testing.T) {
 		var badInf, p G2

--- a/sign/bls/bls_test.go
+++ b/sign/bls/bls_test.go
@@ -23,6 +23,31 @@ func TestBls(t *testing.T) {
 	t.Run("G2/Aggregation", testAggregation[bls.G2])
 	t.Run("G1/DuplicatedMsg", testDuplicatedMsgs[bls.G1])
 	t.Run("G2/DuplicatedMsg", testDuplicatedMsgs[bls.G2])
+	t.Run("G1/NonCanonical", testNonCanonical[bls.G1])
+	t.Run("G2/NonCanonical", testNonCanonical[bls.G2])
+}
+
+func testNonCanonical[K bls.KeyGroup](t *testing.T) {
+	ikm := [32]byte{}
+	_, _ = rand.Reader.Read(ikm[:])
+
+	priv, err := bls.KeyGen[K](ikm[:], nil, nil)
+	test.CheckNoErr(t, err, "failed to keygen")
+	pub := priv.PublicKey()
+
+	msg := []byte("hello world")
+	sig := bls.Sign(priv, msg)
+	test.CheckOk(bls.Verify(pub, msg, sig), "baseline signature must verify", t)
+
+	longSig := append(append(bls.Signature{}, sig...), 0x00)
+	test.CheckOk(bls.Verify(pub, msg, longSig) == false,
+		"should fail: signature with trailing byte", t)
+
+	pubBytes, err := pub.MarshalBinary()
+	test.CheckNoErr(t, err, "failed to marshal public key")
+	longPub := new(bls.PublicKey[K])
+	err = longPub.UnmarshalBinary(append(append([]byte{}, pubBytes...), 0x00))
+	test.CheckIsErr(t, err, "should fail: public key with trailing byte")
 }
 
 func testBls[K bls.KeyGroup](t *testing.T) {


### PR DESCRIPTION
Previously we confusingly accepted trailing data.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->