### PR TITLE
tss/rsa: fix length check to prevent runtime out-of-bounds panic

### DIFF
--- a/tss/rsa/keyshare.go
+++ b/tss/rsa/keyshare.go
@@ -116,13 +116,13 @@ func (kshare *KeyShare) UnmarshalBinary(data []byte) error {
 		return fmt.Errorf("rsa_threshold: keyshare unmarshalKeyShareTest failed: data length was too short for reading siLen length")
 	}
 
-	siLen := binary.BigEndian.Uint16(data[6:8])
+	siLen := int(binary.BigEndian.Uint16(data[6:8]))
 
 	if siLen == 0 {
 		return fmt.Errorf("rsa_threshold: keyshare unmarshalKeyShareTest failed: si is a required field but siLen was 0")
 	}
 
-	if uint16(len(data[8:])) < siLen {
+	if len(data[8:]) < siLen {
 		return fmt.Errorf("rsa_threshold: keyshare unmarshalKeyShareTest failed: data length was too short for reading si, needed: %d found: %d", siLen, len(data[8:]))
 	}
 
@@ -141,10 +141,10 @@ func (kshare *KeyShare) UnmarshalBinary(data []byte) error {
 			return fmt.Errorf("rsa_threshold: keyshare unmarshalKeyShareTest failed: data length was too short for reading twoDeltaSiLen length")
 		}
 
-		twoDeltaSiLen := binary.BigEndian.Uint16(data[8+siLen+1 : 8+siLen+3])
+		twoDeltaSiLen := int(binary.BigEndian.Uint16(data[8+siLen+1 : 8+siLen+3]))
 
-		if uint16(len(data[8+siLen+3:])) < twoDeltaSiLen {
-			return fmt.Errorf("rsa_threshold: keyshare unmarshalKeyShareTest failed: data length was too short for reading twoDeltaSi, needed: %d found: %d", twoDeltaSiLen, len(data[8+siLen+2:]))
+		if len(data[8+siLen+3:]) < twoDeltaSiLen {
+			return fmt.Errorf("rsa_threshold: keyshare unmarshalKeyShareTest failed: data length was too short for reading twoDeltaSi, needed: %d found: %d", twoDeltaSiLen, len(data[8+siLen+3:]))
 		}
 
 		twoDeltaSi = new(big.Int).SetBytes(data[8+siLen+3 : 8+siLen+3+twoDeltaSiLen])

--- a/tss/rsa/keyshare_test.go
+++ b/tss/rsa/keyshare_test.go
@@ -3,6 +3,8 @@ package rsa
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/binary"
+	"math"
 	"math/big"
 	"testing"
 )
@@ -140,6 +142,19 @@ func TestMarshallKeyShare(t *testing.T) {
 	unmarshalKeyShareTest(t, []byte{0, 1, 0, 1, 0, 1, 0, 2, 1})
 	unmarshalKeyShareTest(t, []byte{0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 0})
 	unmarshalKeyShareTest(t, []byte{0, 1, 0, 1, 0, 1, 0, 1, 1, 1, 0, 1})
+}
+
+func TestUnmarshalKeyShareBoundsWrap(t *testing.T) {
+	for _, siLen := range []uint16{math.MaxUint16 - 7, math.MaxUint16 - 1, math.MaxUint16} {
+		data := make([]byte, 8+int(siLen))
+		binary.BigEndian.PutUint16(data[6:8], siLen)
+		data[8] = 1
+
+		share := KeyShare{}
+		if err := share.UnmarshalBinary(data); err == nil {
+			t.Fatalf("unmarshal unexpectedly succeeded for siLen=%d", siLen)
+		}
+	}
 }
 
 func TestMarshallKeyShareFull(t *testing.T) {

--- a/tss/rsa/signShare.go
+++ b/tss/rsa/signShare.go
@@ -79,14 +79,14 @@ func (s *SignShare) UnmarshalBinary(data []byte) error {
 	players := binary.BigEndian.Uint16(data[0:2])
 	threshold := binary.BigEndian.Uint16(data[2:4])
 	index := binary.BigEndian.Uint16(data[4:6])
-	xiLen := binary.BigEndian.Uint16(data[6:8])
+	xiLen := int(binary.BigEndian.Uint16(data[6:8]))
 
 	if xiLen == 0 {
 		return fmt.Errorf("rsa_threshold: signshare unmarshalKeyShareTest failed: xi is a required field but xiLen was 0")
 	}
 
-	if uint16(len(data[8:])) < xiLen {
-		return fmt.Errorf("rsa_threshold: signshare unmarshalKeyShareTest failed: data length was too short for reading xi, needed: %d found: %d", xiLen, len(data[6:]))
+	if len(data[8:]) < xiLen {
+		return fmt.Errorf("rsa_threshold: signshare unmarshalKeyShareTest failed: data length was too short for reading xi, needed: %d found: %d", xiLen, len(data[8:]))
 	}
 
 	xi := big.Int{}

--- a/tss/rsa/signShare_test.go
+++ b/tss/rsa/signShare_test.go
@@ -3,6 +3,8 @@ package rsa
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/binary"
+	"math"
 	"math/big"
 	"testing"
 )
@@ -64,6 +66,19 @@ func TestMarshallSignShare(t *testing.T) {
 	unmarshalSignShareTest(t, []byte{0, 0, 0, 0, 0, 0, 0, 0})
 	unmarshalSignShareTest(t, []byte{0, 0, 0, 0, 0, 0, 0, 1})
 	unmarshalSignShareTest(t, []byte{0, 0, 0, 0, 0, 0, 0, 2, 1})
+}
+
+func TestUnmarshalSignShareBoundsWrap(t *testing.T) {
+	for _, xiLen := range []uint16{math.MaxUint16 - 7, math.MaxUint16 - 1, math.MaxUint16} {
+		data := make([]byte, 8+int(xiLen))
+		binary.BigEndian.PutUint16(data[6:8], xiLen)
+		data[8] = 1
+
+		share := SignShare{}
+		if err := share.UnmarshalBinary(data); err != nil {
+			t.Fatalf("unmarshal unexpectedly failed for xiLen=%d: %v", xiLen, err)
+		}
+	}
 }
 
 func TestMarshallFullSignShare(t *testing.T) {


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/640" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->