### PR TITLE
hpke: don't panic when unmarshalling opener/sealer from empty buffer

### DIFF
--- a/hpke/marshal.go
+++ b/hpke/marshal.go
@@ -121,6 +121,9 @@ func (c *sealContext) MarshalBinary() ([]byte, error) {
 // never be copied, restored more than once, or used concurrently with the
 // original context or any other restored copy.
 func UnmarshalSealer(raw []byte) (Sealer, error) {
+	if len(raw) == 0 {
+		return nil, errors.New("failed to parse context")
+	}
 	if raw[0] != 0 {
 		return nil, errors.New("incorrect role")
 	}
@@ -162,6 +165,9 @@ func (c *openContext) MarshalBinary() ([]byte, error) {
 // never be copied, restored more than once, or used concurrently with the
 // original context or any other restored copy.
 func UnmarshalOpener(raw []byte) (Opener, error) {
+	if len(raw) == 0 {
+		return nil, errors.New("failed to parse context")
+	}
 	if raw[0] != 1 {
 		return nil, errors.New("incorrect role")
 	}


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/656" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->