### PR TITLE
ristretto: reject non-canonical scalars

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudflare/circl
 go 1.25.0
 
 require (
-	github.com/bwesterb/go-ristretto v1.2.3
+	github.com/bwesterb/go-ristretto v1.2.4
 	golang.org/x/crypto v0.54.0
 	golang.org/x/sys v0.47.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bwesterb/go-ristretto v1.2.3 h1:1w53tCkGhCQ5djbat3+MH0BAQ5Kfgbt56UZQ/JMzngw=
-github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
+github.com/bwesterb/go-ristretto v1.2.4 h1:8HUl/bYdUaLakTdT2mfYomzPego+qjs5dOrYgAo3+J0=
+github.com/bwesterb/go-ristretto v1.2.4/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=

--- a/group/ristretto255.go
+++ b/group/ristretto255.go
@@ -259,8 +259,21 @@ func (s *ristrettoScalar) MarshalBinary() ([]byte, error) {
 	return s.s.MarshalBinary()
 }
 
+// Unmarshals a scalar.
+//
+// Errors if not reduced as recommended in RFC 9496 §4.4.
+// Note that this behaviour changed. Previously we ignored the top 3 bits
+// and reduced the remainder.
 func (s *ristrettoScalar) UnmarshalBinary(data []byte) error {
-	return s.s.UnmarshalBinary(data)
+	if len(data) != 32 {
+		return ErrUnmarshal
+	}
+	var b [32]byte
+	copy(b[:], data)
+	if !s.s.SetBytesStrict(&b) {
+		return ErrUnmarshal
+	}
+	return nil
 }
 
 func (s *ristrettoScalar) Marshal(b *cryptobyte.Builder) error {
@@ -273,6 +286,6 @@ func (s *ristrettoScalar) Unmarshal(str *cryptobyte.String) bool {
 	if !str.CopyBytes(b[:]) {
 		return false
 	}
-	s.s.SetBytes(&b)
-	return true
+	// Reject non-canonical encodings; see UnmarshalBinary.
+	return s.s.SetBytesStrict(&b)
 }

--- a/group/ristretto255_test.go
+++ b/group/ristretto255_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"testing"
+
+	"golang.org/x/crypto/cryptobyte"
 )
 
 // https://tools.ietf.org/html/draft-irtf-cfrg-ristretto255-decaf448-00#appendix-A.1
@@ -102,6 +104,88 @@ func TestInvalidEncodings(t *testing.T) {
 		err = Ristretto255.NewElement().UnmarshalBinary(raw)
 		if err == nil {
 			t.Fatalf("Decode succeeded for vector %d: %v", i, enc)
+		}
+	}
+}
+
+// TestRistrettoScalarNonCanonical checks that scalar decoding rejects
+// non-canonical encodings, i.e. any 32-byte string that is not the canonical
+// little-endian encoding of an integer in the range [0, l). Previously the
+// decoding delegated to go-ristretto Scalar.SetBytes, which masked bits
+// 253-255 and reduced modulo l, silently accepting many distinct encodings of
+// the same scalar (proof/key byte malleability). See RFC 9496 §4.4 and
+// RFC 9497 §4.1.
+func TestRistrettoScalarNonCanonical(t *testing.T) {
+	// canonical encodings that MUST be accepted.
+	valid := []string{
+		// 0
+		"0000000000000000000000000000000000000000000000000000000000000000",
+		// 1
+		"0100000000000000000000000000000000000000000000000000000000000000",
+		// l-1, the largest canonical scalar.
+		"ecd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010",
+	}
+
+	// non-canonical encodings that MUST be rejected.
+	invalid := []string{
+		// l, the group order (out of range: valid range is [0, l)).
+		"edd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010",
+		// l+1.
+		"eed3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010",
+		// All ones: a value far larger than l with the top three bits set.
+		"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		// Scalar 1 with bit 255 set: the old masking behavior reduced this
+		// to 1; it MUST now be rejected as non-canonical.
+		"0100000000000000000000000000000000000000000000000000000000000080",
+		// l-1 with the top three bits set (bits 253-255): masked to l-1 by
+		// the old code; MUST now be rejected.
+		"ecd3f55c1a631258d69cf7a2def9de14000000000000000000000000000000f0",
+	}
+
+	for i, enc := range valid {
+		raw, err := hex.DecodeString(enc)
+		if err != nil {
+			t.Fatal("DecodeString")
+		}
+
+		s := Ristretto255.NewScalar()
+		if err = s.UnmarshalBinary(raw); err != nil {
+			t.Errorf("UnmarshalBinary rejected canonical vector %d (%v): %v", i, enc, err)
+		}
+
+		// re-encoding a canonical scalar must yield the same bytes.
+		out, err := s.MarshalBinary()
+		if err != nil {
+			t.Fatalf("MarshalBinary %d", i)
+		}
+		if !bytes.Equal(out, raw) {
+			t.Errorf("round-trip mismatch for vector %d: got %x want %s", i, out, enc)
+		}
+
+		// the cryptobyte path must also accept it.
+		str := cryptobyte.String(raw)
+		if ok := Ristretto255.NewScalar().(interface {
+			Unmarshal(*cryptobyte.String) bool
+		}).Unmarshal(&str); !ok {
+			t.Errorf("Unmarshal rejected canonical vector %d (%v)", i, enc)
+		}
+	}
+
+	for i, enc := range invalid {
+		raw, err := hex.DecodeString(enc)
+		if err != nil {
+			t.Fatal("DecodeString")
+		}
+
+		if err = Ristretto255.NewScalar().UnmarshalBinary(raw); err == nil {
+			t.Errorf("UnmarshalBinary accepted non-canonical vector %d (%v)", i, enc)
+		}
+
+		str := cryptobyte.String(raw)
+		if ok := Ristretto255.NewScalar().(interface {
+			Unmarshal(*cryptobyte.String) bool
+		}).Unmarshal(&str); ok {
+			t.Errorf("Unmarshal accepted non-canonical vector %d (%v)", i, enc)
 		}
 	}
 }


### PR DESCRIPTION
Previously we ignored the top 3 bits and reduced otherwise. RFC 9496 allows this, see section 4.4, but advises rejecting all but canonical scalars. Adjust behaviour accordingly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->