### PR TITLE
kem/hybrid: derive the same key pair from a seed every time

### DIFF
--- a/kem/hybrid/ckem.go
+++ b/kem/hybrid/ckem.go
@@ -134,8 +134,9 @@ func (sch cScheme) DeriveKeyPair(seed []byte) (kem.PublicKey, kem.PrivateKey) {
 	h := xof.SHAKE256.New()
 	_, _ = h.Write(seed)
 
-	// crypto/ecdh's GenerateKey may read an extra byte from the reader
-	// (randutil.MaybeReadByte), so the scalar is sampled here instead.
+	// crypto/ecdh's GenerateKey reads an extra byte from the reader on
+	// purpose (randutil.MaybeReadByte), to defeat exactly this kind of
+	// deterministic derivation, so the scalar is sampled here instead.
 	bitmask := byte(0xFF)
 	if sch.curve == ecdh.P521() {
 		// The scalar is 521 bits carried in 66 bytes.

--- a/kem/hybrid/ckem.go
+++ b/kem/hybrid/ckem.go
@@ -125,22 +125,37 @@ func (sch cScheme) GenerateKeyPair() (kem.PublicKey, kem.PrivateKey, error) {
 	return pk, sk, nil
 }
 
+// DeriveKeyPair deterministically derives a key pair from seed.
+// Panics if seed is not of length SeedSize().
 func (sch cScheme) DeriveKeyPair(seed []byte) (kem.PublicKey, kem.PrivateKey) {
 	if len(seed) != sch.SeedSize() {
 		panic(kem.ErrSeedSize)
 	}
 	h := xof.SHAKE256.New()
 	_, _ = h.Write(seed)
-	privKey, err := sch.curve.GenerateKey(h)
-	if err != nil {
-		panic(err)
+
+	// crypto/ecdh's GenerateKey may read an extra byte from the reader
+	// (randutil.MaybeReadByte), so the scalar is sampled here instead.
+	bitmask := byte(0xFF)
+	if sch.curve == ecdh.P521() {
+		// The scalar is 521 bits carried in 66 bytes.
+		bitmask = 0x01
 	}
-	pubKey := privKey.PublicKey()
+	candidate := make([]byte, sch.PrivateKeySize())
+	for ctr := 0; ctr < 256; ctr++ {
+		_, _ = h.Read(candidate)
+		candidate[0] &= bitmask
+		privKey, err := sch.curve.NewPrivateKey(candidate)
+		if err != nil {
+			// Out of range or zero; draw the next candidate.
+			continue
+		}
+		sk := cPrivateKey{scheme: sch, key: privKey}
+		pk := cPublicKey{scheme: sch, key: privKey.PublicKey()}
+		return &pk, &sk
+	}
 
-	sk := cPrivateKey{scheme: sch, key: privKey}
-	pk := cPublicKey{scheme: sch, key: pubKey}
-
-	return &pk, &sk
+	panic("hybrid: cannot derive a key pair from this seed")
 }
 
 func (sch cScheme) Encapsulate(pk kem.PublicKey) (ct, ss []byte, err error) {

--- a/kem/hybrid/ckem_test.go
+++ b/kem/hybrid/ckem_test.go
@@ -1,0 +1,57 @@
+package hybrid
+
+import (
+	"bytes"
+	"crypto/ecdh"
+	"testing"
+
+	"github.com/cloudflare/circl/internal/test"
+)
+
+// DeriveKeyPair once read its seed through crypto/ecdh's GenerateKey, which
+// may consume an extra byte of the reader, so one seed gave different keys.
+func TestCSchemeDeriveKeyPairDeterministic(t *testing.T) {
+	for _, sch := range []cScheme{{ecdh.P256()}, {ecdh.P384()}, {ecdh.P521()}} {
+		t.Run(sch.Name(), func(t *testing.T) {
+			seed := bytes.Repeat([]byte{0x5a}, sch.SeedSize())
+			pk, sk := sch.DeriveKeyPair(seed)
+			want, err := pk.MarshalBinary()
+			test.CheckNoErr(t, err, "marshaling the derived public key failed")
+			wantSK, err := sk.MarshalBinary()
+			test.CheckNoErr(t, err, "marshaling the derived private key failed")
+			test.CheckOk(len(want) == sch.PublicKeySize(), "wrong public key size", t)
+			test.CheckOk(len(wantSK) == sch.PrivateKeySize(), "wrong private key size", t)
+
+			for i := range 32 {
+				pkI, skI := sch.DeriveKeyPair(seed)
+				gotPK, errPK := pkI.MarshalBinary()
+				test.CheckNoErr(t, errPK, "marshaling the derived public key failed")
+				gotSK, errSK := skI.MarshalBinary()
+				test.CheckNoErr(t, errSK, "marshaling the derived private key failed")
+				if !bytes.Equal(want, gotPK) || !bytes.Equal(wantSK, gotSK) {
+					t.Fatalf("derivation %d from one seed gave a different key pair", i)
+				}
+			}
+
+			pkOther, _ := sch.DeriveKeyPair(bytes.Repeat([]byte{0x5b}, sch.SeedSize()))
+			other, err := pkOther.MarshalBinary()
+			test.CheckNoErr(t, err, "marshaling the derived public key failed")
+			test.CheckOk(!bytes.Equal(want, other), "different seeds gave the same key", t)
+		})
+	}
+}
+
+func TestCSchemeEncapsulateDeterministically(t *testing.T) {
+	sch := cScheme{ecdh.P256()}
+	pk, _ := sch.DeriveKeyPair(bytes.Repeat([]byte{0x11}, sch.SeedSize()))
+	seed := bytes.Repeat([]byte{0x22}, sch.EncapsulationSeedSize())
+	wantCT, wantSS, err := sch.EncapsulateDeterministically(pk, seed)
+	test.CheckNoErr(t, err, "EncapsulateDeterministically failed")
+	for i := range 32 {
+		ct, ss, errI := sch.EncapsulateDeterministically(pk, seed)
+		test.CheckNoErr(t, errI, "EncapsulateDeterministically failed")
+		if !bytes.Equal(wantCT, ct) || !bytes.Equal(wantSS, ss) {
+			t.Fatalf("encapsulation %d from one seed gave a different ciphertext", i)
+		}
+	}
+}


### PR DESCRIPTION
`cScheme.DeriveKeyPair` read its seed through `crypto/ecdh`'s `GenerateKey`, which calls `randutil.MaybeReadByte` and so consumes an extra byte of the reader on a random subset of calls. One seed produced different key pairs, and `EncapsulateDeterministically` inherited it. The P-256 hybrid KEMs are built on this scheme.

The scalar is now sampled from the SHAKE stream directly and handed to `NewPrivateKey`, with the top byte masked for P-521 and out-of-range candidates redrawn.

Two tests derive from one seed repeatedly; on main they fail within a few derivations.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/circl/pull/699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->