### PR TITLE
frodo: pack: fix accidental zero buffer assumption

### DIFF
--- a/kem/frodo/frodo640shake/util.go
+++ b/kem/frodo/frodo640shake/util.go
@@ -24,7 +24,7 @@ func pack(out []byte, in []uint16) {
 		in6 := in[(i*8)+6] & logQMask
 		in7 := in[(i*8)+7] & logQMask
 
-		out[j] |= byte(in0 >> 7)
+		out[j] = byte(in0 >> 7)
 		out[j+1] = (byte(in0&0x7F) << 1) | byte(in1>>14)
 
 		out[j+2] = byte(in1 >> 6)


### PR DESCRIPTION
Accidentally it was assumed the buffers to which material is packed is zero (as values were bitwise-or-ed into the buffer instead of assigned.)

The pack functions are also used internally in the Fujisaki-Okamoto (FO) transform, but in that case the buffers are guaranteed to be zero.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->