### PR TITLE
secretsharing: check that share ID is not zero.

### DIFF
--- a/secretsharing/ss.go
+++ b/secretsharing/ss.go
@@ -23,12 +23,15 @@
 package secretsharing
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
 	"github.com/cloudflare/circl/group"
 	"github.com/cloudflare/circl/math/polynomial"
 )
+
+var errZeroID = errors.New("secretsharing: share ID cannot be zero")
 
 // Share represents a share of a secret.
 type Share struct {
@@ -120,11 +123,18 @@ func Verify(t uint, s Share, c SecretCommitment) bool {
 }
 
 // Recover returns a secret provided more than t different shares are given.
-// Returns an error if the number of shares is not above the threshold t.
+// Returns an error if the number of shares is not above the threshold t, or if
+// any share has a zero ID.
 // Panics if some shares are duplicated, i.e., shares must have different IDs.
 func Recover(t uint, shares []Share) (secret group.Scalar, err error) {
 	if l := len(shares); l <= int(t) {
 		return nil, errThreshold(t, uint(l))
+	}
+
+	for i := range shares {
+		if shares[i].ID.IsZero() {
+			return nil, errZeroID
+		}
 	}
 
 	x := make([]group.Scalar, t+1)

--- a/secretsharing/ss_test.go
+++ b/secretsharing/ss_test.go
@@ -104,6 +104,32 @@ func TestShareWithID(tt *testing.T) {
 	})
 }
 
+func TestRecoverZeroID(tt *testing.T) {
+	g := group.P256
+	t := uint(2)
+	n := uint(5)
+
+	secret := g.RandomScalar(rand.Reader)
+	ss := secretsharing.New(rand.Reader, t, secret)
+	shares := ss.Share(n)
+
+	// A single Share{ID:0, Value:V} would otherwise force Recover to return
+	// the attacker-chosen V, independent of the honest shares.
+	attackerValue := g.RandomScalar(rand.Reader)
+	tampered := make([]secretsharing.Share, 0, t+1)
+	tampered = append(tampered, secretsharing.Share{
+		ID:    g.NewScalar(),
+		Value: attackerValue,
+	})
+	for i := uint(0); i < t; i++ {
+		tampered = append(tampered, shares[i])
+	}
+
+	got, err := secretsharing.Recover(t, tampered)
+	test.CheckIsErr(tt, err, "must fail to recover with a zero share ID")
+	test.CheckOk(got == nil, "must not recover a secret with a zero share ID", tt)
+}
+
 func BenchmarkSecretSharing(b *testing.B) {
 	g := group.P256
 	t := uint(3)


### PR DESCRIPTION
Recover() didn't check whether the share ID is zero, which allows one manipulated share to determine the final recovered secret. The applicability is rather narrow: the Verify() function that checks secret commitments already did check whether the share ID is zero. Without calling Verify(), an attacker can already manipulate the shared secret already to a certain degree. Arguably, we wouldn't need to check it here, but it's cheap to do so.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->