### PR TITLE
kyber: document pk isn't checked like ML-KEM

### DIFF
--- a/kem/kyber/kyber1024/kyber.go
+++ b/kem/kyber/kyber1024/kyber.go
@@ -246,6 +246,11 @@ func (pk *PublicKey) Pack(buf []byte) {
 // Unpacks pk from buf.
 //
 // Panics if buf is not of size PublicKeySize.
+//
+// Following the round-3 Kyber reference implementation, non-canonical
+// encodings (coefficients in {q, …, 4095}) are accepted and reduced mod q;
+// H(pk) binds the raw bytes. Note that this is different from final FIPS 203,
+// which checks whether the coefficients are reduced (§7.2).
 func (pk *PublicKey) Unpack(buf []byte) {
 	if len(buf) != PublicKeySize {
 		panic("buf must be of length PublicKeySize")

--- a/kem/kyber/kyber512/kyber.go
+++ b/kem/kyber/kyber512/kyber.go
@@ -246,6 +246,11 @@ func (pk *PublicKey) Pack(buf []byte) {
 // Unpacks pk from buf.
 //
 // Panics if buf is not of size PublicKeySize.
+//
+// Following the round-3 Kyber reference implementation, non-canonical
+// encodings (coefficients in {q, …, 4095}) are accepted and reduced mod q;
+// H(pk) binds the raw bytes. Note that this is different from final FIPS 203,
+// which checks whether the coefficients are reduced (§7.2).
 func (pk *PublicKey) Unpack(buf []byte) {
 	if len(buf) != PublicKeySize {
 		panic("buf must be of length PublicKeySize")

--- a/kem/kyber/kyber768/kyber.go
+++ b/kem/kyber/kyber768/kyber.go
@@ -246,6 +246,11 @@ func (pk *PublicKey) Pack(buf []byte) {
 // Unpacks pk from buf.
 //
 // Panics if buf is not of size PublicKeySize.
+//
+// Following the round-3 Kyber reference implementation, non-canonical
+// encodings (coefficients in {q, …, 4095}) are accepted and reduced mod q;
+// H(pk) binds the raw bytes. Note that this is different from final FIPS 203,
+// which checks whether the coefficients are reduced (§7.2).
 func (pk *PublicKey) Unpack(buf []byte) {
 	if len(buf) != PublicKeySize {
 		panic("buf must be of length PublicKeySize")

--- a/kem/kyber/templates/pkg.templ.go
+++ b/kem/kyber/templates/pkg.templ.go
@@ -315,6 +315,11 @@ func (pk *PublicKey) Unpack(buf []byte) error {
 	}
 {{- else -}}
 // Panics if buf is not of size PublicKeySize.
+//
+// Following the round-3 Kyber reference implementation, non-canonical
+// encodings (coefficients in {q, …, 4095}) are accepted and reduced mod q;
+// H(pk) binds the raw bytes. Note that this is different from final FIPS 203,
+// which checks whether the coefficients are reduced (§7.2).
 func (pk *PublicKey) Unpack(buf []byte) {
 	if len(buf) != PublicKeySize {
 		panic("buf must be of length PublicKeySize")


### PR DESCRIPTION
The round 3 Kyber reference implementation accepts unreduced coefficients for the public key, but hashes the unreduced coefficients into the shared secret, which binds them.

ML-KEM instead checks whether the coefficients of a public key are reduced.

Both approaches have up and downsides. Our Kyber implementation matches what the Kyber reference implementation did.

This commit adds a comment noting that, so that GenAI doesn't warn about the mismatch with ML-KEM.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->