### PR TITLE
zk/qndleq: document Qn membership precondition

### DIFF
--- a/zk/qndleq/qndleq.go
+++ b/zk/qndleq/qndleq.go
@@ -118,6 +118,10 @@ func Prove(random io.Reader, x, g, gx, h, hx, N *big.Int, secParam uint) (*Proof
 }
 
 // Verify checks whether x = Log_g(g^x) = Log_h(h^x).
+//
+// The caller must ensure that g, gx, h, and hx are in Qn. Verify only checks
+// their bounds; Qn membership cannot be checked without additional information
+// about N and must be established separately for attacker-controlled inputs.
 func (p Proof) Verify(g, gx, h, hx, N *big.Int) bool {
 	err := checkBounds(N, g, gx, h, hx)
 	if err != nil {


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->