### PR TITLE
dh/sidh: document Import() side-effect for kem/sike.

### DIFF
--- a/dh/sidh/sidh.go
+++ b/dh/sidh/sidh.go
@@ -78,7 +78,8 @@ func NewPublicKey(id uint8, v KeyVariant) *PublicKey {
 
 // Import clears content of the public key currently stored in the structure
 // and imports key stored in the byte string. Returns error in case byte string
-// size is wrong. Doesn't perform any validation.
+// size is wrong. Doesn't perform any validation. In particular, sikep434,
+// sikep503, and sikep751 all accept non-canonical encoding of field elements.
 func (pub *PublicKey) Import(input []byte) error {
 	if len(input) != pub.Size() {
 		return errors.New("sidh: input to short")


### PR DESCRIPTION
This function doesn't check that the bytes encode an integer smaller than the field modulus, meaning non-conanical encodings of the SIKE public keys are accepted. This KEM is deprecated, so just document this fact.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->