### PR TITLE
zk/dleq: Don't accept trailing data on proof

### DIFF
--- a/zk/dleq/dleq.go
+++ b/zk/dleq/dleq.go
@@ -255,7 +255,8 @@ func (p *Proof) MarshalBinary() ([]byte, error) {
 
 func (p *Proof) UnmarshalBinary(g group.Group, data []byte) error {
 	scalarSize := int(g.Params().ScalarLength)
-	if len(data) < 2*scalarSize {
+	// NOTE Previously trailing data was accepted.
+	if len(data) != 2*scalarSize {
 		return io.ErrShortBuffer
 	}
 

--- a/zk/dleq/dleq.go
+++ b/zk/dleq/dleq.go
@@ -12,6 +12,7 @@ package dleq
 import (
 	"crypto"
 	"encoding/binary"
+	"fmt"
 	"io"
 
 	"github.com/cloudflare/circl/group"
@@ -257,7 +258,7 @@ func (p *Proof) UnmarshalBinary(g group.Group, data []byte) error {
 	scalarSize := int(g.Params().ScalarLength)
 	// NOTE Previously trailing data was accepted.
 	if len(data) != 2*scalarSize {
-		return io.ErrShortBuffer
+		return fmt.Errorf("dleq: invalid proof length: got %d bytes, want %d", len(data), 2*scalarSize)
 	}
 
 	c := g.NewScalar()

--- a/zk/dleq/dleq_test.go
+++ b/zk/dleq/dleq_test.go
@@ -95,6 +95,10 @@ func testErrors(
 	err = tamperedProof.UnmarshalBinary(g, proofBytes[:5])
 	test.CheckIsErr(t, err, "unmarshal must fail")
 
+	// Trailing bytes must be rejected to keep the encoding canonical.
+	err = tamperedProof.UnmarshalBinary(g, append(append([]byte{}, proofBytes...), 0x00))
+	test.CheckIsErr(t, err, "unmarshal with trailing bytes must fail")
+
 	err = tamperedProof.UnmarshalBinary(g, proofBytes)
 	test.CheckNoErr(t, err, "proof must be unmarshaled")
 	test.CheckOk(false == Victor.Verify(a, ka, b, kb, tamperedProof), "proof must not verify", t)


### PR DESCRIPTION
Somewhat idiosyncratically, and without documenting it, we accepted trailing data when unpacking.  That's confusing, so let's be strict going forward.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->