### PR TITLE
zk/dleq: add base point `a` to challenge derivation.

### DIFF
--- a/oprf/client.go
+++ b/oprf/client.go
@@ -117,8 +117,7 @@ func (c VerifiableClient) Finalize(f *FinalizeData, e *Evaluation) (outputs [][]
 		return nil, err
 	}
 
-	if !(dleq.Verifier{Params: c.getDLEQParams()}).VerifyBatch(
-		c.params.group.Generator(),
+	if !(dleq.Verifier{Params: c.getDLEQParams()}).VerifyBatchRFC9497(
 		c.pkS.e,
 		f.evalReq.Elements,
 		e.Elements,
@@ -140,8 +139,7 @@ func (c PartialObliviousClient) Finalize(f *FinalizeData, e *Evaluation, info []
 		return nil, err
 	}
 
-	if !(dleq.Verifier{Params: c.getDLEQParams()}).VerifyBatch(
-		c.params.group.Generator(),
+	if !(dleq.Verifier{Params: c.getDLEQParams()}).VerifyBatchRFC9497(
 		tweakedKey,
 		e.Elements,
 		f.evalReq.Elements,

--- a/oprf/server.go
+++ b/oprf/server.go
@@ -39,9 +39,8 @@ func (s Server) Evaluate(req *EvaluationRequest) (*Evaluation, error) {
 func (s VerifiableServer) Evaluate(req *EvaluationRequest) (*Evaluation, error) {
 	evaluations := s.server.evaluate(req.Elements, s.privateKey.k)
 
-	proof, err := dleq.Prover{Params: s.getDLEQParams()}.ProveBatch(
+	proof, err := dleq.Prover{Params: s.getDLEQParams()}.ProveBatchRFC9497(
 		s.privateKey.k,
-		s.params.group.Generator(),
 		s.PublicKey().e,
 		req.Elements,
 		evaluations,
@@ -62,9 +61,8 @@ func (s PartialObliviousServer) Evaluate(req *EvaluationRequest, info []byte) (*
 
 	evaluations := s.server.evaluate(req.Elements, evalSecret)
 
-	proof, err := dleq.Prover{Params: s.getDLEQParams()}.ProveBatch(
+	proof, err := dleq.Prover{Params: s.getDLEQParams()}.ProveBatchRFC9497(
 		keyProof,
-		s.params.group.Generator(),
 		s.params.group.NewElement().MulGen(keyProof),
 		evaluations,
 		req.Elements,

--- a/oprf/vectors_test.go
+++ b/oprf/vectors_test.go
@@ -185,9 +185,8 @@ func (v *vector) test(t *testing.T) {
 			case VerifiableMode:
 				ss := server.(VerifiableServer)
 				prover := dleq.Prover{Params: ss.getDLEQParams()}
-				proof, err = prover.ProveBatchWithRandomness(
+				proof, err = prover.ProveBatchWithRandomnessRFC9497(
 					ss.privateKey.k,
-					ss.params.group.Generator(),
 					server.PublicKey().e,
 					evalReq.Elements,
 					eval.Elements,
@@ -196,9 +195,8 @@ func (v *vector) test(t *testing.T) {
 				ss := server.(*s1)
 				keyProof, _, _ := ss.secretFromInfo(ss.info)
 				prover := dleq.Prover{Params: ss.getDLEQParams()}
-				proof, err = prover.ProveBatchWithRandomness(
+				proof, err = prover.ProveBatchWithRandomnessRFC9497(
 					keyProof,
-					ss.params.group.Generator(),
 					ss.params.group.NewElement().MulGen(keyProof),
 					eval.Elements,
 					evalReq.Elements,

--- a/zk/dleq/dleq.go
+++ b/zk/dleq/dleq.go
@@ -1,8 +1,8 @@
 // Package dleq provides zero-knowledge proofs of Discrete-Logarithm Equivalence (DLEQ).
 //
-// This implementation is compatible with the one used for VOPRFs [1].
-// It supports batching proofs to amortize the cost of the proof generation and
-// verification.
+// It supports batching proofs to amortize the cost of proof generation and
+// verification. The methods whose names end in RFC9497 implement the
+// fixed-generator transcript used for VOPRFs [1].
 //
 // Warning: When instantiated with the group.P256, group.P384, or group.P521
 // groups, proof generation is currently not constant time in the secret
@@ -53,15 +53,57 @@ func (p Prover) ProveBatch(k group.Scalar, a, ka group.Element, bi, kbi []group.
 	return p.ProveBatchWithRandomness(k, a, ka, bi, kbi, p.Params.G.RandomScalar(rnd))
 }
 
+// ProveBatchRFC9497 generates a batched proof using the fixed-generator
+// transcript specified in RFC 9497.
+func (p Prover) ProveBatchRFC9497(
+	k group.Scalar,
+	ka group.Element,
+	bi, kbi []group.Element,
+	rnd io.Reader,
+) (*Proof, error) {
+	return p.ProveBatchWithRandomnessRFC9497(k, ka, bi, kbi, p.Params.G.RandomScalar(rnd))
+}
+
 func (p Prover) ProveBatchWithRandomness(
 	k group.Scalar,
 	a, ka group.Element,
 	bi, kbi []group.Element,
 	rnd group.Scalar,
 ) (*Proof, error) {
+	return p.proveBatchWithRandomness(k, a, ka, bi, kbi, rnd, true)
+}
+
+// ProveBatchWithRandomnessRFC9497 generates a batched proof using the
+// fixed-generator transcript specified in RFC 9497 and the supplied scalar as
+// proof randomness.
+func (p Prover) ProveBatchWithRandomnessRFC9497(
+	k group.Scalar,
+	ka group.Element,
+	bi, kbi []group.Element,
+	rnd group.Scalar,
+) (*Proof, error) {
+	return p.proveBatchWithRandomness(k, p.G.Generator(), ka, bi, kbi, rnd, false)
+}
+
+func (p Prover) proveBatchWithRandomness(
+	k group.Scalar,
+	a, ka group.Element,
+	bi, kbi []group.Element,
+	rnd group.Scalar,
+	bindBase bool,
+) (*Proof, error) {
 	M, Z, err := p.computeComposites(k, ka, bi, kbi)
 	if err != nil {
 		return nil, err
+	}
+
+	challengeInput := make([][]byte, 0, 6)
+	if bindBase {
+		aSer, marshalErr := a.MarshalBinaryCompress()
+		if marshalErr != nil {
+			return nil, marshalErr
+		}
+		challengeInput = append(challengeInput, aSer)
 	}
 
 	kAm, err := ka.MarshalBinaryCompress()
@@ -91,7 +133,8 @@ func (p Prover) ProveBatchWithRandomness(
 		return nil, err
 	}
 
-	cc := p.doChallenge([5][]byte{kAm, a0, a1, a2, a3})
+	challengeInput = append(challengeInput, kAm, a0, a1, a2, a3)
+	cc := p.doChallenge(challengeInput)
 	ss := p.G.NewScalar()
 	ss.Mul(cc, k)
 	ss.Sub(rnd, ss)
@@ -172,7 +215,7 @@ func (p Params) computeComposites(
 	return m, z, nil
 }
 
-func (p Params) doChallenge(a [5][]byte) group.Scalar {
+func (p Params) doChallenge(a [][]byte) group.Scalar {
 	h2Input := []byte{}
 	lenBuf := []byte{0, 0}
 
@@ -194,6 +237,21 @@ func (v Verifier) Verify(a, ka, b, kb group.Element, p *Proof) bool {
 }
 
 func (v Verifier) VerifyBatch(a, ka group.Element, bi, kbi []group.Element, p *Proof) bool {
+	return v.verifyBatch(a, ka, bi, kbi, p, true)
+}
+
+// VerifyBatchRFC9497 verifies a batched proof using the fixed-generator
+// transcript specified in RFC 9497.
+func (v Verifier) VerifyBatchRFC9497(ka group.Element, bi, kbi []group.Element, p *Proof) bool {
+	return v.verifyBatch(v.G.Generator(), ka, bi, kbi, p, false)
+}
+
+func (v Verifier) verifyBatch(
+	a, ka group.Element,
+	bi, kbi []group.Element,
+	p *Proof,
+	bindBase bool,
+) bool {
 	if p == nil || p.c == nil || p.s == nil {
 		return false
 	}
@@ -210,6 +268,15 @@ func (v Verifier) VerifyBatch(a, ka group.Element, bi, kbi []group.Element, p *P
 	sM := g.NewElement().Mul(M, p.s)
 	cZ := g.NewElement().Mul(Z, p.c)
 	t3 := g.NewElement().Add(sM, cZ)
+
+	challengeInput := make([][]byte, 0, 6)
+	if bindBase {
+		aSer, marshalErr := a.MarshalBinaryCompress()
+		if marshalErr != nil {
+			return false
+		}
+		challengeInput = append(challengeInput, aSer)
+	}
 
 	kAm, err := ka.MarshalBinaryCompress()
 	if err != nil {
@@ -233,7 +300,8 @@ func (v Verifier) VerifyBatch(a, ka group.Element, bi, kbi []group.Element, p *P
 		return false
 	}
 
-	gotC := v.Params.doChallenge([5][]byte{kAm, a0, a1, a2, a3})
+	challengeInput = append(challengeInput, kAm, a0, a1, a2, a3)
+	gotC := v.Params.doChallenge(challengeInput)
 
 	return gotC.IsEqual(p.c)
 }

--- a/zk/dleq/dleq_test.go
+++ b/zk/dleq/dleq_test.go
@@ -57,6 +57,45 @@ func TestDLEQ(t *testing.T) {
 	}
 }
 
+func TestChallengeBindsBase(t *testing.T) {
+	g := group.P256
+	params := dleq.Params{G: g, H: crypto.SHA256, DST: []byte("domain_sep_string")}
+	prover := dleq.Prover{Params: params}
+	verifier := dleq.Verifier{Params: params}
+
+	k := g.RandomScalar(rand.Reader)
+	b := g.RandomElement(rand.Reader)
+	kb := g.NewElement().Mul(b, k)
+	ka := g.RandomElement(rand.Reader)
+
+	r := g.RandomScalar(rand.Reader)
+	a := g.Generator()
+	proof, err := prover.ProveWithRandomness(k, a, ka, b, kb, r)
+	test.CheckNoErr(t, err, "wrong proof generation")
+
+	rawProof, err := proof.MarshalBinary()
+	test.CheckNoErr(t, err, "error on marshaling proof")
+	scalarLen := int(g.Params().ScalarLength)
+	c := g.NewScalar()
+	err = c.UnmarshalBinary(rawProof[:scalarLen])
+	test.CheckNoErr(t, err, "error on unmarshaling challenge")
+	s := g.NewScalar()
+	err = s.UnmarshalBinary(rawProof[scalarLen:])
+	test.CheckNoErr(t, err, "error on unmarshaling response")
+
+	rA := g.NewElement().Mul(a, r)
+	cKA := g.NewElement().Mul(ka, c)
+	diff := g.NewElement().Add(rA, g.NewElement().Neg(cKA))
+	forgedA := g.NewElement().Mul(diff, g.NewScalar().Inv(s))
+
+	if g.NewElement().Mul(forgedA, k).IsEqual(ka) {
+		t.Fatal("unexpected true statement")
+	}
+	if verifier.Verify(forgedA, ka, b, kb, proof) {
+		t.Fatal("Verify accepted a proof for a false statement with an adaptively chosen base")
+	}
+}
+
 func testMarshal(t *testing.T, g group.Group, proof *dleq.Proof) {
 	t.Helper()
 


### PR DESCRIPTION
Currently `a` can be fixed after the challenge, allowing an attacker to forge a proof for a false statement. This is an issue if the application requires transmitting `a` in band. This is not the case for RFC 9497 (VOPRF), the primary use case for the DLEQ proof implementation. However this is a major foot gun for other users.

Modify proof generation to add `a` to the Fiat-Shamir transform by default. Add a new API intended for RFC 9497 that implements the previous behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->