### PR TITLE
pki: return an error for schemes without an object identifier

### DIFF
--- a/pki/marshal_nooid_test.go
+++ b/pki/marshal_nooid_test.go
@@ -1,0 +1,68 @@
+package pki_test
+
+import (
+	"crypto"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/cloudflare/circl/pki"
+	"github.com/cloudflare/circl/sign"
+	"github.com/cloudflare/circl/sign/schemes"
+)
+
+// Schemes without an object identifier, such as Dilithium and SLH-DSA, must
+// get an error from the marshal functions rather than a panic.
+func TestMarshalSchemeWithoutOid(t *testing.T) {
+	n := 0
+	for _, scheme := range schemes.All() {
+		if _, ok := scheme.(pki.CertificateScheme); ok {
+			continue
+		}
+		n++
+		t.Run(scheme.Name(), func(t *testing.T) {
+			pk, sk, err := scheme.GenerateKey()
+			if err != nil {
+				t.Fatal(err)
+			}
+			for name, call := range map[string]func() ([]byte, error){
+				"MarshalPKIXPublicKey":  func() ([]byte, error) { return pki.MarshalPKIXPublicKey(pk) },
+				"MarshalPEMPublicKey":   func() ([]byte, error) { return pki.MarshalPEMPublicKey(pk) },
+				"MarshalPKIXPrivateKey": func() ([]byte, error) { return pki.MarshalPKIXPrivateKey(sk) },
+				"MarshalPEMPrivateKey":  func() ([]byte, error) { return pki.MarshalPEMPrivateKey(sk) },
+			} {
+				out, err := call()
+				if err == nil {
+					t.Fatalf("%s: got no error and %d bytes, want an error", name, len(out))
+				}
+				if !strings.Contains(err.Error(), "object identifier") {
+					t.Fatalf("%s: got error %q, want it to name the missing object identifier", name, err)
+				}
+			}
+		})
+	}
+	if n == 0 {
+		t.Fatal("no registered scheme lacks an object identifier; this test covers nothing")
+	}
+}
+
+// unseededKey reports an ML-DSA scheme but does not implement sign.Seeded.
+type unseededKey struct{ scheme sign.Scheme }
+
+func (k unseededKey) Scheme() sign.Scheme            { return k.scheme }
+func (k unseededKey) Equal(crypto.PrivateKey) bool   { return false }
+func (k unseededKey) Public() crypto.PublicKey       { return nil }
+func (k unseededKey) MarshalBinary() ([]byte, error) { return []byte{0}, nil }
+func (k unseededKey) Sign(io.Reader, []byte, crypto.SignerOpts) ([]byte, error) {
+	return nil, nil
+}
+
+func TestMarshalMLDSAPrivateKeyWithoutSeed(t *testing.T) {
+	scheme := schemes.ByName("ML-DSA-44")
+	if scheme == nil {
+		t.Fatal("ML-DSA-44 is not registered")
+	}
+	if _, err := pki.MarshalPKIXPrivateKey(unseededKey{scheme}); err == nil {
+		t.Fatal("got no error for an ML-DSA private key that carries no seed")
+	}
+}

--- a/pki/pki.go
+++ b/pki/pki.go
@@ -5,6 +5,7 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/cloudflare/circl/sign"
@@ -36,6 +37,18 @@ func init() {
 			allSchemesByTLS[tlsScheme.TLSIdentifier()] = scheme
 		}
 	}
+}
+
+// schemeOid returns the object identifier of scheme, or an error if it has none.
+func schemeOid(scheme sign.Scheme) (asn1.ObjectIdentifier, error) {
+	cert, ok := scheme.(CertificateScheme)
+	if !ok {
+		return nil, fmt.Errorf(
+			"scheme %s is not supported in X509: it has no object identifier",
+			scheme.Name(),
+		)
+	}
+	return cert.Oid(), nil
 }
 
 func SchemeByOid(oid asn1.ObjectIdentifier) sign.Scheme { return allSchemesByOID[oid.String()] }
@@ -199,12 +212,16 @@ func MarshalPKIXPublicKey(pk sign.PublicKey) ([]byte, error) {
 	}
 
 	scheme := pk.Scheme()
+	oid, err := schemeOid(scheme)
+	if err != nil {
+		return nil, err
+	}
 	return asn1.Marshal(struct {
 		pkix.AlgorithmIdentifier
 		asn1.BitString
 	}{
 		pkix.AlgorithmIdentifier{
-			Algorithm: scheme.(CertificateScheme).Oid(),
+			Algorithm: oid,
 		},
 		asn1.BitString{
 			Bytes:     data,
@@ -232,10 +249,18 @@ func MarshalPKIXPrivateKey(sk sign.PrivateKey) ([]byte, error) {
 		err  error
 	)
 	scheme := sk.Scheme()
+	oid, err := schemeOid(scheme)
+	if err != nil {
+		return nil, err
+	}
 
 	// ML-DSA is special. See comment in UnmarshalPKIXPrivateKey().
 	if isMLDSA(scheme) {
-		seed := sk.(sign.Seeded).Seed()
+		seeded, ok := sk.(sign.Seeded)
+		if !ok {
+			return nil, errors.New("ML-DSA private key does not carry a seed")
+		}
+		seed := seeded.Seed()
 		if seed == nil {
 			return nil, errors.New("seed not retained in ML-DSA private key")
 		}
@@ -262,7 +287,7 @@ func MarshalPKIXPrivateKey(sk sign.PrivateKey) ([]byte, error) {
 	return asn1.Marshal(pkixPrivKey{
 		0,
 		pkix.AlgorithmIdentifier{
-			Algorithm: scheme.(CertificateScheme).Oid(),
+			Algorithm: oid,
 		},
 		data,
 	})


### PR DESCRIPTION
The four `pki` marshal functions asserted `scheme.(CertificateScheme)` to reach an object identifier, and `MarshalPKIXPrivateKey` asserted `sk.(sign.Seeded)` for ML-DSA. A scheme without an OID panicked instead of returning the error the signature declares. Dilithium and SLH-DSA are registered in `sign/schemes` without one, so this is reachable with the library's own keys.

Each site now returns an error. The new test marshals a key of every registered scheme that lacks an OID through all four functions; on main it panics.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/circl/pull/700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->