### PR TITLE
oprf: reject input and info that overflow the length prefix

### DIFF
--- a/oprf/client.go
+++ b/oprf/client.go
@@ -2,6 +2,7 @@ package oprf
 
 import (
 	"crypto/rand"
+	"math"
 
 	"github.com/cloudflare/circl/group"
 	"github.com/cloudflare/circl/zk/dleq"
@@ -51,6 +52,12 @@ func (c client) blind(inputs [][]byte, blinds []Blind) (*FinalizeData, *Evaluati
 	blindedElements := make([]Blinded, len(inputs))
 	dst := c.params.getDST(hashToGroupDST)
 	for i := range inputs {
+		// finalizeHash frames the input with I2OSP(len(input), 2), so an input
+		// of 2^16 bytes or more silently wraps the length prefix. Reject it, as
+		// scalarFromInfo already does for info.
+		if len(inputs[i]) > math.MaxUint16 {
+			return nil, nil, ErrInvalidInput
+		}
 		blind := blinds[i]
 		if blind == nil || *blind.Group().Params() != *c.params.group.Params() || blind.IsZero() {
 			return nil, nil, ErrInvalidInput

--- a/oprf/keys.go
+++ b/oprf/keys.go
@@ -3,6 +3,7 @@ package oprf
 import (
 	"encoding/binary"
 	"io"
+	"math"
 
 	"github.com/cloudflare/circl/group"
 )
@@ -111,6 +112,11 @@ func DeriveKey(s Suite, mode Mode, seed, info []byte) (*PrivateKey, error) {
 	}
 	if len(seed) != 32 {
 		return nil, ErrInvalidSeed
+	}
+	// deriveInput frames info with I2OSP(len(info), 2), so info of 2^16 bytes
+	// or more silently wraps the length prefix.
+	if len(info) > math.MaxUint16 {
+		return nil, ErrInvalidInfo
 	}
 	p.m = mode
 

--- a/oprf/oprf_test.go
+++ b/oprf/oprf_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/cloudflare/circl/group"
@@ -275,6 +276,43 @@ func TestDeterministicBlindRejectsInvalidBlind(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRejectsOversizedInput(t *testing.T) {
+	// RFC 9497 frames the input and info with I2OSP(len, 2), so a length of
+	// 2^16 or more wraps the prefix. Reject those, but keep accepting the
+	// maximum admissible length so valid callers are unaffected.
+	key, err := GenerateKey(SuiteP256, rand.Reader)
+	test.CheckNoErr(t, err, "failed private key generation")
+
+	oversized := make([]byte, math.MaxUint16+1)
+	maxSized := make([]byte, math.MaxUint16)
+
+	t.Run("blind", func(t *testing.T) {
+		client := NewClient(SuiteP256)
+		if _, _, err := client.Blind([][]byte{oversized}); err != ErrInvalidInput {
+			t.Fatalf("got %v, want %v", err, ErrInvalidInput)
+		}
+		_, _, err := client.Blind([][]byte{maxSized})
+		test.CheckNoErr(t, err, "max-length input must be accepted")
+	})
+
+	t.Run("fullEvaluate", func(t *testing.T) {
+		server := NewServer(SuiteP256, key)
+		if _, err := server.FullEvaluate(oversized); err != ErrInvalidInput {
+			t.Fatalf("got %v, want %v", err, ErrInvalidInput)
+		}
+		_, err := server.FullEvaluate(maxSized)
+		test.CheckNoErr(t, err, "max-length input must be accepted")
+	})
+
+	t.Run("deriveKey", func(t *testing.T) {
+		if _, err := DeriveKey(SuiteP256, BaseMode, make([]byte, 32), oversized); err != ErrInvalidInfo {
+			t.Fatalf("got %v, want %v", err, ErrInvalidInfo)
+		}
+		_, err := DeriveKey(SuiteP256, BaseMode, make([]byte, 32), maxSized)
+		test.CheckNoErr(t, err, "max-length info must be accepted")
+	})
 }
 
 func TestFinalizeRejectsMalformedState(t *testing.T) {

--- a/oprf/server.go
+++ b/oprf/server.go
@@ -3,6 +3,7 @@ package oprf
 import (
 	"crypto/rand"
 	"crypto/subtle"
+	"math"
 
 	"github.com/cloudflare/circl/group"
 	"github.com/cloudflare/circl/zk/dleq"
@@ -91,6 +92,12 @@ func (s server) secretFromInfo(info []byte) (t, tInv group.Scalar, err error) {
 }
 
 func (s server) fullEvaluate(input, info []byte) ([]byte, error) {
+	// finalizeHash frames the input with I2OSP(len(input), 2), so an input of
+	// 2^16 bytes or more silently wraps the length prefix. Reject it, as
+	// scalarFromInfo already does for info.
+	if len(input) > math.MaxUint16 {
+		return nil, ErrInvalidInput
+	}
 	evalSecret := s.privateKey.k
 	if s.params.m == PartialObliviousMode {
 		var err error


### PR DESCRIPTION
The OPRF and POPRF hashing steps frame each variable-length field with I2OSP(len, 2) as RFC 9497 specifies, and the prefix is built with a uint16 cast over the field length. For the client input, the server-side full-evaluation input, and the DeriveKey info that length is never bounded first, so a value of 65536 bytes or more wraps the two-byte prefix (a 65536-byte input encodes a length of 0) and the value is accepted rather than rejected. scalarFromInfo already guards its info with the same math.MaxUint16 check and returns ErrInvalidInfo, so the eval-path info is fine, but the sibling sites that frame the input and the derive-key info were missed. I came across it while comparing the length-prefix handling across the package and confirmed all three call sites accept an over-length value today. The change adds the same bound at blind, fullEvaluate, and DeriveKey, and keeps the maximum admissible length of 65535 bytes working so valid callers are unaffected.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/circl/pull/694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->