### PR TITLE
internal/test: unify ACVP test vector parsing

### DIFF
--- a/internal/test/acvp.go
+++ b/internal/test/acvp.go
@@ -1,0 +1,87 @@
+package test
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+// ACVP is a decoded pair of ACVP test vector files: the prompt file, holding
+// the test groups, and the expectedResults file, holding the results indexed
+// by test case id.
+//
+// Vectors come from https://github.com/usnistgov/ACVP-Server, where every
+// algorithm directory pairs a prompt.json with an expectedResults.json.
+type ACVP struct {
+	// Groups are the raw test groups of the prompt file. Unmarshal each one
+	// into whatever shape the algorithm under test expects.
+	Groups []json.RawMessage
+
+	results map[int]json.RawMessage
+}
+
+// ReadACVP reads the gzipped prompt and expectedResults files of the ACVP
+// test vector directory dir.
+func ReadACVP(t testing.TB, dir string) *ACVP {
+	t.Helper()
+
+	acvp := &ACVP{
+		Groups:  readACVPGroups(t, filepath.Join(dir, "prompt.json.gz")),
+		results: make(map[int]json.RawMessage),
+	}
+
+	for _, rawGroup := range readACVPGroups(t, filepath.Join(dir, "expectedResults.json.gz")) {
+		var group struct {
+			Tests []json.RawMessage `json:"tests"`
+		}
+		if err := json.Unmarshal(rawGroup, &group); err != nil {
+			t.Fatal(err)
+		}
+
+		for _, rawTest := range group.Tests {
+			var abstractTest struct {
+				TcID int `json:"tcId"`
+			}
+			if err := json.Unmarshal(rawTest, &abstractTest); err != nil {
+				t.Fatal(err)
+			}
+			if _, exists := acvp.results[abstractTest.TcID]; exists {
+				t.Fatalf("Duplicate test id: %d", abstractTest.TcID)
+			}
+			acvp.results[abstractTest.TcID] = rawTest
+		}
+	}
+
+	return acvp
+}
+
+// Result unmarshals the expected result of test case tcID into result.
+func (a *ACVP) Result(t testing.TB, tcID int, result interface{}) {
+	t.Helper()
+
+	rawResult, ok := a.results[tcID]
+	if !ok {
+		t.Fatalf("Missing result: %d", tcID)
+	}
+	if err := json.Unmarshal(rawResult, result); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readACVPGroups(t testing.TB, path string) []json.RawMessage {
+	t.Helper()
+
+	buf, err := ReadGzip(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var file struct {
+		TestGroups []json.RawMessage `json:"testGroups"`
+	}
+	if err := json.Unmarshal(buf, &file); err != nil {
+		t.Fatal(err)
+	}
+
+	return file.TestGroups
+}

--- a/kem/mlkem/acvp_test.go
+++ b/kem/mlkem/acvp_test.go
@@ -22,56 +22,9 @@ func TestACVP(t *testing.T) {
 
 // nolint:funlen,gocyclo
 func testACVP(t *testing.T, sub string) {
-	buf, err := test.ReadGzip("testdata/ML-KEM-" + sub + "-FIPS203/prompt.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
+	vectors := test.ReadACVP(t, "testdata/ML-KEM-"+sub+"-FIPS203")
 
-	var prompt struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err = json.Unmarshal(buf, &prompt); err != nil {
-		t.Fatal(err)
-	}
-
-	buf, err = test.ReadGzip("testdata/ML-KEM-" + sub + "-FIPS203/expectedResults.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var results struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err := json.Unmarshal(buf, &results); err != nil {
-		t.Fatal(err)
-	}
-
-	rawResults := make(map[int]json.RawMessage)
-
-	for _, rawGroup := range results.TestGroups {
-		var abstractGroup struct {
-			Tests []json.RawMessage `json:"tests"`
-		}
-		if err := json.Unmarshal(rawGroup, &abstractGroup); err != nil {
-			t.Fatal(err)
-		}
-		for _, rawTest := range abstractGroup.Tests {
-			var abstractTest struct {
-				TcID int `json:"tcId"`
-			}
-			if err := json.Unmarshal(rawTest, &abstractTest); err != nil {
-				t.Fatal(err)
-			}
-			if _, exists := rawResults[abstractTest.TcID]; exists {
-				t.Fatalf("Duplicate test id: %d", abstractTest.TcID)
-			}
-			rawResults[abstractTest.TcID] = rawTest
-		}
-	}
-
-	for _, rawGroup := range prompt.TestGroups {
+	for _, rawGroup := range vectors.Groups {
 		var abstractGroup struct {
 			TestType string `json:"testType"`
 		}
@@ -103,13 +56,7 @@ func testACVP(t *testing.T, sub string) {
 					Ek test.HexBytes `json:"ek"`
 					Dk test.HexBytes `json:"dk"`
 				}
-				rawResult, ok := rawResults[tst.TcID]
-				if !ok {
-					t.Fatalf("Missing result: %d", tst.TcID)
-				}
-				if err := json.Unmarshal(rawResult, &result); err != nil {
-					t.Fatal(err)
-				}
+				vectors.Result(t, tst.TcID, &result)
 
 				var seed [64]byte
 				copy(seed[:], tst.D)
@@ -157,13 +104,7 @@ func testACVP(t *testing.T, sub string) {
 					C test.HexBytes `json:"c"`
 					K test.HexBytes `json:"k"`
 				}
-				rawResult, ok := rawResults[tst.TcID]
-				if !ok {
-					t.Fatalf("Missing result: %d", tst.TcID)
-				}
-				if err := json.Unmarshal(rawResult, &result); err != nil {
-					t.Fatal(err)
-				}
+				vectors.Result(t, tst.TcID, &result)
 
 				ek, err := scheme.UnmarshalBinaryPublicKey(tst.Ek)
 				if err != nil {
@@ -210,13 +151,7 @@ func testACVP(t *testing.T, sub string) {
 				var result struct {
 					K test.HexBytes `json:"k"`
 				}
-				rawResult, ok := rawResults[tst.TcID]
-				if !ok {
-					t.Fatalf("Missing rawResult: %d", tst.TcID)
-				}
-				if err := json.Unmarshal(rawResult, &result); err != nil {
-					t.Fatal(err)
-				}
+				vectors.Result(t, tst.TcID, &result)
 
 				ss, err := scheme.Decapsulate(dk, tst.C)
 				if err != nil {

--- a/sign/dilithium/templates/acvp.templ.go
+++ b/sign/dilithium/templates/acvp.templ.go
@@ -28,58 +28,11 @@ func TestACVP(t *testing.T) {
 
 // nolint:funlen,gocyclo
 func testACVP(t *testing.T, sub string) {
-	buf, err := test.ReadGzip("../testdata/ML-DSA-" + sub + "-FIPS204/prompt.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var prompt struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err = json.Unmarshal(buf, &prompt); err != nil {
-		t.Fatal(err)
-	}
-
-	buf, err = test.ReadGzip("../testdata/ML-DSA-" + sub + "-FIPS204/expectedResults.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var results struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err := json.Unmarshal(buf, &results); err != nil {
-		t.Fatal(err)
-	}
-
-	rawResults := make(map[int]json.RawMessage)
-
-	for _, rawGroup := range results.TestGroups {
-		var abstractGroup struct {
-			Tests []json.RawMessage `json:"tests"`
-		}
-		if err := json.Unmarshal(rawGroup, &abstractGroup); err != nil {
-			t.Fatal(err)
-		}
-		for _, rawTest := range abstractGroup.Tests {
-			var abstractTest struct {
-				TcID int `json:"tcId"`
-			}
-			if err := json.Unmarshal(rawTest, &abstractTest); err != nil {
-				t.Fatal(err)
-			}
-			if _, exists := rawResults[abstractTest.TcID]; exists {
-				t.Fatalf("Duplicate test id: %d", abstractTest.TcID)
-			}
-			rawResults[abstractTest.TcID] = rawTest
-		}
-	}
+	vectors := test.ReadACVP(t, "../testdata/ML-DSA-"+sub+"-FIPS204")
 
 	scheme := Scheme()
 
-	for _, rawGroup := range prompt.TestGroups {
+	for _, rawGroup := range vectors.Groups {
 		var abstractGroup struct {
 			TestType string `json:"testType"`
 		}
@@ -109,13 +62,7 @@ func testACVP(t *testing.T, sub string) {
 					Pk test.HexBytes `json:"pk"`
 					Sk test.HexBytes `json:"sk"`
 				}
-				rawResult, ok := rawResults[tst.TcID]
-				if !ok {
-					t.Fatalf("Missing result: %d", tst.TcID)
-				}
-				if err := json.Unmarshal(rawResult, &result); err != nil {
-					t.Fatal(err)
-				}
+				vectors.Result(t, tst.TcID, &result)
 
 				pk, sk := scheme.DeriveKey(tst.Seed)
 
@@ -159,13 +106,7 @@ func testACVP(t *testing.T, sub string) {
 				var result struct {
 					Signature test.HexBytes `json:"signature"`
 				}
-				rawResult, ok := rawResults[tst.TcID]
-				if !ok {
-					t.Fatalf("Missing result: %d", tst.TcID)
-				}
-				if err := json.Unmarshal(rawResult, &result); err != nil {
-					t.Fatal(err)
-				}
+				vectors.Result(t, tst.TcID, &result)
 
 				sk, err := scheme.UnmarshalBinaryPrivateKey(tst.Sk)
 				if err != nil {
@@ -212,13 +153,7 @@ func testACVP(t *testing.T, sub string) {
 				var result struct {
 					TestPassed bool `json:"testPassed"`
 				}
-				rawResult, ok := rawResults[tst.TcID]
-				if !ok {
-					t.Fatalf("Missing result: %d", tst.TcID)
-				}
-				if err := json.Unmarshal(rawResult, &result); err != nil {
-					t.Fatal(err)
-				}
+				vectors.Result(t, tst.TcID, &result)
 
 				passed2 := unsafeVerifyInternal(pk.(*PublicKey), tst.Message, tst.Signature)
 				if passed2 != result.TestPassed {

--- a/sign/mldsa/mldsa44/acvp_test.go
+++ b/sign/mldsa/mldsa44/acvp_test.go
@@ -24,58 +24,11 @@ func TestACVP(t *testing.T) {
 
 // nolint:funlen,gocyclo
 func testACVP(t *testing.T, sub string) {
-	buf, err := test.ReadGzip("../testdata/ML-DSA-" + sub + "-FIPS204/prompt.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var prompt struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err = json.Unmarshal(buf, &prompt); err != nil {
-		t.Fatal(err)
-	}
-
-	buf, err = test.ReadGzip("../testdata/ML-DSA-" + sub + "-FIPS204/expectedResults.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var results struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err := json.Unmarshal(buf, &results); err != nil {
-		t.Fatal(err)
-	}
-
-	rawResults := make(map[int]json.RawMessage)
-
-	for _, rawGroup := range results.TestGroups {
-		var abstractGroup struct {
-			Tests []json.RawMessage `json:"tests"`
-		}
-		if err := json.Unmarshal(rawGroup, &abstractGroup); err != nil {
-			t.Fatal(err)
-		}
-		for _, rawTest := range abstractGroup.Tests {
-			var abstractTest struct {
-				TcID int `json:"tcId"`
-			}
-			if err := json.Unmarshal(rawTest, &abstractTest); err != nil {
-				t.Fatal(err)
-			}
-			if _, exists := rawResults[abstractTest.TcID]; exists {
-				t.Fatalf("Duplicate test id: %d", abstractTest.TcID)
-			}
-			rawResults[abstractTest.TcID] = rawTest
-		}
-	}
+	vectors := test.ReadACVP(t, "../testdata/ML-DSA-"+sub+"-FIPS204")
 
 	scheme := Scheme()
 
-	for _, rawGroup := range prompt.TestGroups {
+	for _, rawGroup := range vectors.Groups {
 		var abstractGroup struct {
 			TestType string `json:"testType"`
 		}
@@ -105,13 +58,7 @@ func testACVP(t *testing.T, sub string) {
 					Pk test.HexBytes `json:"pk"`
 					Sk test.HexBytes `json:"sk"`
 				}
-				rawResult, ok := rawResults[tst.TcID]
-				if !ok {
-					t.Fatalf("Missing result: %d", tst.TcID)
-				}
-				if err := json.Unmarshal(rawResult, &result); err != nil {
-					t.Fatal(err)
-				}
+				vectors.Result(t, tst.TcID, &result)
 
 				pk, sk := scheme.DeriveKey(tst.Seed)
 
@@ -155,13 +102,7 @@ func testACVP(t *testing.T, sub string) {
 				var result struct {
 					Signature test.HexBytes `json:"signature"`
 				}
-				rawResult, ok := rawResults[tst.TcID]
-				if !ok {
-					t.Fatalf("Missing result: %d", tst.TcID)
-				}
-				if err := json.Unmarshal(rawResult, &result); err != nil {
-					t.Fatal(err)
-				}
+				vectors.Result(t, tst.TcID, &result)
 
 				sk, err := scheme.UnmarshalBinaryPrivateKey(tst.Sk)
 				if err != nil {
@@ -208,13 +149,7 @@ func testACVP(t *testing.T, sub string) {
 				var result struct {
 					TestPassed bool `json:"testPassed"`
 				}
-				rawResult, ok := rawResults[tst.TcID]
-				if !ok {
-					t.Fatalf("Missing result: %d", tst.TcID)
-				}
-				if err := json.Unmarshal(rawResult, &result); err != nil {
-					t.Fatal(err)
-				}
+				vectors.Result(t, tst.TcID, &result)
 
 				passed2 := unsafeVerifyInternal(pk.(*PublicKey), tst.Message, tst.Signature)
 				if passed2 != result.TestPassed {

--- a/sign/mldsa/mldsa65/acvp_test.go
+++ b/sign/mldsa/mldsa65/acvp_test.go
@@ -24,58 +24,11 @@ func TestACVP(t *testing.T) {
 
 // nolint:funlen,gocyclo
 func testACVP(t *testing.T, sub string) {
-	buf, err := test.ReadGzip("../testdata/ML-DSA-" + sub + "-FIPS204/prompt.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var prompt struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err = json.Unmarshal(buf, &prompt); err != nil {
-		t.Fatal(err)
-	}
-
-	buf, err = test.ReadGzip("../testdata/ML-DSA-" + sub + "-FIPS204/expectedResults.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var results struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err := json.Unmarshal(buf, &results); err != nil {
-		t.Fatal(err)
-	}
-
-	rawResults := make(map[int]json.RawMessage)
-
-	for _, rawGroup := range results.TestGroups {
-		var abstractGroup struct {
-			Tests []json.RawMessage `json:"tests"`
-		}
-		if err := json.Unmarshal(rawGroup, &abstractGroup); err != nil {
-			t.Fatal(err)
-		}
-		for _, rawTest := range abstractGroup.Tests {
-			var abstractTest struct {
-				TcID int `json:"tcId"`
-			}
-			if err := json.Unmarshal(rawTest, &abstractTest); err != nil {
-				t.Fatal(err)
-			}
-			if _, exists := rawResults[abstractTest.TcID]; exists {
-				t.Fatalf("Duplicate test id: %d", abstractTest.TcID)
-			}
-			rawResults[abstractTest.TcID] = rawTest
-		}
-	}
+	vectors := test.ReadACVP(t, "../testdata/ML-DSA-"+sub+"-FIPS204")
 
 	scheme := Scheme()
 
-	for _, rawGroup := range prompt.TestGroups {
+	for _, rawGroup := range vectors.Groups {
 		var abstractGroup struct {
 			TestType string `json:"testType"`
 		}
@@ -105,13 +58,7 @@ func testACVP(t *testing.T, sub string) {
 					Pk test.HexBytes `json:"pk"`
 					Sk test.HexBytes `json:"sk"`
 				}
-				rawResult, ok := rawResults[tst.TcID]
-				if !ok {
-					t.Fatalf("Missing result: %d", tst.TcID)
-				}
-				if err := json.Unmarshal(rawResult, &result); err != nil {
-					t.Fatal(err)
-				}
+				vectors.Result(t, tst.TcID, &result)
 
 				pk, sk := scheme.DeriveKey(tst.Seed)
 
@@ -155,13 +102,7 @@ func testACVP(t *testing.T, sub string) {
 				var result struct {
 					Signature test.HexBytes `json:"signature"`
 				}
-				rawResult, ok := rawResults[tst.TcID]
-				if !ok {
-					t.Fatalf("Missing result: %d", tst.TcID)
-				}
-				if err := json.Unmarshal(rawResult, &result); err != nil {
-					t.Fatal(err)
-				}
+				vectors.Result(t, tst.TcID, &result)
 
 				sk, err := scheme.UnmarshalBinaryPrivateKey(tst.Sk)
 				if err != nil {
@@ -208,13 +149,7 @@ func testACVP(t *testing.T, sub string) {
 				var result struct {
 					TestPassed bool `json:"testPassed"`
 				}
-				rawResult, ok := rawResults[tst.TcID]
-				if !ok {
-					t.Fatalf("Missing result: %d", tst.TcID)
-				}
-				if err := json.Unmarshal(rawResult, &result); err != nil {
-					t.Fatal(err)
-				}
+				vectors.Result(t, tst.TcID, &result)
 
 				passed2 := unsafeVerifyInternal(pk.(*PublicKey), tst.Message, tst.Signature)
 				if passed2 != result.TestPassed {

--- a/sign/mldsa/mldsa87/acvp_test.go
+++ b/sign/mldsa/mldsa87/acvp_test.go
@@ -24,58 +24,11 @@ func TestACVP(t *testing.T) {
 
 // nolint:funlen,gocyclo
 func testACVP(t *testing.T, sub string) {
-	buf, err := test.ReadGzip("../testdata/ML-DSA-" + sub + "-FIPS204/prompt.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var prompt struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err = json.Unmarshal(buf, &prompt); err != nil {
-		t.Fatal(err)
-	}
-
-	buf, err = test.ReadGzip("../testdata/ML-DSA-" + sub + "-FIPS204/expectedResults.json.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var results struct {
-		TestGroups []json.RawMessage `json:"testGroups"`
-	}
-
-	if err := json.Unmarshal(buf, &results); err != nil {
-		t.Fatal(err)
-	}
-
-	rawResults := make(map[int]json.RawMessage)
-
-	for _, rawGroup := range results.TestGroups {
-		var abstractGroup struct {
-			Tests []json.RawMessage `json:"tests"`
-		}
-		if err := json.Unmarshal(rawGroup, &abstractGroup); err != nil {
-			t.Fatal(err)
-		}
-		for _, rawTest := range abstractGroup.Tests {
-			var abstractTest struct {
-				TcID int `json:"tcId"`
-			}
-			if err := json.Unmarshal(rawTest, &abstractTest); err != nil {
-				t.Fatal(err)
-			}
-			if _, exists := rawResults[abstractTest.TcID]; exists {
-				t.Fatalf("Duplicate test id: %d", abstractTest.TcID)
-			}
-			rawResults[abstractTest.TcID] = rawTest
-		}
-	}
+	vectors := test.ReadACVP(t, "../testdata/ML-DSA-"+sub+"-FIPS204")
 
 	scheme := Scheme()
 
-	for _, rawGroup := range prompt.TestGroups {
+	for _, rawGroup := range vectors.Groups {
 		var abstractGroup struct {
 			TestType string `json:"testType"`
 		}
@@ -105,13 +58,7 @@ func testACVP(t *testing.T, sub string) {
 					Pk test.HexBytes `json:"pk"`
 					Sk test.HexBytes `json:"sk"`
 				}
-				rawResult, ok := rawResults[tst.TcID]
-				if !ok {
-					t.Fatalf("Missing result: %d", tst.TcID)
-				}
-				if err := json.Unmarshal(rawResult, &result); err != nil {
-					t.Fatal(err)
-				}
+				vectors.Result(t, tst.TcID, &result)
 
 				pk, sk := scheme.DeriveKey(tst.Seed)
 
@@ -155,13 +102,7 @@ func testACVP(t *testing.T, sub string) {
 				var result struct {
 					Signature test.HexBytes `json:"signature"`
 				}
-				rawResult, ok := rawResults[tst.TcID]
-				if !ok {
-					t.Fatalf("Missing result: %d", tst.TcID)
-				}
-				if err := json.Unmarshal(rawResult, &result); err != nil {
-					t.Fatal(err)
-				}
+				vectors.Result(t, tst.TcID, &result)
 
 				sk, err := scheme.UnmarshalBinaryPrivateKey(tst.Sk)
 				if err != nil {
@@ -208,13 +149,7 @@ func testACVP(t *testing.T, sub string) {
 				var result struct {
 					TestPassed bool `json:"testPassed"`
 				}
-				rawResult, ok := rawResults[tst.TcID]
-				if !ok {
-					t.Fatalf("Missing result: %d", tst.TcID)
-				}
-				if err := json.Unmarshal(rawResult, &result); err != nil {
-					t.Fatal(err)
-				}
+				vectors.Result(t, tst.TcID, &result)
 
 				passed2 := unsafeVerifyInternal(pk.(*PublicKey), tst.Message, tst.Signature)
 				if passed2 != result.TestPassed {


### PR DESCRIPTION
Fixes #533.

`kem/mlkem/acvp_test.go` and `sign/dilithium/templates/acvp.templ.go` each carried their own copy of the same 50 lines: read the gzipped `prompt` and `expectedResults` files, decode both into raw test groups, then index the results by `tcId` while rejecting duplicates. The template's copy is expanded into `sign/mldsa/mldsa{44,65,87}/acvp_test.go`, so the block existed four times in the tree.

This moves it into `internal/test` as `ReadACVP`:

```go
vectors := test.ReadACVP(t, "testdata/ML-KEM-"+sub+"-FIPS203")

for _, rawGroup := range vectors.Groups {
        ...
        vectors.Result(t, tst.TcID, &result)
}
```

`Groups` stays raw `json.RawMessage`, so each call site keeps unmarshalling into the shape its algorithm expects. `Result` fails the test on a missing id, which is what the inlined code did.

Net effect is 350 lines removed for 112 added, and a new ACVP-based test no longer has to re-derive the loader.

### Scope

`sign/slhdsa/acvp_test.go` is deliberately left alone. It matches prompts to results *positionally* through fully typed structs (`outputs.TestGroups[gi].Tests[ti]`) rather than by `tcId`, and asserts the ids line up. Folding it into `ReadACVP` would change what those tests assert, which did not seem like something to bundle into a refactor. Happy to do it as a follow-up if you would prefer the whole ACVP surface on one loader, since the id-keyed lookup is the more robust of the two.

### Verification

- `go test -count=1 ./...` passes.
- `go generate -v ./...` leaves the working tree unchanged; the three `mldsa*/acvp_test.go` files in this PR are the regenerated output of the template change, not hand edits.
- `go vet ./...` and `go vet -vettool=shadow ./...` are clean.
- `golangci-lint run` reports nothing on `internal/test`, `kem/mlkem` and `sign/mldsa/...`.
- The ACVP subtests still execute rather than silently skipping:

```console
$ go test -count=1 -run TestACVP -v ./kem/mlkem/ ./sign/mldsa/mldsa44/
=== RUN   TestACVP
=== RUN   TestACVP/keyGen
=== RUN   TestACVP/encapDecap
--- PASS: TestACVP (0.04s)
ok      github.com/cloudflare/circl/kem/mlkem
=== RUN   TestACVP
=== RUN   TestACVP/keyGen
=== RUN   TestACVP/sigGen
=== RUN   TestACVP/sigVer
--- PASS: TestACVP (0.07s)
ok      github.com/cloudflare/circl/sign/mldsa/mldsa44
```

No test vectors, assertions, public API or crypto paths are touched.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->