### PR TITLE
fourq: document point decoding is lenient

### DIFF
--- a/dh/curve4q/curve4Q.go
+++ b/dh/curve4q/curve4Q.go
@@ -17,6 +17,10 @@ func KeyGen(public, secret *Key) {
 
 // Shared calculates a shared key k from Alice's secret and Bob's public key.
 // Returns true on success.
+//
+// The public key is decoded leniently (see fourq.Point.Unmarshal) and the
+// cofactor is cleared during scalar multiplication. Hence public keys must
+// not be treated as unique identifiers without canonicalization.
 func Shared(shared, secret, public *Key) bool {
 	var P, Q fourq.Point
 	ok := P.Unmarshal((*[Size]byte)(public))

--- a/ecc/fourq/point.go
+++ b/ecc/fourq/point.go
@@ -248,6 +248,10 @@ func (P *Point) Marshal(out *[Size]byte) {
 }
 
 // Unmarshal retrieves a point P from the input buffer. On success, returns true.
+//
+// Decoding is lenient; distinct byte strings decode to the same point.
+// Callers must not treat an accepted encoding as a unique point identifier.
+// Marshal always emits the canonical form.
 func (P *Point) Unmarshal(in *[Size]byte) bool {
 	var Q Point
 	s := in[Size-1] >> 7


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->