### PR TITLE
oprf: reject invalid deterministic blinds

### DIFF
--- a/oprf/client.go
+++ b/oprf/client.go
@@ -51,11 +51,19 @@ func (c client) blind(inputs [][]byte, blinds []Blind) (*FinalizeData, *Evaluati
 	blindedElements := make([]Blinded, len(inputs))
 	dst := c.params.getDST(hashToGroupDST)
 	for i := range inputs {
+		blind := blinds[i]
+		if blind == nil || *blind.Group().Params() != *c.params.group.Params() || blind.IsZero() {
+			return nil, nil, ErrInvalidInput
+		}
+
 		point := c.params.group.HashToElement(inputs[i], dst)
 		if point.IsIdentity() {
 			return nil, nil, ErrInvalidInput
 		}
-		blindedElements[i] = c.params.group.NewElement().Mul(point, blinds[i])
+		blindedElements[i] = c.params.group.NewElement().Mul(point, blind)
+		if blindedElements[i].IsIdentity() {
+			return nil, nil, ErrInvalidInput
+		}
 	}
 
 	evalReq := &EvaluationRequest{blindedElements}

--- a/oprf/oprf_test.go
+++ b/oprf/oprf_test.go
@@ -248,6 +248,35 @@ func TestErrors(t *testing.T) {
 	})
 }
 
+func TestDeterministicBlindRejectsInvalidBlind(t *testing.T) {
+	for _, suite := range []Suite{
+		SuiteRistretto255,
+		SuiteP256,
+		SuiteP384,
+		SuiteP521,
+	} {
+		t.Run(suite.(fmt.Stringer).String(), func(t *testing.T) {
+			client := NewClient(suite)
+			for _, tc := range []struct {
+				name  string
+				blind Blind
+			}{
+				{"nil", nil},
+				{"zero", suite.Group().NewScalar()},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					finData, evalReq, err := client.DeterministicBlind(
+						[][]byte{[]byte("input")}, []Blind{tc.blind})
+					if err != ErrInvalidInput || finData != nil || evalReq != nil {
+						t.Fatalf("got finalize data %v, request %v, and error %v; want nil, nil, and %v",
+							finData, evalReq, err, ErrInvalidInput)
+					}
+				})
+			}
+		})
+	}
+}
+
 // TestIdentityKeyRejection ensures the OPRF parsing boundary rejects the
 // identity public key and the zero private key, as required by RFC 9497.
 // Accepting them would let an attacker impersonate a verifiable OPRF server


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cloudflare/circl/pull/688" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->