### PR TITLE
README: warn that not all packages are constant time

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Curve Cryptography (ECC).
 
 🚨 This library is offered as-is, and without a guarantee. Therefore, it is expected that changes in the code, repository, and API occur in the future. We recommend to take caution before using this library in a production application since part of its content is experimental. All security issues must be reported, please notify us immediately following the instructions given in our [Security Policy](https://github.com/cloudflare/circl/security/policy).
 
+### Constant-Time Caveats
+
+⚠️ Not every package in CIRCL is constant time. The following packages document, at the
+top of their `doc.go` or main source file, the specific operations that are known to
+leak timing information: [`group/`](./group), [`oprf/`](./oprf),
+[`blindsign/blindrsa/partiallyblindrsa/`](./blindsign/blindrsa/partiallyblindrsa),
+[`secretsharing/`](./secretsharing), [`tss/rsa/`](./tss/rsa), [`zk/dl/`](./zk/dl),
+[`zk/dleq/`](./zk/dleq), and [`ecc/p384/`](./ecc/p384).
+
 ## Installation
 
 You can get CIRCL by fetching:


### PR DESCRIPTION
Adds a "Constant-Time Caveats" subsection to the README's Security Disclaimer, pointing readers at the per-package constant-time caveats that were added in #638 (seven packages) and #651 (ecc/p384): `group/`, `oprf/`, `blindsign/blindrsa/partiallyblindrsa/`, `secretsharing/`, `tss/rsa/`, `zk/dl/`, `zk/dleq/`, and `ecc/p384/`.

#657 asked for an explicit README-level warning that some experimental CIRCL packages are not constant time. PRs #638 and #651 added per-package caveats, but the README's Security Disclaimer still only mentioned that the library is experimental — it never mentioned constant time. A reader who only skims the README has no signal that they should drill into the per-package docs before relying on a package in a side-channel-sensitive context.

One file changed: `README.md` (+9 lines, -0 lines). No source files touched, no API change, no tests added (documentation-only change). `go generate -v ./...` is a no-op; `go build ./...` and `go vet ./...` are clean.

Note: `dh/csidh` also has inline `// Non-constant time!` comments in `curve.go` (lines 91, 133, 163) and `csidh.go` (line 73) that predate #638. These are on internal functions rather than at the package level, so I've left them out of the README list — happy to add a footnote if you'd prefer.

First-time contributor to CIRCL — happy to adjust wording, location, or scope.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->