### PR TITLE
ed{25519,448}: don't accept trailing data for keys

### DIFF
--- a/sign/ed25519/signapi.go
+++ b/sign/ed25519/signapi.go
@@ -69,7 +69,8 @@ func (*scheme) DeriveKey(seed []byte) (sign.PublicKey, sign.PrivateKey) {
 }
 
 func (*scheme) UnmarshalBinaryPublicKey(buf []byte) (sign.PublicKey, error) {
-	if len(buf) < PublicKeySize {
+	// NOTE Old version of CIRCL accepted trailing data.
+	if len(buf) != PublicKeySize {
 		return nil, sign.ErrPubKeySize
 	}
 	pub := make(PublicKey, PublicKeySize)
@@ -78,7 +79,8 @@ func (*scheme) UnmarshalBinaryPublicKey(buf []byte) (sign.PublicKey, error) {
 }
 
 func (*scheme) UnmarshalBinaryPrivateKey(buf []byte) (sign.PrivateKey, error) {
-	if len(buf) < PrivateKeySize {
+	// NOTE Old version of CIRCL accepted trailing data.
+	if len(buf) != PrivateKeySize {
 		return nil, sign.ErrPrivKeySize
 	}
 	priv := make(PrivateKey, PrivateKeySize)

--- a/sign/ed448/signapi.go
+++ b/sign/ed448/signapi.go
@@ -69,7 +69,8 @@ func (*scheme) DeriveKey(seed []byte) (sign.PublicKey, sign.PrivateKey) {
 }
 
 func (*scheme) UnmarshalBinaryPublicKey(buf []byte) (sign.PublicKey, error) {
-	if len(buf) < PublicKeySize {
+	// NOTE Old version of CIRCL accepted trailing data.
+	if len(buf) != PublicKeySize {
 		return nil, sign.ErrPubKeySize
 	}
 	pub := make(PublicKey, PublicKeySize)
@@ -78,7 +79,8 @@ func (*scheme) UnmarshalBinaryPublicKey(buf []byte) (sign.PublicKey, error) {
 }
 
 func (*scheme) UnmarshalBinaryPrivateKey(buf []byte) (sign.PrivateKey, error) {
-	if len(buf) < PrivateKeySize {
+	// NOTE Old version of CIRCL accepted trailing data.
+	if len(buf) != PrivateKeySize {
 		return nil, sign.ErrPrivKeySize
 	}
 	priv := make(PrivateKey, PrivateKeySize)


### PR DESCRIPTION
We previously intentionally accepted trailing data when unpacking public and private keys. This is surprising to many and we didn't document it. Be more strict instead.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->