### PR TITLE
ot/simot: don't panic on mismatched ciphertext lengths

### DIFF
--- a/ot/simot/simotlocal.go
+++ b/ot/simot/simotlocal.go
@@ -184,6 +184,9 @@ func (sender *Sender) Round2Sender(B group.Element) ([]byte, []byte) {
 // Input: choice, choice bit of receiver
 // Choose e0 or e1 based on choice bit in constant time
 func (receiver *Receiver) Round3Receiver(e0, e1 []byte, choice int) error {
+	if len(e0) != len(e1) {
+		return errors.New("simot: sender ciphertexts e0 and e1 have different lengths")
+	}
 	receiver.ec = make([]byte, len(e1))
 	// If c == 1, copy e1
 	subtle.ConstantTimeCopy(choice, receiver.ec, e1)


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->