### PR TITLE
mlsbset: fix stray index in Encode comment

### DIFF
--- a/math/mlsbset/mlsbset.go
+++ b/math/mlsbset/mlsbset.go
@@ -69,7 +69,7 @@ func (m Encoder) Encode(k []byte) (*Power, error) {
 
 	// Original algorithm starts with c := k >> D, then computes
 	//
-	//	  b_(i-D) = s_(j%D) * lsb(c)
+	//	  b_(i-D) = s_(i%D) * lsb(c)
 	//	  c = [ (c>>1)+1   if b_(i-D) = -1
 	//		  [ c>>1       otherwise
 	//


### PR DESCRIPTION
Missed this in #639.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/658" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->