### PR TITLE
sign: benchmark on different messages

### DIFF
--- a/sign/schemes/schemes_test.go
+++ b/sign/schemes/schemes_test.go
@@ -155,6 +155,8 @@ func BenchmarkSign(b *testing.B) {
 		_, sk, _ := scheme.GenerateKey()
 		b.Run(scheme.Name(), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
+				msg[0] = byte(i)
+				msg[1] = byte(i>>8)
 				_ = scheme.Sign(sk, msg, opts)
 			}
 		})


### PR DESCRIPTION
This makes the ML-DSA signing benchmarks produce meaningful results: ML-DSA signing time depends on the message.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/circl/pull/692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->